### PR TITLE
Typo in the proof of theorem 2.6.4

### DIFF
--- a/basics.tex
+++ b/basics.tex
@@ -1243,7 +1243,7 @@ Now given $p : \id[Z]{z}{w}$ and $x : A(z) \times B(z)$, we can transport $x$ al
   \begin{align*}
     \transfib{A\times B}px&\jdeq x\\
     \transfib{A}{p}{\proj{1}x}&\jdeq \proj1x\\
-    \transfib{A}{p}{\proj{2}x}&\jdeq \proj2x.
+    \transfib{B}{p}{\proj{2}x}&\jdeq \proj2x.
   \end{align*}
   Thus, it remains to show $x = (\proj1 x, \proj2x)$.
   But this is the propositional uniqueness principle for product types, which, as we remarked above, follows from \autoref{thm:path-prod}.


### PR DESCRIPTION
The second `transport^A` should be a `transport^B`.
