### PR TITLE
Fix a couple of typos in §5.3.

### DIFF
--- a/induction.tex
+++ b/induction.tex
@@ -285,7 +285,7 @@ In general, the $\w$-type $\wtype{x:A} B(x)$ specified by  $A : \type$ and $B : 
   $\supp : \prd{a:A} \Big(B(a) \to \wtype{x:A} B(x)\Big) \to \wtype{x:A} B(x)$.
 \end{itemize}
 %
-The constructor $\supp$ (short for supremum\index{supremum!constructor of a W-type@constructor of a $\w$-type}) takes a label $a : A$ and a function $f : B(a) \to \wtype{a:A} B(a)$ representing the arguments to $a$, and constructs a new element of $\wtype{x:A} B(x)$. Using our previous encoding of natural numbers as $\w$-types, we can for instance define
+The constructor $\supp$ (short for supremum\index{supremum!constructor of a W-type@constructor of a $\w$-type}) takes a label $a : A$ and a function $f : B(a) \to \wtype{x:A} B(x)$ representing the arguments to $a$, and constructs a new element of $\wtype{x:A} B(x)$. Using our previous encoding of natural numbers as $\w$-types, we can for instance define
 \begin{equation*}
 \zerow \defeq \supp(\bfalse, \; \lamu{x:\emptyt} \rec\emptyt(\natw,x)).
 \end{equation*}


### PR DESCRIPTION
The textual description of sup contradicts the displayed type of sup in §5.3 (p. 195 in the ebook edition of version 207-g21ac918): sup should take a term of dependent sum type as input, not a term of dependent product type. The textual description also has a variable shadowing problem.

(The attached patch does not include an errata entry.)
