### PR TITLE
Automatically mark and push errata (almost)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
 language: c
 
 env:
+ global:
+   - secure: "1JBF9mV0vgq1StF9McuBHKc+sOQXX7mNiEEkFNfsyjKY/pM7rFWoqZk7CQhg9HvFuQyJgljYgVsLEcKDQ07DNpHBUb54aR/5Uwqse75vLtrqCR8DQfbM6BwKeUfQRRNtExFQu8bzFfgsmzk6pNv/wJ4Bg8QLRBGo4KPjnG9fIxo="
+
  matrix:
-   - LATEXMK="yes"
-   - LATEXMK=""
+   - LATEXMK="yes" UPDATE_ERRATA=""
+   - LATEXMK=""    UPDATE_ERRATA="yes"
 
 
 install:
  - echo | sudo add-apt-repository ppa:texlive-backports/ppa
  - sudo apt-get update -q
- - sudo apt-get install -q texlive
+ - sudo apt-get install -q texlive wget curl sed grep
  - if [ ! -z "$LATEXMK" ]; then sudo apt-get install -q latexmk; fi
  - wget http://mirrors.ctan.org/macros/latex/contrib/comment/comment.sty
  - wget http://www.ctan.org/tex-archive/macros/latex/contrib/misc/nextpage.sty
@@ -26,3 +29,7 @@ install:
  - wget http://mirrors.ctan.org/macros/latex/contrib/braket/braket.sty
 
 script: make
+
+# add -f to force a push even if we're not on HoTT/HoTT.
+# generally only useful for debugging
+after_script: etc/ci/update_errata.sh

--- a/etc/ci/add_upstream.sh
+++ b/etc/ci/add_upstream.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# in case we're run from out of git repo
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd "$DIR" 1>/dev/null
+
+echo "Adding remote..."
+git remote add upstream git://github.com/HoTT/book.git
+git remote update
+
+popd 1>/dev/null

--- a/etc/ci/configure_commit.sh
+++ b/etc/ci/configure_commit.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# in case we're run from out of git repo
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd "$DIR" 1>/dev/null
+
+# now change to the git root
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+echo "Configuring git for commit"
+if [ -z "$(git config --global user.name)" ]; then
+    git config --global user.name "Travis-CI Bot"
+fi
+if [ -z "$(git config --global user.email)" ]; then
+    git config --global user.email "Travis-CI-Bot@travis.fake"
+fi
+
+popd 1>/dev/null

--- a/etc/ci/push_remote.sh
+++ b/etc/ci/push_remote.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# in case we're run from out of git repo
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd "$DIR" 1>/dev/null
+
+# now change to the git root
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR" 1>/dev/null
+
+if [ -z "$OAUTH_TOKEN" ]; then
+    echo 'Error: Not pushing because $OAUTH_TOKEN is empty'
+    exit 1
+fi
+
+echo "Updating ~/.netrc file"
+echo >> ~/.netrc
+echo "machine github.com login $OAUTH_TOKEN" >> ~/.netrc
+
+REPO="$(git remote -v | grep -o 'origin\s\+\(.*\?\)\s\+(push)' | sed s'/origin\s\+//g' | sed s'/\s\+(push)//g' | sed s'#git://github.com/#https://github.com/#g')"
+
+echo '$ git push '"$REPO ""$@"
+git push $REPO "$@"
+
+popd 1>/dev/null

