### PR TITLE
Say "path induction" rather than "identity elimination" in 2.1.4, close ...

### DIFF
--- a/basics.tex
+++ b/basics.tex
@@ -475,7 +475,7 @@ It is a familiar fact in topology that when we concatenate a path $p$ with the r
       \big(\refl{x}\ct(\refl{x}\ct \refl{x})= (\refl{x}\ct \refl{x})\ct \refl{x}\big)
     \end{equation*}
     which is definitionally equal to the type $(\refl{x} = \refl{x})$, and is therefore inhabited by $\refl{\refl{x}}$.
-    Applying the identity elimination rule three times, therefore, we obtain an element of the overall desired type.
+    Applying the path induction rule three times, therefore, we obtain an element of the overall desired type.
 
     \mentalpause
 


### PR DESCRIPTION
...#414.

I don't think this needs an erratum.
