### PR TITLE
Fix some overfull hbox problems in the ebook version

### DIFF
--- a/basics.tex
+++ b/basics.tex
@@ -230,7 +230,7 @@ We begin with symmetry of equality, which, in topological language, means that `
   \begin{equation*}
     d\defeq \lam{x} \refl{x}:\prd{x:A} D(x,x,\refl{x}).
   \end{equation*}
-  Thus, the induction principle for identity types gives us an element $\indid{A}(D,d,x,y,p): (y= x)$ for each $p:(x= y)$.
+  Thus, the induction principle for identity types gives us an element $\indid{A}\allowbreak (D,d,x,y,p): (y= x)$ for each $p:(x= y)$.
   We can now define the desired function $\opp{(\blank)}$ to be $\lam{p} \indid{A}(D,d,x,y,p)$, i.e.\ we set $\opp{p} \defeq \indid{A}(D,d,x,y,p)$.
   The conversion rule~\eqref{eq:Jconv} gives $\opp{\refl{x}}\jdeq \refl{x}$, as required.
 \end{proof}
@@ -2155,7 +2155,7 @@ p_2 &: \transfib{\semigroupstrsym}{p_1}{(m,a)}{(m',a')}.
 \end{align*}
 By univalence, $p_1$ is $\ua(e)$ for some equivalence $e$. By
 \cref{thm:path-sigma}, function extensionality, and the above analysis of
-transport along $\semigroupstrsym$, $p_2$ is equivalent to a pair
+transport along \\ $\semigroupstrsym$, $p_2$ is equivalent to a pair
 of proofs, the first of which shows that
 \begin{equation*} \label{eq:equality-semigroup-mult}
 \prd{y_1,y_2:B} e(m(\opp{e}(y_1), \opp{e}(y_2))) = m'(y_1,y_2)

--- a/induction.tex
+++ b/induction.tex
@@ -745,7 +745,7 @@ involving the naturality properties of operations of the form $p_{\, * \,}$.
 %%%%%
 
 \index{natural numbers!encoded as a W-type@encoded as a $\w$-type}%
-Finally, as desired, we can encode homotopy-natural-numbers as homotopy-$\w$-types:
+Finally, as desired, we can encode homotopy-natural-numbers as homo\-topy-$\w$-types:
 
 \begin{thm}
 The rules for natural numbers with propositional computation rules can be derived from the rules for $\w$-types with propositional computation rules.


### PR DESCRIPTION
There are some severe overfull hbox problems  (i.e. _truncated_ lines!) in the ebook version (and presumably also the ustrade version): see, for instance, pp 77, 120, and 202 in the original released version, or pp 79, 122, and 204 in the version of commit 7de3423000c2069ad51c07657376532fc2af4708.

Long mathematical expressions like that on p. 79 can be broken up by inserting `\allowbreak` at appropriate points, and problems like on p. 204 can be fixed by inserting discretionary hyphens (or `\allowhyphens` from the ), but I'm afraid more substantial changes are needed to fix problems like that on p. 122. (In the attached patch, I just insert a ragged line break, which looks bad but does the job.)
