### PR TITLE
Typo: prop-trunc

### DIFF
--- a/logic.tex
+++ b/logic.tex
@@ -691,7 +691,7 @@ Similarly, when discussing subsets as in \autoref{subsec:prop-subsets}, we may u
   A \setminus \setof{x:A | P(x)}
   &\defeq \setof{x:A | \neg P(x)}.
 \end{align*}
-Of course, in the absence of \LEM{}, the latter are not ``complements'' in the usual sense: we may not have $B \cup (A\setminus B) = A$.
+Of course, in the absence of \LEM{}, the latter are not ``complements'' in the usual sense: we may not have $A \cup (A\setminus B) = A$.
 
 \index{truncation!propositional|)}%
 \index{mere proposition|)}%


### PR DESCRIPTION
The statement which is given does not hold in general. I have changed it to something which at least hold, but I can't know what was supposed to stand there.
