### PR TITLE
Fixed an error in Lemma 11.4.1 definition

### DIFF
--- a/reals.tex
+++ b/reals.tex
@@ -1798,11 +1798,11 @@ without further assumptions.
 
 \begin{lem} \label{lem:untruncated-linearity-reals-coincide}
   %
-  If for every $x : \RD$ there merely exists
+  If there merely exists
   %
   \begin{equation}
     \label{eq:untruncated-linearity}
-    c : \prd{y : \RD} \prd{q, r : \Q} (q < r) \to (q < x) + (y < r)
+    c : \prd{y : \RD} \prd{q, r : \Q} (q < r) \to (q < y) + (y < r)
   \end{equation}
   %
   then the Cauchy and Dedekind reals coincide.


### PR DESCRIPTION
I'm not sure I fixed it right, but it was utter nonsense before. At worst the premise is now trivially true instead of trivially false.
