### PR TITLE
Make a list of errata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,17 @@
-We are more than happy to receive pull requests which fix typos, as
-long they are the really obvious kind (e.g. a spelling error,
-inserting a ~ to prevent an unfortunate linebreak) that won't generate
-any additional work for us.  We are not at the moment asking for
-general pull requests from the public, although we might do that after
-an initial release.
+We are very happy to receive pull requests which fix typos,
+formatting, and obvious mathematical errors; which clarify exposition
+in a straightforward way; or which add new technical functionality
+(such as versions for other devices).  We are not asking for new
+mathematical content from the public at this time.
+
+Please make sure that your pull request is attached to the correct
+branch.  Changes which add new mathematics, or which alter the
+numbering of existing sections, theorems, or equations, must wait for
+the second edition.  Other changes, as long as they are not of
+unreasonable size, can be released as updates to the first edition.
+
+Corrections of typos and other errors should also be listed in the
+errata for the first edition (errata.tex).
 
 We are very grateful everyone who is showing interest in our project,
 and to anyone who helps us improve it!  However, in order to avoid any

--- a/errata.tex
+++ b/errata.tex
@@ -1,0 +1,167 @@
+% This is the errata document for the homotopy type theory book.
+
+% This file supports two book sizes:
+% - Letter size (8.5" x 11")
+% - US Trade size (6" x 9")
+%
+% To activate one or the other, uncomment the appropriate font size in
+% the documentclass below, and then one of the two page geometry incantations
+%
+% NOTE: The 6" x 9" format is only experimental. It will break the
+% title page, for example.
+
+\PassOptionsToPackage{table}{xcolor}
+
+% DOCUMENT CLASS
+\documentclass[
+%
+%10pt % for US Trade 6" x 9" book
+%
+11pt % for Letter size book
+]{article}
+\usepackage{etex} % We're running out of registers and dimensions, or some such
+
+\newcounter{chapter}            % So that macros.tex doesn't choke
+
+% PAGE GEOMETRY
+%
+% Uncomment one of these
+
+% We make the page 40pt taller than the standard LaTeX book.
+
+% OPTION 1: Letter
+\usepackage[papersize={8.5in,11in},
+            twoside,
+            includehead,
+            top=1in,
+            bottom=1in,
+            inner=0.75in,
+            outer=1.0in,
+            bindingoffset=0.35in]{geometry}
+
+% OPTION 2: US Trade
+% \usepackage[papersize={6in,9in},
+%             twoside,
+%             includehead,
+%             top=0.75in,
+%             bottom=0.75in,
+%             inner=0.5in,
+%             outer=0.75in,
+%             bindingoffset=0.35in]{geometry}
+
+% HYPERLINKING AND PDF METADATA
+
+\usepackage[pagebackref,
+            colorlinks,
+            citecolor=darkgreen,
+            linkcolor=darkgreen,
+            unicode,
+            pdfauthor={Univalent Foundations Program},
+            pdftitle={Homotopy Type Theory: Univalent Foundations of Mathematics},
+            pdfsubject={Mathematics},
+            pdfkeywords={type theory, homotopy theory, univalence axiom}]{hyperref}
+
+% OTHER PACKAGES
+
+% Use this package and stick \layout somewhere in the text to see
+% page margins, text size and width etc. Useful for debugging page format.
+%\usepackage{layout}
+
+%%% Because Germans have umlauts and Slavs have even stranger ways of mangling letters
+\usepackage[utf8]{inputenc}
+
+%%% For table {tab:theorems}
+\usepackage{pifont}
+
+%%% Multi-Columns for long lists of names
+\usepackage{multicol}
+
+%%% Set the fonts
+\usepackage{mathpazo}
+\usepackage[scaled=0.95]{helvet}
+\usepackage{courier}
+\linespread{1.05} % Palatino looks better with this
+
+\usepackage{graphicx}
+\usepackage{comment}
+
+\usepackage{wallpaper} % For the background image on the cover page
+
+\usepackage{fancyhdr} % To set headers and footers
+
+\usepackage{nextpage} % So we can jump to odd-numbered pages
+
+\usepackage{amssymb,amsmath,amsthm,stmaryrd,mathrsfs,wasysym}
+\usepackage{enumitem,mathtools,xspace}
+\usepackage{xcolor} % For colored cells in tables we need \cellcolor
+\usepackage{booktabs} % For nice tables
+\usepackage{array} % For nice tables
+\usepackage{supertabular} % For index of symbols
+\definecolor{darkgreen}{rgb}{0,0.45,0}
+\usepackage{aliascnt}
+\usepackage[capitalize]{cleveref}
+\usepackage[all,2cell]{xy}
+\UseAllTwocells
+\usepackage{natbib}
+\usepackage{braket} % used for \setof{ ... } macro
+\usepackage{tikz}
+\usetikzlibrary{decorations.pathmorphing}
+
+\usepackage{etoolbox}           % hacking commands for TOC
+
+\usepackage{mathpartir}         % for formal.tex appendix, section 3
+
+\usepackage[numbered]{bookmark} % add chapter/section numbers to the toc in the pdf metadata
+
+\input{macros}
+
+%%%% Indexing
+\usepackage{makeidx}
+\makeindex
+
+%%%% Header and footers
+\pagestyle{fancyplain}
+\setlength{\headheight}{15pt}
+\renewcommand{\sectionmark}[1]{\markright{\textsc{\thesection\ #1}}}
+
+\lhead[\fancyplain{}{{\thepage}}]%
+      {\fancyplain{}{\nouppercase{\rightmark}}}
+\rhead[\fancyplain{}{\nouppercase{\leftmark}}]%
+      {\fancyplain{}{\thepage}}
+\cfoot{\textsc{\scriptsize \textcolor{gray}{[Draft of \today]}}}
+\lfoot[]{}
+\rfoot[]{}
+
+%%%% Chapter & part style
+\usepackage{titlesec}
+\titleformat{\part}[display]{\fontsize{40}{40}\fontseries{m}\fontshape{sc}\selectfont}{\hfil\partname\ \Roman{part}}{20pt}{\fontsize{60}{60}\fontseries{b}\fontshape{sc}\selectfont\hfil}
+\titleformat{\chapter}[display]{\fontsize{23}{25}\fontseries{m}\fontshape{it}\selectfont}{\chaptertitlename\ \thechapter}{20pt}{\fontsize{35}{35}\fontseries{b}\fontshape{n}\selectfont}
+
+\input{main.labels}
+
+\title{Errata for the HoTT Book, first edition}
+
+\begin{document}
+\maketitle
+
+\begin{tabular}{llp{11cm}}
+  \textbf{Location} & \textbf{Fixed in} & \textbf{Change}\\
+  \hline
+  \autoref{sec:sigma-types}
+  & be277a8
+  & In the types of $g$ and $\ind{\sm{x:A}B(x)}$, there is a $\prd{a:A}{b:B(x)}$ in which $x$ should be $a$.\\
+  \autoref{sec:more-formal-sigma}
+  & cd691e8
+  & In $\Sigma$-\comp\ and the following paragraph, $y.C$ should be $z.C$, and ``we bind \dots $y$ in $C$'' should likewise say $z$.\\
+  \autoref{sec:coproduct-types}
+  & 264d934
+  & In two displayed equations, $f(\inl(b))$ should be $f(\inr(b))$.\\
+  \autoref{sec:sigma-types}
+  & d0bfa0d
+  & At two places in the definition of $\ac$, $R(a,\fst(g(x)))$ should be $R(x,\fst(g(x)))$.\\
+  \autoref{sec:dependent-paths}
+  & d4a47c2
+  & Soon after \autoref{rmk:defid}, the phrase ``An element $b:P(\base)$ in the fiber over the constructor $\base:\nat$'' should say $\base:\Sn^1$.\\
+\end{tabular}
+
+\end{document}


### PR DESCRIPTION
As discussed at issue #298, I've added some remarks about versions.  The appropriate branch(es) still need to be created.  I also started some kind of errata list, with all the substantive corrections I could find that have been made since the "first-edition" tag.  For each one I listed the commit hash where it was fixed.  It would be better to list the associated number that appears in the "Book version" on the title page, so that a reader could compare it to the number in their copy and instantly know which errata they have to worry about, but I don't know how to extract that number (Andrej?).
