### PR TITLE
Correction to fix for issue #379

### DIFF
--- a/macros.tex
+++ b/macros.tex
@@ -3,8 +3,8 @@
 
 %%% Notes and exercise sections
 \makeatletter
-\newcommand{\sectionNotes}{\phantomsection\section*{Notes}\addcontentsline{toc}{section}{Notes}\sectionmark{\@chapapp{} \thechapter{} Notes}}
-\newcommand{\sectionExercises}[1]{\phantomsection\section*{Exercises}\addcontentsline{toc}{section}{Exercises}\sectionmark{\@chapapp{} \thechapter{} Exercises}}
+\newcommand{\sectionNotes}{\phantomsection\section*{Notes}\addcontentsline{toc}{section}{Notes}\markright{\textsc{\@chapapp{} \thechapter{} Notes}}}
+\newcommand{\sectionExercises}[1]{\phantomsection\section*{Exercises}\addcontentsline{toc}{section}{Exercises}\markright{\textsc{\@chapapp{} \thechapter{} Exercises}}}
 \makeatother
 
 %%% Definitional equality (used infix) %%%


### PR DESCRIPTION
The previous patch had a bug; this removes the printing of the old section number from the section mark for exercises/notes.
