### PR TITLE
Missing parenthesis in Ch. 1 exercises (p. 54)

### DIFF
--- a/preliminaries.tex
+++ b/preliminaries.tex
@@ -1875,7 +1875,7 @@ Assuming as given only the \emph{iterator} for natural numbers
 with the defining equations
 \begin{align*}
 \ite(C,c_0,c_s,0)  &\defeq c_0, \\
-\ite(C,c_0,c_s,\suc(n)) &\defeq c_s(\ite(C,C_0,c_s,n)  
+\ite(C,c_0,c_s,\suc(n)) &\defeq c_s(\ite(C,C_0,c_s,n))
 \end{align*}
 derive the recursor $\rec{\nat}$.
 \end{ex}


### PR DESCRIPTION
The second line of the defining equations for exercise 1.4 is missing a close parenthesis.
