### PR TITLE
Fix definition of \pairpath in section 2.6

### DIFF
--- a/basics.tex
+++ b/basics.tex
@@ -1185,7 +1185,7 @@ space are pairs of paths.
 In particular, we have shown that~\eqref{eq:path-prod} has an inverse~\eqref{eq:path-prod-inverse}, which we may denote by
 \symlabel{defn:pairpath}
 \[
-\pairpath : (\id{\proj{1}(x)}{\proj{1}(y)}) \times (\id{\proj{1}(x)}{\proj{1}(y)}) \to (\id x y).
+\pairpath : (\id{\proj{1}(x)}{\proj{1}(y)}) \times (\id{\proj{2}(x)}{\proj{2}(y)}) \to (\id x y).
 \]
 Note that a special case of this yields the propositional uniqueness principle\index{uniqueness!principle, propositional!for product types} for products: $z = (\proj1(z),\proj2(z))$.
 


### PR DESCRIPTION
In section 2.6, on page 77, after the proof, the type of \pairpath is given incorrectly, using pr_1 for both sides of the pair.
