### PR TITLE
Fix URL to http://homotopytypetheory.org

### DIFF
--- a/introduction.tex
+++ b/introduction.tex
@@ -427,7 +427,7 @@ Obviously, however, much work remains to be done.
 
 \index{open!problem|)}%
 
-The homotopy type theory community maintains a web site and group blog at \url{http://www.homotopytypetheory.org}, as well as a discussion email list.
+The homotopy type theory community maintains a web site and group blog at \url{http://homotopytypetheory.org}, as well as a discussion email list.
 Newcomers are always welcome!
 
 


### PR DESCRIPTION
The current URL http://www.homotopytypetheory.org is a
permanent redirect (301) to http://homotopytypetheory.org,
so the latter URL should be used instead.
