### PR TITLE
typo in Lemma 8.6.10 (freudlemma)

### DIFF
--- a/homotopy.tex
+++ b/homotopy.tex
@@ -1703,19 +1703,19 @@ In addition to~\eqref{eq:freudcodeN} and~\eqref{eq:freudcodeS}, we will need to 
 For this we use the following lemma.
 
 \begin{lem}\label{thm:freudlemma}
-  Let $A:\UU$, $B:A\to \UU$, and $C:\prd{a:A} B(a)\to\UU$, and also $a_1,a_2:A$ with $m:x=y$ and $b:B(a_2)$.
+  Let $A:\UU$, $B:A\to \UU$, and $C:\prd{a:A} B(a)\to\UU$, and also $a_1,a_2:A$ with $m:a_1=a_2$ and $b:B(a_2)$.
   Then the function
   \[\transfib{\widehat{C}}{\pairpath(m,t)}{\blank} : C(a_1,\transfib{B}{\opp m}{b}) \to C(a_2,b),\]
   where $t:\transfib{B}{m}{\transfib{B}{\opp m}{b}} = b$ is the obvious coherence path and $\widehat{C}:(\sm{a:A} B(a)) \to\type$ is the uncurried form of $C$, is equal to the equivalence obtained by univalence from the composite
   \begin{align}
-    C(x,\transfib{B}{\opp m}{b})
+    C(a_1,\transfib{B}{\opp m}{b})
     &= \transfib{\lam{a} B(a)\to \UU}{m}{C(a_1)}(b)
     \tag{by~\eqref{eq:transport-arrow}}\\
     &= C(a_2,b). \tag{by $\happly(\apd{C}{m},b)$}
   \end{align}
 \end{lem}
 \begin{proof}
-  By path induction, we may assume $y$ is $x$ and $m$ is $\refl{x}$, in which case both functions are the identity.
+  By path induction, we may assume $a_2$ is $a_1$ and $m$ is $\refl{a_1}$, in which case both functions are the identity.
 \end{proof}
 
 We apply this lemma with $A\defeq\susp X$ and $B\defeq \lam{y}(\north=y)$ and $C\defeq\code$, while $a_1\defeq\north$ and $a_2\defeq\south$ and $m\defeq \merid(x_1)$ for some $x_1:X$, and finally $b\defeq q$ is some path $\north=\south$.


### PR DESCRIPTION
Two points are variously referred to as a_1,a_2 and x,y. Went with a_1,a_2 since x's are being used for elements of X elsewhere.
