### PR TITLE
Fix typo in exercise 1.4 from "C_0" to "c_0"

### DIFF
--- a/preliminaries.tex
+++ b/preliminaries.tex
@@ -1906,7 +1906,7 @@ Assuming as given only the \emph{iterator} for natural numbers
 with the defining equations
 \begin{align*}
 \ite(C,c_0,c_s,0)  &\defeq c_0, \\
-\ite(C,c_0,c_s,\suc(n)) &\defeq c_s(\ite(C,C_0,c_s,n))
+\ite(C,c_0,c_s,\suc(n)) &\defeq c_s(\ite(C,c_0,c_s,n))
 \end{align*}
 derive the recursor $\rec{\nat}$.
 \end{ex}


### PR DESCRIPTION
See also: http://homotopytypetheory.org/#comment-4259
