### PR TITLE
Put references that are in maths mode in a `\text` command

### DIFF
--- a/categories.tex
+++ b/categories.tex
@@ -633,7 +633,7 @@ By \autoref{ct:adjprop,ct:isoprop}, if $A$ is a category, then the type ``$F$ is
   Finally, consider the other composite~\ref{item:ct:ffeso2}$\to$\ref{item:ct:ffeso1}$\to$\ref{item:ct:ffeso2}.
   Since being fully faithful is a mere proposition, it suffices to observe that we recover, for each $b:B$, the same $a:A$ and isomorphism $F a \cong b$.
   But this is clear, since we used this function and isomorphism to define $G_0$ and $\epsilon$ in~\ref{item:ct:ffeso1}, which in turn are precisely what we used to recover~\ref{item:ct:ffeso2} again.
-  Thus, the composites in both directions are equal to identities, hence we have an equivalence \eqv{\ref{item:ct:ffeso1}}{\ref{item:ct:ffeso2}}.
+  Thus, the composites in both directions are equal to identities, hence we have an equivalence \eqv{\text{\ref{item:ct:ffeso1}}}{\text{\ref{item:ct:ffeso2}}}.
 \end{proof}
 
 However, if $B$ is not a category, then neither type in \autoref{ct:ffeso} may necessarily be a mere proposition.


### PR DESCRIPTION
There is a line in which a reference is inside a maths environment
(enforced by `\ensuremath`).  As these are references, they are
actually text elements so should be in `\text` commands.
