### PR TITLE
Misspellings run

### DIFF
--- a/coq_introduction/Reading_HoTT_in_Coq.v
+++ b/coq_introduction/Reading_HoTT_in_Coq.v
@@ -1076,7 +1076,7 @@ Check @idpath nat 4.
 (**
 which is an element that has type "4=4".  Obviously, with implicit
 arguments, we do not need "nat" and can use just "idpath 4".  Not so
-obviously, we can go a step futher.  If type inferencing can determing
+obviously, we can go a step further.  If type inferencing can determing
 the type returned by "idpath", such as "4=4" in our example, then
 implicit arguments can fill in the "4" as well!  So most of the time
 you will just see "idpath" or its [Notation], "1" (in the "path_scope"

--- a/mathpartir.sty
+++ b/mathpartir.sty
@@ -345,12 +345,12 @@
 %  after                execute val at the end/right
 %  
 %  Note that most options must come in this order to avoid strange
-%  typesetting (in particular  leftskip must preceed left and Left and
+%  typesetting (in particular  leftskip must precede left and Left and
 %  rightskip must follow Right or right; vdots must come last 
 %  or be only followed by rightskip. 
 %  
 
-%% Keys that make sence in all kinds of rules
+%% Keys that make sense in all kinds of rules
 \def \mprset #1{\setkeys{mprset}{#1}}
 \define@key {mprset}{andskip}[]{\mpr@andskip=#1}
 \define@key {mprset}{lineskip}[]{\lineskip=#1}


### PR DESCRIPTION
Based on:
  misspellings $(find \* -type f ! -name '_.png' ! -name '_.xcf')

This is a tool I use for spell checking source code. I was curious how
it would do on math/tex. Mostly false positives, but the following
three valid hits.