--- a/etc/ci/update_errata.sh
+++ b/etc/ci/update_errata.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# in case we're run from out of git repo
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd "$DIR" 1>/dev/null
+
+# now change to the git root
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+# only make if we should ($UPDATE_ERRATA is not empty) and we're the same as origin/master
+if [ -z "$UPDATE_ERRATA" ]; then
+    echo 'Not updating errata because $UPDATE_ERRATA is not set'
+    exit 0
+fi
+
+git reset --hard
+
+"$DIR"/add_upstream.sh
+
+git remote update
+
+SUPPORTS_UNSHALLOW="$(git fetch --help | grep -c -- '--unshallow')"
+if [ "$SUPPORTS_UNSHALLOW" -eq 0 ]; then
+    echo "Your git ($(git --version)) does not support the --unshallow option to fetch"
+    echo '$ git fetch --depth 1000000000'
+    git fetch --depth 1000000000
+else
+    echo '$ git fetch --unshallow'
+    git fetch --unshallow
+fi
+
+git fetch --tags
+
+echo "Updating errata..."
+echo '$ ./mark-errata'
+./mark-errata
+
+if [ -z "$(git diff HEAD)" ]; then
+    exit 0
+fi
+
+"$DIR"/configure_commit.sh
+echo '$ git --no-pager diff HEAD'
+git --no-pager diff HEAD
+echo '$ git --no-pager diff HEAD..origin/master'
+git --no-pager diff HEAD..origin/master
+echo '$ git --no-pager diff HEAD..upstream/master'
+git --no-pager diff HEAD..upstream/master
+
+BAD_REMOTES="$(git remote -v | grep origin | grep -v 'github.com/HoTT/book')"
+UPSTREAM_LOG="$(git log HEAD..upstream/master)"
+
+git commit -am "Mark Errata (auto)"
+
+# check that we're in the right place, or that we have -f
+if [ "$1" != "-f" ]; then
+    if [ ! -z "$BAD_REMOTES" ]; then
+	echo 'Not updating errata because there are remotes which are not HoTT/book:'
+	echo "$BAD_REMOTES"
+	exit 0
+    fi
+
+    git remote update
+    # only make the errata if we're the same as upstream/master
+    if [ ! -z "$UPSTREAM_LOG" ]; then
+	echo "Not making errata beause we do not match with upstream/master; call '$0 -f' to force"
+	exit 0
+    fi
+fi
+
+git rebase origin master && "$DIR"/push_remote.sh HEAD:master
+
+popd 1>/dev/null

--- a/mark-errata
+++ b/mark-errata
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 for COMMIT in $( git blame errata.tex | grep -o '% merge of.\+' | grep -o '[^ ]\+$' ); do
-    MERGE=$(git log "$COMMIT..master" --ancestry-path --merges --oneline | grep -o '^[^ ]\+' | xargs git describe | sed s/first-edition-//)
-    echo Marking $COMMIT as $MERGE
+    MERGE=$(git log "$COMMIT..master" --ancestry-path --merges --oneline | grep -o '^[^ ]\+' | xargs git describe | sed s'/first-edition-//g')
+    echo "Marking $COMMIT as $MERGE"
     sed -i "s/% merge of $COMMIT/$MERGE/g" errata.tex
 done


### PR DESCRIPTION
This commit uses the `mark-errata` script to mark errata on travis.
If travis builds something which is the same as the official repo's
master, and we are building for the official repo, then we autocommit
updated errata and push to the master branch.

Someone who has push bits for this repo will need to replace my OAuth
key with one of their own.  I record the process here (adapted from
082425c2b6633dc66ebe2365b860e2ad88c5610f of HoTT/HoTT), so that if we
need to update the keys, there will be a reference.

First, generate the OAuth token that will be used, replacing
'<username>' with your username.  You must have permission to push to
HoTT/book.

``` bash
$ TOKEN="$(curl -u '<username>' -d '{"scopes":["repo"],"note":"For Travis-CI Bot for HoTT/book"}' https://api.github.com/authorizations | grep -o 'token": "[^"]*' | sed s'/token": "//g')"
```

It will prompt you for your password.

Now, the hard part (at least if you don't have sudo). Hope that you
either have ruby and gem installed, or a version of ssh-keygen which
supports the `-e -m` flag combination (check with `ssh-keygen -\?`).  If
you have ruby and gem, then you can follow
http://about.travis-ci.org/docs/user/encryption-keys/, and run

``` bash
$ gem install travis
$ travis encrypt -r HoTT/book "OAUTH_TOKEN=$TOKEN"
```

and update the `secure:` part of the `.travis.yml` file with the resulting
secret.  Otherwise, you can follow
http://about.travis-ci.org/docs/user/travis-pro/#How-can-I-encrypt-files-that-include-sensitive-data%3F
and run

``` bash
$ \curl https://api.travis-ci.org/repos/HoTT/book/key | perl -pe 's/^{"key"://; s/^"//; s/"}$//' | sed s'/\\n/\n/g' > id_travis.pub
$ ssh-keygen -e -m PKCS8 -f id_travis.pub > id_travis.pub.pem
$ echo "OAUTH_TOKEN=$TOKEN" | openssl rsautl -encrypt -pubin -inkey id_travis.pub.pem
```

However, if `ssh-keygen` fails, complaining about `-m` being
unrecognized, then you must clone or copy
https://gist.github.com/thwarted/1024558
(https://gist.github.com/1024558.git), install the required python
dependencies (for me, pyasn1), and then run that on `id_travis.pub` to
get the `id_travis.pub.pem` file, and then run the `openssl rsautl`
commmand.  Either way, the output of that third command should be placed
in the `.travis.yml` file, replacing the existing secret.

Perhaps we should include these instructions somewhere in the
repository?
