### PR TITLE
typo in proof of Definition 8.6.5

### DIFF
--- a/homotopy.tex
+++ b/homotopy.tex
@@ -1671,7 +1671,7 @@ Applying this with $y\defeq \north$ will show that all fibers of $\sigma$ are $2
   It remains to construct, for each $x_1:X$, a dependent path
   \[ \dpath{\lam{y}(\north=y)\to\type}{\merid(x_1)}{\code(\north)}{\code(\south)}. \]
   By \autoref{thm:dpath-arrow}, this is equivalent to giving a family of paths
-  \[ \prd{q:\north=\south} \code(\north)(\transfib{\lam{y}(\north=y)}{\merid(x_1)}{q}) = \code(\south)(q). \]
+  \[ \prd{q:\north=\south} \code(\north)(\transfib{\lam{y}(\north=y)}{\opp{\merid(x_1)}}{q}) = \code(\south)(q). \]
   And by univalence and transport in path types, this is equivalent to a family of equivalences
   \[ \prd{q:\north=\south} \code(\north,q \ct \opp{\merid(x_1)}) \eqvsym \code(\south,q). \]
   We will define a family of maps


### PR DESCRIPTION
path needed to be inverted
