### PR TITLE
mismatched brace in basics.tex

### DIFF
--- a/basics.tex
+++ b/basics.tex
@@ -711,7 +711,7 @@ In fact, we will see later on that if $x=y$ then actually $P(x)$ and $P(y)$ are 
 
 Topologically, the transportation lemma can be viewed as a ``path lifting'' operation in a fibration.
 \index{fibration}%
-\indexdef{total!space}{%
+\indexdef{total!space}%
 We think of a type family $P:A\to \type$ as a \emph{fibration} with base space $A$, with $P(x)$ being the fiber over $x$, and with $\sm{x:A}P(x)$ being the \define{total space} of the fibration, with first projection $\sm{x:A}P(x)\to A$.
 The defining property of a fibration is that given a path $p:x=y$ in the base space $A$ and a point $u:P(x)$ in the fiber over $x$, we may lift the path $p$ to a path in the total space starting at $u$.
 The point $\trans p u$ can be thought of as the other endpoint of this lifted path.


### PR DESCRIPTION
Responsible for this message in hott-online.log:

 (\end occurred inside a group at level 1)

 ### simple group (level 1) entered at line 714 ({)
 ### bottom level 
