### PR TITLE
Some inappropriate uses of \text... to \math…

### DIFF
--- a/macros.tex
+++ b/macros.tex
@@ -426,7 +426,7 @@
 \newcommand{\inv}[1]{{#1}^{-1}}
 \newcommand{\idtoiso}{\ensuremath{\mathsf{idtoiso}}\xspace}
 \newcommand{\isotoid}{\ensuremath{\mathsf{isotoid}}\xspace}
-\newcommand{\op}{^{\textrm{op}}}
+\newcommand{\op}{^{\mathrm{op}}}
 \newcommand{\y}{\ensuremath{\mathbf{y}}\xspace}
 \newcommand{\dgr}[1]{{#1}^{\dagger}}
 \newcommand{\unitaryiso}{\mathrel{\cong^\dagger}}
@@ -544,7 +544,7 @@
 \newcommand{\istype}[1]{\mathsf{is}\mbox{-}{#1}\mbox{-}\mathsf{type}}
 \newcommand{\nplusone}{\ensuremath{(n+1)}}
 \newcommand{\nminusone}{\ensuremath{(n-1)}}
-\newcommand{\fact}{\textsf{fact}}
+\newcommand{\fact}{\mathsf{fact}}
 
 %%% Macros for homotopy
 \newcommand{\kbar}{\overline{k}} % Used in van Kampen's theorem


### PR DESCRIPTION
There are some inappropriate uses of `\text...` formatting commands – see e.g. Theorem 7.6.6 ("fact" is italicised) and Theorem 9.5.4 ("op" is italicised). The attached patch changes these to the corresponding `\math...` commands. (Another possibility is to insert an `\upshape` command somewhere to ensure that the text is always printed upright.)
