### PR TITLE
Convert mathpartir.sty to UTF-8 encoding

### DIFF
--- a/mathpartir.sty
+++ b/mathpartir.sty
@@ -1,6 +1,6 @@
 %  Mathpartir --- Math Paragraph for Typesetting Inference Rules
 %
-%  Copyright (C) 2001, 2002, 2003, 2004, 2005 Didier Rémy
+%  Copyright (C) 2001, 2002, 2003, 2004, 2005 Didier RÃ©my
 %
 %  Author         : Didier Remy 
 %  Version        : 1.2.0


### PR DESCRIPTION
I'm trying to create an ePUB 3.0 version of this using pandoc, which
requires all input files to be in UTF-8.

This is sort of like a typo, since many utilities would otherwise render
the author's copyright as "Didier R?my"
