### PR TITLE
Fix alignment in the Nat induction principle display

### DIFF
--- a/preliminaries.tex
+++ b/preliminaries.tex
@@ -1108,7 +1108,7 @@ We now follow the same approach as for other types, generalizing primitive recur
 Thus, assume as given a family $C : \nat \to \UU$, an element $c_0 : C(0)$, and a function $c_s : \prd{n:\nat} C(n) \to C(\suc(n))$; then we can construct $f : \prd{n:\nat} C(n)$ with the defining equations:\index{computation rule!for natural numbers}
 \begin{align*}
   f(0) &\defeq c_0, \\
-  f(\suc(n)) \defeq c_s(n,f(n)).
+  f(\suc(n)) &\defeq c_s(n,f(n)).
 \end{align*}
 We can also package this into a single function
 \symlabel{defn:induction-nat}%


### PR DESCRIPTION
Note: the problematic display occurs on p. 37 of [http://hottheory.files.wordpress.com/2013/03/hott-online.pdf](http://hottheory.files.wordpress.com/2013/03/hott-online.pdf) in section 1.9: "The natural numbers".
