### PR TITLE
Lemma 11.2.2. Proof. Rename a variable to avoid shadowing.

### DIFF
--- a/reals.tex
+++ b/reals.tex
@@ -287,9 +287,9 @@ multiplicative inverses, we must first introduce order. Define $\leq$ and $<$ as
 \end{lem}
 
 \begin{proof}
-  If $L_x(q)$ then by roundedness there merely is $r > q$ such that $L_x(r)$, and since
-  $U_q(r)$ it follows that $q < x$. Conversely, if $q < x$ then there is $r : \Q$ such
-  that $U_q(r)$ and $L_x(r)$, hence $L_x(q)$ because $L_x$ is a lower set. The other half
+  If $L_x(q)$ then by roundedness there merely is $s > q$ such that $L_x(s)$, and since
+  $U_q(s)$ it follows that $q < x$. Conversely, if $q < x$ then there is $s : \Q$ such
+  that $U_q(s)$ and $L_x(s)$, hence $L_x(q)$ because $L_x$ is a lower set. The other half
   of the proof is symmetric.
 \end{proof}
 


### PR DESCRIPTION
May I suggest renaming a variable r in the proof of Lemma 11.2.2 to a different name?
It's currently shadowing an existing variable of the same type from the outer scope (the lemma statement).
