### PR TITLE
formal notation for judgmental equality in appendix differs from intro

### DIFF
--- a/formal.tex
+++ b/formal.tex
@@ -53,7 +53,7 @@ is customary in much type-theoretic literature.
 In \autoref{cha:typetheory}, we presented the two basic \define{judgments}
 \index{judgment}
 of type theory. The first, $a:A$, asserts that a term $a$ has type $A$. The second,
-$a\jdeq b:A$, states that the two terms $a$ and $b$ are \define{judgmentally
+$a\jdeq b:A$ (written $a\jdeq_A b$ or $a \jdeq b$ in the introduction), states that the two terms $a$ and $b$ are \define{judgmentally
 equal}
 \index{equality!judgmental}
 \index{judgmental equality}


### PR DESCRIPTION
compared notation for judgmental equality with that in the intro
