### PR TITLE
Update cleveref from 0.17.9 to 0.19

### DIFF
--- a/cleveref.sty
+++ b/cleveref.sty
@@ -6,11 +6,13 @@
 %%
 %% cleveref.dtx  (with options: `package')
 %% 
-%% LaTeX package for automatic cross-referencing text.
+%% LaTeX package for intelligent cross-referencing.
 %% 
-%% Copyright (C) 2006  Toby Cubitt
+%% Copyright (C) 2006--2013  Toby Cubitt
 %% See the files README and COPYING.
 %% 
+\def\packagedate{2013/12/28}
+\def\packageversion{0.19}
 %% This file may be distributed and/or modified under the
 %% conditions of the LaTeX Project Public License, either version 1.2
 %% of this license or (at your option) any later version.
@@ -22,7 +24,7 @@
 %% version 1999/12/01 or later.
 \NeedsTeXFormat{LaTeX2e}[1999/12/01]
 \ProvidesPackage{cleveref}
- [2011/03/22 v0.17.9 Intelligent cross-referencing]
+ [\packagedate\space v\packageversion\space Intelligent cross-referencing]
 %% \CharacterTable
 %%  {Upper-case    \A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z
 %%   Lower-case    \a\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x\y\z
@@ -38,521 +40,266 @@
 %%   Right bracket \]     Circumflex    \^     Underscore    \_
 %%   Grave accent  \`     Left brace    \{     Vertical bar  \|
 %%   Right brace   \}     Tilde         \~}
-\def\cref@currentlabel{}
-\let\cref@old@refstepcounter\refstepcounter
+\def\cref@currentlabel{}%
+\let\cref@old@refstepcounter\refstepcounter%
 \def\refstepcounter{%
   \@ifnextchar[{\refstepcounter@optarg}{\refstepcounter@noarg}%]
-}
+}%
 \def\refstepcounter@noarg#1{%
   \cref@old@refstepcounter{#1}%
   \cref@constructprefix{#1}{\cref@result}%
   \@ifundefined{cref@#1@alias}%
     {\def\@tempa{#1}}%
     {\def\@tempa{\csname cref@#1@alias\endcsname}}%
-  \protected@xdef\cref@currentlabel{%
+  \protected@edef\cref@currentlabel{%
     [\@tempa][\arabic{#1}][\cref@result]%
-    \csname p@#1\endcsname\csname the#1\endcsname}}
+    \csname p@#1\endcsname\csname the#1\endcsname}}%
 \def\refstepcounter@optarg[#1]#2{%
   \cref@old@refstepcounter{#2}%
   \cref@constructprefix{#2}{\cref@result}%
-  \protected@xdef\cref@currentlabel{%
-    [#1][\arabic{#2}][\cref@result]%
-    \csname p@#2\endcsname\csname the#2\endcsname}}
-\let\cref@old@footnotetext\@footnotetext
-\let\cref@old@mpfootnotetext\@mpfootnotetext
-\def\@footnotetext{%
-  \cref@constructprefix{footnote}{\cref@result}%
-  \protected@xdef\cref@currentlabel{%
-    [footnote][\arabic{footnote}][\cref@result]\p@footnote\@thefnmark}%
-  \cref@old@footnotetext}
-\def\@mpfootnotetext#1{%
-  \cref@constructprefix{mpfootnote}{\cref@result}%
-  \protected@xdef\cref@currentlabel{%
-    [footnote][\arabic{mpfootnote}][\cref@result]\p@footnote\@thefnmark}%
-  \cref@old@mpfootnotetext{#1}}
+  \@ifundefined{cref@#1@alias}%
+    {\def\@tempa{#1}}%
+    {\def\@tempa{\csname cref@#1@alias\endcsname}}%
+  \protected@edef\cref@currentlabel{%
+    [\@tempa][\arabic{#2}][\cref@result]%
+    \csname p@#2\endcsname\csname the#2\endcsname}}%
 \AtBeginDocument{%
-  \let\cref@old@label\label
+  \let\cref@old@label\label%
   \def\label{\@ifnextchar[\label@optarg\label@noarg}%]
+  \let\cref@label\label%
   \def\label@noarg#1{%
     \@bsphack%
     \cref@old@label{#1}%
     \protected@write\@auxout{}%
-      {\string\newlabel{cref@#1}{{\cref@currentlabel}{\thepage}}}%
+      {\string\newlabel{#1@cref}{{\cref@currentlabel}{\thepage}}}%
     \@esphack}%
   \def\label@optarg[#1]#2{%
     \@bsphack%
     \cref@old@label{#2}%
-    \protected@xdef\cref@currentlabel{%
+    \protected@edef\cref@currentlabel{%
       \expandafter\cref@override@label@type%
         \cref@currentlabel\@nil{#1}}%
     \protected@write\@auxout{}%
-      {\string\newlabel{cref@#2}{{\cref@currentlabel}{\thepage}}}%
+      {\string\newlabel{#2@cref}{{\cref@currentlabel}{\thepage}}}%
     \@esphack}%
-  \@ifpackageloaded{amsmath}{%
-    \let\cref@label\label
-    \let\cref@old@label@in@display\label@in@display
-    \def\label@in@display{%
-      \@ifnextchar[\label@in@display@optarg\label@in@display@noarg}%]
-    \def\label@in@display@noarg#1{\cref@old@label@in@display{{#1}}}
-    \def\label@in@display@optarg[#1]#2{%
-      \cref@old@label@in@display{[#1]{#2}}}
-    \def\ltx@label#1{\cref@label#1}
-\def\measure@#1{%
-    \begingroup
-        \measuring@true
-        \global\eqnshift@\z@
-        \global\alignsep@\z@
-        \global\let\tag@lengths\@empty
-        \global\let\field@lengths\@empty
-        \savecounters@
-        \global\setbox0\vbox{%
-            \let\math@cr@@@\math@cr@@@align@measure
-            \everycr{\noalign{\global\tag@false
-              \global\let\raise@tag\@empty \global\column@\z@}}%
-            \let\label\@gobble@optarg%  <<< cleveref modification
-            \global\row@\z@
-            \tabskip\z@
-            \halign{\span\align@preamble\crcr
-                #1%
-                \math@cr@@@
-                \global\column@\z@
-                \add@amps\maxfields@\cr
-            }%
-        }%
-        \restorecounters@
-        \ifodd\maxfields@
-            \global\advance\maxfields@\@ne
-        \fi
-        \ifnum\xatlevel@=\tw@
-            \ifnum\maxfields@<\thr@@
-                \let\xatlevel@\z@
-            \fi
-        \fi
-        \setbox\z@\vbox{%
-          \unvbox\z@ \unpenalty \global\setbox\@ne\lastbox
-        }%
-        \global\totwidth@\wd\@ne
-        \if@fleqn \global\advance\totwidth@\@mathmargin \fi
-        \global\let\maxcolumn@widths\@empty
-        \begingroup
-          \let\or\relax
-          \loop
-            \global\setbox\@ne\hbox{%
-              \unhbox\@ne \unskip \global\setbox\thr@@\lastbox
-            }%
-          \ifhbox\thr@@
-           \xdef\maxcolumn@widths{ \or \the\wd\thr@@ \maxcolumn@widths}%
-          \repeat
-        \endgroup
-        \dimen@\displaywidth
-        \advance\dimen@-\totwidth@
-        \ifcase\xatlevel@
-            \global\alignsep@\z@
-            \let\minalignsep\z@
-            \@tempcntb\z@
-            \if@fleqn
-                \@tempcnta\@ne
-                \global\eqnshift@\@mathmargin
-            \else
-                \@tempcnta\tw@
-                \global\eqnshift@\dimen@
-                \global\divide\eqnshift@\@tempcnta
-            \fi
-        \or
-            \@tempcntb\maxfields@
-            \divide\@tempcntb\tw@
-            \@tempcnta\@tempcntb
-            \advance\@tempcntb\m@ne
-            \if@fleqn
-                \global\eqnshift@\@mathmargin
-                \global\alignsep@\dimen@
-                \global\divide\alignsep@\@tempcnta
-            \else
-                \global\advance\@tempcnta\@ne
-                \global\eqnshift@\dimen@
-                \global\divide\eqnshift@\@tempcnta
-                \global\alignsep@\eqnshift@
-            \fi
-        \or
-            \@tempcntb\maxfields@
-            \divide\@tempcntb\tw@
-            \global\advance\@tempcntb\m@ne
-            \global\@tempcnta\@tempcntb
-            \global\eqnshift@\z@
-            \global\alignsep@\dimen@
-            \if@fleqn
-                \global\advance\alignsep@\@mathmargin\relax
-            \fi
-            \global\divide\alignsep@\@tempcntb
-        \fi
-        \ifdim\alignsep@<\minalignsep\relax
-            \global\alignsep@\minalignsep\relax
-            \ifdim\eqnshift@>\z@
-                \if@fleqn\else
-                    \global\eqnshift@\displaywidth
-                    \global\advance\eqnshift@-\totwidth@
-                    \global\advance\eqnshift@-\@tempcntb\alignsep@
-                    \global\divide\eqnshift@\tw@
-                \fi
-            \fi
-        \fi
-        \ifdim\eqnshift@<\z@
-            \global\eqnshift@\z@
-        \fi
-        \calc@shift@align
-        \global\tagshift@\totwidth@
-        \global\advance\tagshift@\@tempcntb\alignsep@
-        \if@fleqn
-            \ifnum\xatlevel@=\tw@
-                \global\advance\tagshift@-\@mathmargin\relax
-            \fi
-        \else
-            \global\advance\tagshift@\eqnshift@
-        \fi
-        \iftagsleft@ \else
-            \global\advance\tagshift@-\displaywidth
-        \fi
-        \dimen@\minalignsep\relax
-        \global\advance\totwidth@\@tempcntb\dimen@
-        \ifdim\totwidth@>\displaywidth
-            \global\let\displaywidth@\totwidth@
-        \else
-            \global\let\displaywidth@\displaywidth
-        \fi
-    \endgroup
-}
-\def\gmeasure@#1{%
-    \begingroup
-        \measuring@true
-        \totwidth@\z@
-        \global\let\tag@lengths\@empty
-        \savecounters@
-        \setbox\@ne\vbox{%
-            \everycr{\noalign{\global\tag@false
-              \global\let\raise@tag\@empty \global\column@\z@}}%
-            \let\label\@gobble%  <<< cleveref modification
-            \halign{%
-                \setboxz@h{$\m@th\displaystyle{##}$}%
-                \ifdim\wdz@>\totwidth@
-                    \global\totwidth@\wdz@
-                \fi
-               &\setboxz@h{\strut@{##}}%
-                \savetaglength@
-                \crcr
-                #1%
-                \math@cr@@@
-            }%
-        }%
-        \restorecounters@
-        \if@fleqn
-            \global\advance\totwidth@\@mathmargin
-        \fi
-        \iftagsleft@
-            \ifdim\totwidth@>\displaywidth
-                \global\let\gdisplaywidth@\totwidth@
-            \else
-                \global\let\gdisplaywidth@\displaywidth
-            \fi
-        \fi
-    \endgroup
-}
-\def\multline@#1{%
-    \Let@
-    \@display@init{\global\advance\row@\@ne \global\dspbrk@lvl\m@ne}%
-    \chardef\dspbrk@context\z@
-    \restore@math@cr
-    \let\tag\tag@in@align
-    \global\tag@false \global\let\raise@tag\@empty
-    \mmeasure@{#1}%
-    \let\tag\gobble@tag \let\label\@gobble@optarg%  <<< cleveref modification
-    \tabskip \if@fleqn \@mathmargin \else \z@skip \fi
-    \totwidth@\displaywidth
-    \if@fleqn
-        \advance\totwidth@-\@mathmargin
-    \fi
-    \halign\bgroup
-        \hbox to\totwidth@{%
-            \if@fleqn
-                \hskip \@centering \relax
-            \else
-                \hfil
-            \fi
-            \strut@
-            $\m@th\displaystyle{}##\endmultline@math
-            \hfil
-        }% $
-        \crcr
-        \if@fleqn
-            \hskip-\@mathmargin
-            \def\multline@indent{\hskip\@mathmargin}%
-        \else
-            \hfilneg
-            \def\multline@indent{\hskip\multlinegap}%
-        \fi
-        \iftagsleft@
-            \iftag@
-                \begingroup
-                    \ifshifttag@
-                        \rlap{\vbox{%
-                                \normalbaselines
-                                \hbox{%
-                                    \strut@
-                                    \make@display@tag
-                                }%
-                                \vbox to\lineht@{}%
-                                \raise@tag
-                        }}%
-                        \multline@indent
-                    \else
-                        \setbox\z@\hbox{\make@display@tag}%
-                        \dimen@\@mathmargin \advance\dimen@-\wd\z@
-                        \ifdim\dimen@<\multlinetaggap
-                          \dimen@\multlinetaggap
-                        \fi
-                        \box\z@ \hskip\dimen@\relax
-                    \fi
-                \endgroup
-            \else
-                \multline@indent
-            \fi
-        \else
-            \multline@indent
-        \fi
-    #1%
-}
-\def\mmeasure@#1{%
-    \begingroup
-        \measuring@true
-        \def\label{%                  <<< cleveref modification
-          \@ifnextchar[\label@in@mmeasure@optarg%]
-            \label@in@mmeasure@noarg}%
-        \def\math@cr@@@{\cr}%
-        \let\shoveleft\@iden \let\shoveright\@iden
-        \savecounters@
-        \global\row@\z@
-        \setbox\@ne\vbox{%
-            \global\let\df@tag\@empty
-            \halign{%
-                \setboxz@h{\@lign$\m@th\displaystyle{}##$}%
-                \iftagsleft@
-                    \ifnum\row@=\@ne
-                        \global\totwidth@\wdz@
-                        \global\lineht@\ht\z@
-                    \fi
-                \else
-                    \global\totwidth@\wdz@
-                    \global\lineht@\dp\z@
-                \fi
-                \crcr
-                #1%
-                \crcr
-            }%
-        }%
-        \ifx\df@tag\@empty\else\global\tag@true\fi
-        \if@eqnsw\global\tag@true\fi
-        \iftag@
-            \setboxz@h{%
-                \if@eqnsw
-                    \stepcounter{equation}%
-                    \tagform@\theequation
-                \else
-                    \df@tag
-                \fi
-            }%
-            \global\tagwidth@\wdz@
-            \dimen@\totwidth@
-            \advance\dimen@\tagwidth@
-            \advance\dimen@\multlinetaggap
-            \iftagsleft@\else
-                \if@fleqn
-                    \advance\dimen@\@mathmargin
-                \fi
-            \fi
-            \ifdim\dimen@>\displaywidth
-                \global\shifttag@true
-            \else
-                \global\shifttag@false
-            \fi
-        \fi
-        \restorecounters@
-    \endgroup
-}
-\def\label@in@mmeasure@noarg#1{%
-  \begingroup%
-    \measuring@false%
-    \cref@old@label@in@display{{#1}}%
-  \endgroup}
-\def\label@in@mmeasure@optarg[#1]#2{%
-  \begingroup%
-    \measuring@false%
-    \cref@old@label@in@display{[#1]{#2}}%
-  \endgroup}
-  \let\cref@old@subequations\subequations%
-  \let\cref@old@endsubequations\endsubequations%
-  \cref@resetby{equation}{\cref@result}%
-  \ifx\cref@result\relax\else%
-    \@addtoreset{parentequation}{\cref@result}%
+}% end of AtBeginDocument
+\let\cref@old@makefntext\@makefntext%
+\long\def\@makefntext{%
+  \cref@constructprefix{footnote}{\cref@result}%
+  \protected@edef\cref@currentlabel{%
+    [footnote][\arabic{footnote}][\cref@result]%
+    \p@footnote\@thefnmark}%
+  \cref@old@makefntext}%
+\let\cref@old@othm\@othm%
+\def\@othm#1[#2]#3{%
+  \edef\@tempa{\expandafter\noexpand%
+    \csname cref@#1@name@preamble\endcsname}%
+  \edef\@tempb{\expandafter\noexpand%
+    \csname Cref@#1@name@preamble\endcsname}%
+  \def\@tempc{#3}%
+  \ifx\@tempc\@empty\relax%
+    \expandafter\gdef\@tempa{}%
+    \expandafter\gdef\@tempb{}%
+  \else%
+    \if@cref@capitalise%
+      \expandafter\expandafter\expandafter\gdef\expandafter%
+        \@tempa\expandafter{\MakeUppercase #3}%
+    \else%
+      \expandafter\expandafter\expandafter\gdef\expandafter%
+        \@tempa\expandafter{\MakeLowercase #3}%
+    \fi%
+    \expandafter\expandafter\expandafter\gdef\expandafter%
+      \@tempb\expandafter{\MakeUppercase #3}%
   \fi%
-  \renewenvironment{subequations}{%
-    \@addtoreset{equation}{parentequation}%
-    \cref@old@subequations%
-  }{%
-    \gdef\cl@parentequation{}%
-    \cref@old@endsubequations%
-    \setcounter{parentequation}{0}%
-  }%
-    \def\make@df@tag@@#1{%
-      \gdef\df@tag{\maketag@@@{#1}\def\@currentlabel{#1}%
-        \def\cref@currentlabel{[equation][2147483647][]#1}}}
-    \def\make@df@tag@@@#1{%
-      \gdef\df@tag{\tagform@{#1}%
-        \toks@\@xp{\p@equation{#1}}%
-          \edef\@currentlabel{\the\toks@}%
-          \edef\cref@currentlabel{[equation][2147483647][]\the\toks@}}}
-  }{}%  end of \@ifpackageloaded{amsmath}
-}%  end of AtBeginDocument
-\let\cref@old@appendix\appendix
-\renewcommand\appendix{%
-  \cref@old@appendix%
-  \@ifundefined{chapter}{%
-    \gdef\refstepcounter@noarg##1{%
-      \cref@old@refstepcounter{##1}%
-      \cref@constructprefix{##1}{\cref@result}%
-      \ifx\cref@result\@empty%
-        \def\cref@result{2147483647}%
-      \else%
-        \edef\cref@result{2147483647,\cref@result}%
-      \fi%
-      \def\@tempa{##1}%
-      \def\@tempb{section}%
-      \ifx\@tempa\@tempb%
-        \protected@xdef\cref@currentlabel{%
-          [appendix][\arabic{##1}][\cref@result]%
-          \csname p@##1\endcsname\csname the##1\endcsname}%
-      \else%
-        \def\@tempa{##1}%
-        \def\@tempb{subsection}%
-        \ifx\@tempa\@tempb%
-          \protected@xdef\cref@currentlabel{%
-            [subappendix][\arabic{##1}][\cref@result]%
-            \csname p@##1\endcsname\csname the##1\endcsname}%
+  \cref@stack@add{#1}{\cref@label@types}%
+  \cref@old@othm{#1}[#2]{#3}}%
+\let\cref@old@xnthm\@xnthm%
+\def\@xnthm#1#2[#3]{%
+  \edef\@tempa{\expandafter\noexpand%
+    \csname cref@#1@name@preamble\endcsname}%
+  \edef\@tempb{\expandafter\noexpand%
+      \csname Cref@#1@name@preamble\endcsname}%
+  \def\@tempc{#2}%
+  \ifx\@tempc\@empty\relax%
+    \expandafter\gdef\@tempa{}%
+    \expandafter\gdef\@tempb{}%
+  \else%
+    \if@cref@capitalise%
+      \expandafter\expandafter\expandafter\gdef\expandafter%
+        \@tempa\expandafter{\MakeUppercase #2}%
+    \else%
+      \expandafter\expandafter\expandafter\gdef\expandafter%
+        \@tempa\expandafter{\MakeLowercase #2}%
+    \fi%
+    \expandafter\expandafter\expandafter\gdef\expandafter%
+      \@tempb\expandafter{\MakeUppercase #2}%
+  \fi%
+  \cref@stack@add{#1}{\cref@label@types}%
+  \cref@old@xnthm{#1}{#2}[#3]}%
+\let\cref@old@ynthm\@ynthm%
+\def\@ynthm#1#2{%
+  \edef\@tempa{\expandafter\noexpand%
+    \csname cref@#1@name@preamble\endcsname}%
+  \edef\@tempb{\expandafter\noexpand%
+      \csname Cref@#1@name@preamble\endcsname}%
+  \def\@tempc{#2}%
+  \ifx\@tempc\@empty\relax%
+    \expandafter\gdef\@tempa{}%
+    \expandafter\gdef\@tempb{}%
+  \else%
+    \if@cref@capitalise%
+      \expandafter\expandafter\expandafter\gdef\expandafter%
+        \@tempa\expandafter{\MakeUppercase #2}%
+    \else%
+      \expandafter\expandafter\expandafter\gdef\expandafter%
+        \@tempa\expandafter{\MakeLowercase #2}%
+    \fi%
+    \expandafter\expandafter\expandafter\gdef\expandafter%
+      \@tempb\expandafter{\MakeUppercase #2}%
+  \fi%
+  \cref@stack@add{#1}{\cref@label@types}%
+  \cref@old@ynthm{#1}{#2}}%
+\@ifundefined{appendix}{}{%
+  \g@addto@macro\appendix{%
+    \@ifundefined{chapter}{%
+      \gdef\refstepcounter@noarg#1{%
+        \cref@old@refstepcounter{#1}%
+        \cref@constructprefix{#1}{\cref@result}%
+        \ifx\cref@result\@empty%
+          \def\cref@result{2147483647}%
         \else%
-          \def\@tempa{##1}%
-          \def\@tempb{subsubsection}%
-          \ifx\@tempa\@tempb%
-            \protected@xdef\cref@currentlabel{%
-              [subsubappendix][\arabic{##1}][\cref@result]%
-              \csname p@##1\endcsname\csname the##1\endcsname}%
-          \else%
-            \@ifundefined{cref@##1@alias}%
-              {\def\@tempa{##1}}%
-              {\def\@tempa{\csname cref@##1@alias\endcsname}}%
-            \protected@xdef\cref@currentlabel{%
-              [\@tempa][\arabic{##1}][\cref@result]%
-              \csname p@##1\endcsname\csname the##1\endcsname}
-          \fi%
+          \edef\cref@result{2147483647,\cref@result}%
         \fi%
-      \fi}%
-  }{%
-    \def\refstepcounter@noarg##1{%
-      \cref@old@refstepcounter{##1}%
-      \cref@constructprefix{##1}{\cref@result}%
-      \ifx\cref@result\@empty%
-        \def\cref@result{2147483647}%
-      \else%
-        \edef\cref@result{2147483647,\cref@result}%
-      \fi%
-      \def\@tempa{##1}%
-      \def\@tempb{chapter}%
-      \ifx\@tempa\@tempb%
-        \protected@xdef\cref@currentlabel{%
-          [appendix][\arabic{##1}][\cref@result]%
-          \csname p@##1\endcsname\csname the##1\endcsname}%
-      \else%
-        \def\@tempa{##1}%
+        \def\@tempa{#1}%
         \def\@tempb{section}%
         \ifx\@tempa\@tempb%
-          \protected@xdef\cref@currentlabel{%
-            [subappendix][\arabic{##1}][\cref@result]%
-            \csname p@##1\endcsname\csname the##1\endcsname}%
+          \protected@edef\cref@currentlabel{%
+            [appendix][\arabic{#1}][\cref@result]%
+            \csname p@#1\endcsname\csname the#1\endcsname}%
         \else%
-          \def\@tempa{##1}%
+          \def\@tempa{#1}%
           \def\@tempb{subsection}%
           \ifx\@tempa\@tempb%
-            \protected@xdef\cref@currentlabel{%
-              [subsubappendix][\arabic{##1}][\cref@result]%
-              \csname p@##1\endcsname\csname the##1\endcsname}%
+            \protected@edef\cref@currentlabel{%
+              [subappendix][\arabic{#1}][\cref@result]%
+              \csname p@#1\endcsname\csname the#1\endcsname}%
           \else%
-            \def\@tempa{##1}%
+            \def\@tempa{#1}%
             \def\@tempb{subsubsection}%
             \ifx\@tempa\@tempb%
-              \protected@xdef\cref@currentlabel{%
-                [subsubsubappendix][\arabic{##1}][\cref@result]%
-                \csname p@##1\endcsname\csname the##1\endcsname}%
+              \protected@edef\cref@currentlabel{%
+                [subsubappendix][\arabic{#1}][\cref@result]%
+                \csname p@#1\endcsname\csname the#1\endcsname}%
             \else%
-              \@ifundefined{cref@##1@alias}%
-                {\def\@tempa{##1}}%
-                {\def\@tempa{\csname cref@##1@alias\endcsname}}%
-              \protected@xdef\cref@currentlabel{%
-                [\@tempa][\arabic{##1}][\cref@result]%
-                \csname p@##1\endcsname\csname the##1\endcsname}
+              \@ifundefined{cref@#1@alias}%
+                {\def\@tempa{#1}}%
+                {\def\@tempa{\csname cref@#1@alias\endcsname}}%
+              \protected@edef\cref@currentlabel{%
+                [\@tempa][\arabic{#1}][\cref@result]%
+                \csname p@#1\endcsname\csname the#1\endcsname}%
             \fi%
           \fi%
+        \fi}%
+    }{%
+      \def\refstepcounter@noarg#1{%
+        \cref@old@refstepcounter{#1}%
+        \cref@constructprefix{#1}{\cref@result}%
+        \ifx\cref@result\@empty%
+          \def\cref@result{2147483647}%
+        \else%
+          \edef\cref@result{2147483647,\cref@result}%
         \fi%
-      \fi}%
+        \def\@tempa{#1}%
+        \def\@tempb{chapter}%
+        \ifx\@tempa\@tempb%
+          \protected@edef\cref@currentlabel{%
+            [appendix][\arabic{#1}][\cref@result]%
+            \csname p@#1\endcsname\csname the#1\endcsname}%
+        \else%
+          \def\@tempa{#1}%
+          \def\@tempb{section}%
+          \ifx\@tempa\@tempb%
+            \protected@edef\cref@currentlabel{%
+              [subappendix][\arabic{#1}][\cref@result]%
+              \csname p@#1\endcsname\csname the#1\endcsname}%
+          \else%
+            \def\@tempa{#1}%
+            \def\@tempb{subsection}%
+            \ifx\@tempa\@tempb%
+              \protected@edef\cref@currentlabel{%
+                [subsubappendix][\arabic{#1}][\cref@result]%
+                \csname p@#1\endcsname\csname the#1\endcsname}%
+            \else%
+              \def\@tempa{#1}%
+              \def\@tempb{subsubsection}%
+              \ifx\@tempa\@tempb%
+                \protected@edef\cref@currentlabel{%
+                  [subsubsubappendix][\arabic{#1}][\cref@result]%
+                  \csname p@#1\endcsname\csname the#1\endcsname}%
+              \else%
+                \@ifundefined{cref@#1@alias}%
+                  {\def\@tempa{#1}}%
+                  {\def\@tempa{\csname cref@#1@alias\endcsname}}%
+                \protected@edef\cref@currentlabel{%
+                  [\@tempa][\arabic{#1}][\cref@result]%
+                  \csname p@#1\endcsname\csname the#1\endcsname}%
+              \fi%
+            \fi%
+          \fi%
+        \fi}%
+    }%
   }%
-}
+}% end of \@ifundefined{appendix}
 \def\@gobble@optarg{\@ifnextchar[\@@gobble@optarg\@gobble@orig}%]
-\def\@gobble@orig#1{}
-\def\@@gobble@optarg[#1]#2{}
-\def\cref@getlabel#1#2{%
-  \expandafter\let\expandafter\@tempa\csname r@cref@#1\endcsname%
+\def\@gobble@orig#1{}%
+\def\@@gobble@optarg[#1]#2{}%
+\def\cref@append@toks#1#2{\toks0={#2}%
+  \edef\act{\noexpand#1={\the#1\the\toks0}}%
+  \act}%
+\def\cref@getref#1#2{%
+  \expandafter\let\expandafter#2\csname r@#1@cref\endcsname%
   \expandafter\expandafter\expandafter\def%
-    \expandafter\expandafter\expandafter\@tempa%
+    \expandafter\expandafter\expandafter#2%
     \expandafter\expandafter\expandafter{%
-      \expandafter\@firstoftwo\@tempa}%
+      \expandafter\@firstoftwo#2}}%
+\def\cref@getpageref#1#2{%
+  \expandafter\let\expandafter#2\csname r@#1@cref\endcsname%
+  \expandafter\expandafter\expandafter\def%
+    \expandafter\expandafter\expandafter#2%
+    \expandafter\expandafter\expandafter{%
+      \expandafter\@secondoftwo#2}}%
+\def\cref@getlabel#1#2{%
+  \cref@getref{#1}{\@tempa}%
   \expandafter\@cref@getlabel\@tempa\@nil#2}%
 \def\@cref@getlabel{\@ifnextchar[%]
-  \@@cref@getlabel{\@@cref@getlabel[][][]}}
-\def\@@cref@getlabel[#1][#2][#3]#4\@nil#5{\def#5{#4}}
+  \@@cref@getlabel{\@@cref@getlabel[][][]}}%
+\def\@@cref@getlabel[#1][#2][#3]#4\@nil#5{\def#5{#4}}%
 \def\cref@gettype#1#2{%
-  \expandafter\let\expandafter\@tempa\csname r@cref@#1\endcsname%
-  \expandafter\expandafter\expandafter\def%
-    \expandafter\expandafter\expandafter\@tempa%
-    \expandafter\expandafter\expandafter{%
-      \expandafter\@firstoftwo\@tempa}%
+  \cref@getref{#1}{\@tempa}%
   \expandafter\@cref@gettype\@tempa\@nil#2}%
 \def\@cref@gettype{\@ifnextchar[%]
-  \@@cref@gettype{\@@cref@gettype[][][]}}
-\def\@@cref@gettype[#1][#2][#3]#4\@nil#5{\def#5{#1}}
+  \@@cref@gettype{\@@cref@gettype[][][]}}%
+\def\@@cref@gettype[#1][#2][#3]#4\@nil#5{\def#5{#1}}%
 \def\cref@getcounter#1#2{%
-  \expandafter\let\expandafter\@tempa\csname r@cref@#1\endcsname%
-  \expandafter\expandafter\expandafter\def%
-    \expandafter\expandafter\expandafter\@tempa%
-    \expandafter\expandafter\expandafter{%
-      \expandafter\@firstoftwo\@tempa}%
-  \expandafter\@cref@getcounter\@tempa\@nil#2}
+  \cref@getref{#1}{\@tempa}%
+  \expandafter\@cref@getcounter\@tempa\@nil#2}%
 \def\@cref@getcounter{\@ifnextchar[%]
-  \@@cref@getcounter{\@@cref@getcounter[][][]}}
-\def\@@cref@getcounter[#1][#2][#3]#4\@nil#5{\def#5{#2}}
+  \@@cref@getcounter{\@@cref@getcounter[][][]}}%
+\def\@@cref@getcounter[#1][#2][#3]#4\@nil#5{\def#5{#2}}%
 \def\cref@getprefix#1#2{%
-  \expandafter\let\expandafter\@tempa\csname r@cref@#1\endcsname%
-  \expandafter\expandafter\expandafter\def%
-    \expandafter\expandafter\expandafter\@tempa%
-    \expandafter\expandafter\expandafter{%
-      \expandafter\@firstoftwo\@tempa}%
-  \expandafter\@cref@getprefix\@tempa\@nil#2}
+  \cref@getref{#1}{\@tempa}%
+  \expandafter\@cref@getprefix\@tempa\@nil#2}%
 \def\@cref@getprefix{\@ifnextchar[%]
-  \@@cref@getprefix{\@@cref@getprefix[][][]}}
-\def\@@cref@getprefix[#1][#2][#3]#4\@nil#5{\def#5{#3}}
-\def\cref@override@label@type[#1][#2][#3]#4\@nil#5{[#5][#2][#3]#4}
+  \@@cref@getprefix{\@@cref@getprefix[][][]}}%
+\def\@@cref@getprefix[#1][#2][#3]#4\@nil#5{\def#5{#3}}%
+\def\cref@override@label@type[#1][#2][#3]#4\@nil#5{[#5][#2][#3]#4}%
 \def\cref@constructprefix#1#2{%
   \cref@stack@init{\@tempstack}%
   \edef\@tempa{\noexpand{#1\noexpand}}%
   \expandafter\def\expandafter\@tempa\expandafter{\@tempa{#2}}%
   \expandafter\@cref@constructprefix\@tempa%
   \cref@stack@to@list{\@tempstack}{\@tempa}%
-  \expandafter\def\expandafter#2\expandafter{\@tempa}}
+  \expandafter\def\expandafter#2\expandafter{\@tempa}}%
 \def\@cref@constructprefix#1#2{%
   \cref@resetby{#1}{#2}%
   \ifx#2\relax%
@@ -562,20 +309,17 @@
     \edef\@tempa{{#2}}%
     \expandafter\expandafter\expandafter\@cref@constructprefix%
       \expandafter\@tempa\expandafter{\expandafter#2\expandafter}%
-  \fi}
-\def\cref@append@toks#1#2{\toks0={#2}%
-  \edef\act{\noexpand#1={\the#1\the\toks0}}%
-  \act}%
-\def\cref@stack@init#1{\def#1{\@nil}}
-\def\cref@stack@top#1{\expandafter\@cref@stack@top#1}
-\def\@cref@stack@top#1,#2\@nil{#1}
-\def\cref@stack@pop#1{\expandafter\@cref@stack@pop#1#1}
-\def\@cref@stack@pop#1,#2\@nil#3{\def#3{#2\@nil}}
+  \fi}%
+\def\cref@stack@init#1{\def#1{\@nil}}%
+\def\cref@stack@top#1{\expandafter\@cref@stack@top#1}%
+\def\@cref@stack@top#1,#2\@nil{#1}%
+\def\cref@stack@pop#1{\expandafter\@cref@stack@pop#1#1}%
+\def\@cref@stack@pop#1,#2\@nil#3{\def#3{#2\@nil}}%
 \def\cref@stack@push#1#2{%
-  \expandafter\@cref@stack@push\expandafter{#2}{#1}{#2}}
-\def\@cref@stack@push#1#2#3{\def#3{#2,#1}}
-\def\cref@stack@pull#1#2{\expandafter\@cref@stack@pull#2{#1}{#2}}
-\def\@cref@stack@pull#1\@nil#2#3{\def#3{#1#2,\@nil}}
+  \expandafter\@cref@stack@push\expandafter{#2}{#1}{#2}}%
+\def\@cref@stack@push#1#2#3{\def#3{#2,#1}}%
+\def\cref@stack@pull#1#2{\expandafter\@cref@stack@pull#2{#1}{#2}}%
+\def\@cref@stack@pull#1\@nil#2#3{\def#3{#1#2,\@nil}}%
 \def\cref@stack@to@list#1#2{%
   \cref@isstackfull{#1}%
   \if@cref@stackfull%
@@ -585,8 +329,8 @@
       \expandafter\@cref@stack@to@list#1}%
   \else%
     \def#2{}%
-  \fi}
-\def\@cref@stack@to@list#1,\@nil{#1}
+  \fi}%
+\def\@cref@stack@to@list#1,\@nil{#1}%
 \def\cref@stack@topandbottom#1#2#3{%
   \def#2{}%
   \def#3{}%
@@ -599,7 +343,7 @@
       \edef#3{\cref@stack@top{#1}}%
       \cref@stack@pop{#1}%
       \cref@isstackfull{#1}}%
-  \fi}
+  \fi}%
 \def\cref@stack@add#1#2{%
   \begingroup%
     \def\@arg1{#1}%
@@ -618,17 +362,17 @@
         \cref@isstackfull{\@tempstack}%
       \fi}%
   \expandafter\endgroup%
-  \if@notthere\cref@stack@push{#1}{#2}\fi}
-\newif\if@cref@stackempty
-\newif\if@cref@stackfull
+  \if@notthere\cref@stack@push{#1}{#2}\fi}%
+\newif\if@cref@stackempty%
+\newif\if@cref@stackfull%
 \def\cref@isstackempty#1{%
   \def\@tempa{\@nil}%
   \ifx#1\@tempa\@cref@stackemptytrue%
-  \else\@cref@stackemptyfalse\fi}
+  \else\@cref@stackemptyfalse\fi}%
 \def\cref@isstackfull#1{%
   \def\@tempa{\@nil}%
   \ifx#1\@tempa\@cref@stackfullfalse%
-  \else\@cref@stackfulltrue\fi}
+  \else\@cref@stackfulltrue\fi}%
 \def\cref@stack@sort#1#2{%
   \begingroup%
   \cref@stack@init{\@sortstack}%
@@ -672,32 +416,32 @@
     \expandafter\cref@stack@insert\@tempa%
     \cref@isstackfull{#1}}%
   \expandafter\endgroup\expandafter%
-  \def\expandafter#1\expandafter{\@sortstack}}
+  \def\expandafter#1\expandafter{\@sortstack}}%
 \def\cref@stack@insert#1#2#3#4{%
   \let\@cmp#4%
   \@cref@stack@insert{}{#1}{#2}{#3}%
-  \cref@stack@pop{#3}}
+  \cref@stack@pop{#3}}%
 \def\@cref@stack@insert#1#2#3#4{%
-  \let\@iterate\relax%
+  \let\cref@iterate\relax%
   \cref@isstackempty{#4}%
   \if@cref@stackempty%
     \cref@stack@push{#1,#2#3}{#4}%
   \else%
-    \edef\@tempa{\cref@stack@top{#4}}%
-    \expandafter\@cmp\expandafter{\@tempa}{#2}{\cref@result}%
+    \edef\cref@elem{\cref@stack@top{#4}}%
+    \expandafter\@cmp\expandafter{\cref@elem}{#2}{\cref@result}%
     \ifnum\cref@result=2\relax%
       \cref@stack@push{#1,#2#3}{#4}%
     \else%
       \cref@stack@pop{#4}%
-      \edef\@tempa{{\noexpand#1,\@tempa}{\noexpand#2}%
+      \edef\cref@elem{{\noexpand#1,\cref@elem}{\noexpand#2}%
         {\noexpand#3}{\noexpand#4}}%
-      \expandafter\def\expandafter\@iterate\expandafter%
-        {\expandafter\@cref@stack@insert\@tempa}%
+      \expandafter\def\expandafter\cref@iterate\expandafter%
+        {\expandafter\@cref@stack@insert\cref@elem}%
     \fi%
   \fi%
-  \@iterate}
-\def\cref@counter@first#1#2\@nil{#1}
-\def\cref@counter@rest#1#2\@nil{#2}
+  \cref@iterate}%
+\def\cref@counter@first#1#2\@nil{#1}%
+\def\cref@counter@rest#1#2\@nil{#2}%
 \def\cref@countercmp#1#2#3{%
   \begingroup%
   \def\@tempa{#1}%
@@ -708,10 +452,10 @@
     \ifx\@tempa\@empty%
       \def\cref@result{2}%
     \else%
-      \expandafter\ifx\csname r@cref@#1\endcsname\relax%
+      \expandafter\ifx\csname r@#1@cref\endcsname\relax%
         \def\cref@result{2}%
       \else%
-        \expandafter\ifx\csname r@cref@#2\endcsname\relax%
+        \expandafter\ifx\csname r@#2@cref\endcsname\relax%
           \def\cref@result{1}%
         \else%
           \cref@getcounter{#1}{\@countera}%
@@ -738,7 +482,7 @@
     \fi%
   \fi%
   \expandafter\endgroup\expandafter%
-  \chardef\expandafter#3\expandafter=\cref@result\relax}
+  \chardef\expandafter#3\expandafter=\cref@result\relax}%
 \def\@cref@countercmp{%
   \let\@iterate\relax%
   \cref@isstackempty{\@countstacka}%
@@ -769,8 +513,41 @@
       \fi%
     \fi%
   \fi%
-  \@iterate}
-\newif\if@cref@inresetlist
+  \@iterate}%
+\def\cref@pagecmp#1#2#3{%
+  \begingroup%
+  \def\@tempa{#1}%
+  \ifx\@tempa\@empty%
+    \def\cref@result{1}%
+  \else%
+    \def\@tempa{#2}%
+    \ifx\@tempa\@empty%
+      \def\cref@result{2}%
+    \else%
+      \expandafter\ifx\csname r@#1@cref\endcsname\relax%
+        \def\cref@result{2}%
+      \else%
+        \expandafter\ifx\csname r@#2@cref\endcsname\relax%
+          \def\cref@result{1}%
+        \else%
+          \cref@getpageref{#1}{\@tempa}%
+          \cref@getpageref{#2}{\@tempb}%
+          \ifnum\@tempa<\@tempb\relax%
+            \def\cref@result{1}\relax%
+          \else%
+            \ifnum\@tempa>\@tempb\relax%
+              \def\cref@result{2}\relax%
+                \else%
+              \def\cref@result{0}\relax%
+            \fi%
+          \fi%
+        \fi%
+      \fi%
+    \fi%
+  \fi%
+  \expandafter\endgroup\expandafter%
+  \chardef\expandafter#3\expandafter=\cref@result\relax}%
+\newif\if@cref@inresetlist%
 \def\cref@isinresetlist#1#2{%
   \begingroup%
     \def\@counter{#1}%
@@ -798,7 +575,7 @@
     \fi%
   \expandafter%
   \endgroup%
-  \@next}
+  \@next}%
 \def\cref@resetby#1#2{%
   \let#2\relax%
   \def\@tempa{#1}%
@@ -906,7 +683,7 @@
         \fi%
       \fi%
     \fi%
-  \fi}
+  \fi}%
 \newif\if@cref@refconsecutive%
 \def\cref@isrefconsecutive#1#2{%
   \begingroup%
@@ -929,10 +706,28 @@
         \fi%
       \fi%
     \fi%
-  \expandafter\endgroup\@after}
+  \expandafter\endgroup\@after}%
+\def\cref@ispagerefconsecutive#1#2{%
+  \begingroup%
+  \countdef\refa@counter=0%
+  \countdef\refb@counter=1%
+  \cref@getpageref{#1}{\cref@result}%
+  \refa@counter=\cref@result%
+  \cref@getpageref{#2}{\cref@result}%
+  \refb@counter=\cref@result%
+  \def\@after{\@cref@refconsecutivefalse}%
+  \ifnum\refa@counter=\refb@counter\relax%
+    \def\@after{\@cref@refconsecutivetrue}%
+  \else%
+    \advance\refa@counter 1\relax%
+    \ifnum\refa@counter=\refb@counter\relax%
+      \def\@after{\@cref@refconsecutivetrue}%
+    \fi%
+  \fi%
+  \expandafter\endgroup\@after}%
 \def\cref@processgroup#1#2{%
   \edef\@nextref{\cref@stack@top{#1}}%
-  \expandafter\ifx\csname r@cref@\@nextref\endcsname\relax%
+  \expandafter\ifx\csname r@\@nextref @cref\endcsname\relax%
     \def\@grouptype{\@undefined}%
     \def\@groupformat{\@undefined}%
   \else%
@@ -958,7 +753,7 @@
         \let\@nexttype\@grouptype%
         \let\@nextforamt\@groupformat%
       \else%
-        \expandafter\ifx\csname r@cref@\@nextref\endcsname\relax%
+        \expandafter\ifx\csname r@\@nextref @cref\endcsname\relax%
           \def\@nexttype{\@undefined}%
           \def\@nextformat{\@undefined}%
         \else%
@@ -977,11 +772,11 @@
         \fi%
       \fi%
     \fi}%
-}
+}%
 \def\cref@processgroupall#1#2{%
   \cref@stack@init{\@tempstack}%
   \edef\@nextref{\cref@stack@top{#1}}%
-  \expandafter\ifx\csname r@cref@\@nextref\endcsname\relax%
+  \expandafter\ifx\csname r@\@nextref @cref\endcsname\relax%
     \def\@grouptype{\@undefined}%
     \def\@groupformat{\@undefined}%
   \else%
@@ -1006,7 +801,7 @@
         \let\@nextformat\relax%
       \fi%
     \else%
-      \expandafter\ifx\csname r@cref@\@nextref\endcsname\relax%
+      \expandafter\ifx\csname r@\@nextref @cref\endcsname\relax%
         \def\@nexttype{\@undefined}%
         \def\@nextformat{\@undefined}%
       \else%
@@ -1033,8 +828,8 @@
     \let\@lasttype\@nexttype%
     \let\@lastformat\@nextformat%
     \cref@isstackfull{#1}}%
-  \let#1\@tempstack}
-\def\cref@processconsecutive#1#2#3#4{%
+  \let#1\@tempstack}%
+\def\cref@processconsecutive#1#2#3#4#5{%
   #4=0%
   \edef\@nextref{\cref@stack@top{#1}}%
   \cref@stack@pop{#1}%
@@ -1048,7 +843,7 @@
     \let#3\relax%
     \edef\@nextref{\cref@stack@top{#1}}%
     #4=1\relax%
-    \expandafter\ifx\csname r@cref@#2\endcsname\relax%
+    \expandafter\ifx\csname r@#2@cref\endcsname\relax%
       \@cref@refconsecutivefalse%
     \else%
       \ifx\@nextref\@empty%
@@ -1062,11 +857,11 @@
             \edef\@nextref{\cref@stack@top{#1}}%
           \fi}%
       \else%
-        \expandafter\ifx\csname r@cref@\@nextref\endcsname\relax%
+        \expandafter\ifx\csname r@\@nextref @cref\endcsname\relax%
           \@cref@refconsecutivefalse%
         \else%
           \edef\@tempa{{#2}{\@nextref}}%
-          \expandafter\cref@isrefconsecutive\@tempa%
+          \expandafter#5\@tempa%
         \fi%
       \fi%
     \fi%
@@ -1090,21 +885,79 @@
               \edef\@nextref{\cref@stack@top{#1}}%
             \fi}%
         \else%
-          \expandafter\ifx\csname r@cref@\@nextref\endcsname\relax%
+          \expandafter\ifx\csname r@\@nextref @cref\endcsname\relax%
             \@cref@refconsecutivefalse%
           \else%
             \edef\@tempa{{#3}{\@nextref}}%
-            \expandafter\cref@isrefconsecutive\@tempa%
+            \expandafter#5\@tempa%
           \fi%
         \fi%
       \fi}%
-  \fi}
-\DeclareRobustCommand{\cref}[1]{\@cref{cref}{#1}}
-\DeclareRobustCommand{\Cref}[1]{\@cref{Cref}{#1}}
-\DeclareRobustCommand{\crefrange}[2]{\@setcrefrange{#1}{#2}{cref}{}}
-\DeclareRobustCommand{\Crefrange}[2]{\@setcrefrange{#1}{#2}{Cref}{}}
+  \fi}%
+\newcommand\crefstripprefix[2]{%
+  \begingroup%
+    \edef\@toksa{#1}%
+    \edef\@toksb{#2}%
+    \let\cref@acc\@empty%
+    \@crefstripprefix%
+    \cref@result%
+  \endgroup}
+\def\@crefstripprefix{%
+  \let\@iterate\relax%
+  \def\accum@flag{0}%
+  \let\@tempc\@tempb%
+  \cref@poptok{\@toksa}{\@tempa}%
+  \cref@poptok{\@toksb}{\@tempb}%
+  \ifx\@tempa\@tempb\relax%
+    \def\@iterate{\@crefstripprefix}%
+    \ifx\cref@acc\@empty\relax%
+      \let\cref@acc\@tempb%
+    \else%
+      \ifcat\@tempb\@tempc\relax%
+        \ifcat\@tempb a\relax%
+          \def\accum@flag{1}%
+        \else%
+          \expandafter\chardef\expandafter\@tempa%
+            \expandafter=\expandafter`\@tempb\relax%
+          \ifnum\@tempa>`/\relax%
+            \expandafter\ifnum\@tempb<`:\relax%
+              \def\accum@flag{1}%
+            \fi%
+          \fi%
+        \fi%
+      \fi%
+      \def\@tempa{1}%
+      \ifx\accum@flag\@tempa%
+        \edef\cref@acc{\cref@acc\@tempb}%
+      \else%
+        \let\cref@acc\@empty%
+      \fi%
+    \fi%
+  \else%
+    \ifcat\@tempb\@tempc\relax\else%
+      \let\cref@acc\@empty%
+    \fi%
+    \edef\cref@result{\cref@acc\@tempb\@toksb}%
+  \fi%
+  \@iterate}
+\def\cref@poptok#1#2{%
+  \expandafter\expandafter\expandafter\def%
+    \expandafter\expandafter\expandafter#2%
+    \expandafter\expandafter\expandafter{%
+      \expandafter\@cref@firsttok#1\@nil}%
+  \expandafter\expandafter\expandafter\def%
+    \expandafter\expandafter\expandafter#1%
+    \expandafter\expandafter\expandafter{%
+      \expandafter\@cref@poptok#1\@nil}}
+\def\@cref@firsttok#1#2\@nil{#1}
+\def\@cref@poptok#1#2\@nil{#2}
+\DeclareRobustCommand{\cref}[1]{\@cref{cref}{#1}}%
+\DeclareRobustCommand{\Cref}[1]{\@cref{Cref}{#1}}%
+\DeclareRobustCommand{\crefrange}[2]{\@setcrefrange{#1}{#2}{cref}{}}%
+\DeclareRobustCommand{\Crefrange}[2]{\@setcrefrange{#1}{#2}{Cref}{}}%
 \@ifpackageloaded{hyperref}{\newif\if@crefstarred}{%
-  \@ifpackageloaded{varioref}{\newif\if@crefstarred}{}}
+  \@ifpackageloaded{varioref}{\newif\if@crefstarred}{}}%
+\let\if@crefstarred\iffalse%
 \def\@cref#1#2{%
   \leavevmode%
   \begingroup%
@@ -1144,6 +997,7 @@
     \if@cref@compress%
       \cref@processconsecutive%
         {\@refsubstack}{\@beginref}{\@endref}{\count@consecutive}%
+        {\cref@isrefconsecutive}%
     \else%
       \edef\@beginref{\cref@stack@top{\@refsubstack}}%
       \cref@stack@pop{\@refsubstack}%
@@ -1188,6 +1042,7 @@
       \if@cref@compress%
         \cref@processconsecutive%
           {\@refsubstack}{\@beginref}{\@endref}{\count@consecutive}%
+          {\cref@isrefconsecutive}%
       \else%
         \edef\@beginref{\cref@stack@top{\@refsubstack}}%
         \cref@stack@pop{\@refsubstack}%
@@ -1241,9 +1096,9 @@
       \fi%
     \fi%
   }% end loop over main reference stack
-  \endgroup}
+  \endgroup}%
 \def\@setcref#1#2#3{%
-  \expandafter\ifx\csname r@cref@#1\endcsname\relax%
+  \expandafter\ifx\csname r@#1@cref\endcsname\relax%
     \protect\G@refundefinedtrue%
     \nfss@text{\reset@font\bfseries ??}%
     \@latex@warning{Reference `#1' on page \thepage \space undefined}%
@@ -1265,15 +1120,15 @@
       \expandafter\@@setcref\expandafter%
         {\csname #2@\@temptype @format#3\endcsname}{#1}%
     \fi%
-  \fi}
-\def\@@setcref#1#2{\cref@getlabel{#2}{\@templabel}#1{\@templabel}{}{}}
+  \fi}%
+\def\@@setcref#1#2{\cref@getlabel{#2}{\@templabel}#1{\@templabel}{}{}}%
 \def\@setcrefrange#1#2#3#4{%
   \begingroup%
-    \expandafter\ifx\csname r@cref@#1\endcsname\relax%
+    \expandafter\ifx\csname r@#1@cref\endcsname\relax%
       \protect\G@refundefinedtrue%
       \@latex@warning{Reference `#1' on page \thepage \space%
         undefined}%
-      \expandafter\ifx\csname r@cref@#2\endcsname\relax%
+      \expandafter\ifx\csname r@#2@cref\endcsname\relax%
         \nfss@text{\reset@font\bfseries ??}--%
         \nfss@text{\reset@font\bfseries ??}%
         \@latex@warning{Reference `#2' on page \thepage \space%
@@ -1283,7 +1138,7 @@
         \nfss@text{\reset@font\bfseries ??}--\@labelb%
       \fi%
     \else%
-      \expandafter\ifx\csname r@cref@#2\endcsname\relax%
+      \expandafter\ifx\csname r@#2@cref\endcsname\relax%
         \protect\G@refundefinedtrue%
         \cref@getlabel{#1}{\@labela}%
         \@labela--\nfss@text{\reset@font\bfseries ??}%
@@ -1310,143 +1165,278 @@
               type `\@typea' undefined}%
           \fi%
         \else%
-          \ifx\formata\formatb%
+          \ifx\@formata\@formatb%
             \expandafter\@@setcrefrange\expandafter{\@formata}{#1}{#2}%
           \else%
             \protect\G@refundefinedtrue%
             \nfss@text{\reset@font\bfseries ??}~\@labela--\@labelb%
             \@latex@warning{References `#1' and `#2' in reference range
-              on page \thepage have different types}%
+              on page \thepage \space have different types
+              `\@typea' and `\@typeb'}%
           \fi%
         \fi%
       \fi%
     \fi%
-  \endgroup}
+  \endgroup}%
 \def\@@setcrefrange#1#2#3{%
   \cref@getlabel{#2}{\@labela}%
   \cref@getlabel{#3}{\@labelb}%
-  #1{\@labela}{\@labelb}{}{}{}{}}
-\def\@setcref@pairgroupconjunction{\crefpairgroupconjunction}
-\def\@setcref@middlegroupconjunction{\crefmiddlegroupconjunction}
-\def\@setcref@lastgroupconjunction{\creflastgroupconjunction}
-\DeclareRobustCommand{\labelcref}[1]{\@cref{labelcref}{#1}}
+  #1{\@labela}{\@labelb}{}{}{}{}}%
+\def\@setcref@pairgroupconjunction{\crefpairgroupconjunction}%
+\def\@setcref@middlegroupconjunction{\crefmiddlegroupconjunction}%
+\def\@setcref@lastgroupconjunction{\creflastgroupconjunction}%
+\DeclareRobustCommand{\labelcref}[1]{\@cref{labelcref}{#1}}%
 \DeclareRobustCommand{\namecref}[1]{%
-  \expandafter\ifx\csname r@cref@#1\endcsname\relax%
-    \protect\G@refundefinedtrue%
-    \nfss@text{\reset@font\bfseries ??}%
-    \@latex@warning{Reference `#1' on page \thepage \space undefined}%
-  \else%
-    \cref@gettype{#1}{\@tempa}%
-    \@ifundefined{cref@\@tempa @name}{%
-      \protect\G@refundefinedtrue%``
-      \nfss@text{\reset@font\bfseries ??}%
-      \@latex@warning{Reference name for label type `\@tempa' undefined}%
-    }{\csname cref@\@tempa @name\endcsname}%
-  \fi}
+  \@setnamecref{cref}{#1}{}{}}%
 \DeclareRobustCommand{\nameCref}[1]{%
-  \expandafter\ifx\csname r@cref@#1\endcsname\relax%
-    \protect\G@refundefinedtrue%
-    \nfss@text{\reset@font\bfseries ??}%
-    \@latex@warning{Reference `#1' on page \thepage \space undefined}%
-  \else%
-    \cref@gettype{#1}{\@tempa}%
-    \@ifundefined{Cref@\@tempa @name}{%
-      \protect\G@refundefinedtrue%``
-      \nfss@text{\reset@font\bfseries ??}%
-      \@latex@warning{Reference name for label type `\@tempa' undefined}%
-    }{\csname Cref@\@tempa @name\endcsname}%
-  \fi}
+  \@setnamecref{Cref}{#1}{}{}}%
 \DeclareRobustCommand{\lcnamecref}[1]{%
-  \expandafter\ifx\csname r@cref@#1\endcsname\relax%
-    \protect\G@refundefinedtrue%
-    \nfss@text{\reset@font\bfseries ??}%
-    \@latex@warning{Reference `#1' on page \thepage \space undefined}%
-  \else%
-    \cref@gettype{#1}{\@tempa}%
-    \@ifundefined{cref@\@tempa @name}{%
-      \protect\G@refundefinedtrue%``
-      \nfss@text{\reset@font\bfseries ??}%
-      \@latex@warning{Reference name for label type `\@tempa' undefined}%
-    }{\expandafter\expandafter\expandafter%
-      \MakeLowercase\csname cref@\@tempa @name\endcsname}%
-  \fi}
+  \@setnamecref{Cref}{#1}{}{\MakeLowercase}}%
 \DeclareRobustCommand{\namecrefs}[1]{%
-  \expandafter\ifx\csname r@cref@#1\endcsname\relax%
-    \protect\G@refundefinedtrue%
-    \nfss@text{\reset@font\bfseries ??}%
-    \@latex@warning{Reference `#1' on page \thepage \space undefined}%
-  \else%
-    \cref@gettype{#1}{\@tempa}%
-    \@ifundefined{cref@\@tempa @name@plural}{%
-      \protect\G@refundefinedtrue%``
-      \nfss@text{\reset@font\bfseries ??}%
-      \@latex@warning{Reference name for label type `\@tempa' undefined}%
-    }{\csname cref@\@tempa @name@plural\endcsname}%
-  \fi}
+  \@setnamecref{cref}{#1}{@plural}{}}%
 \DeclareRobustCommand{\nameCrefs}[1]{%
-  \expandafter\ifx\csname r@cref@#1\endcsname\relax%
-    \protect\G@refundefinedtrue%
-    \nfss@text{\reset@font\bfseries ??}%
-    \@latex@warning{Reference `#1' on page \thepage \space undefined}%
-  \else%
-    \cref@gettype{#1}{\@tempa}%
-    \@ifundefined{Cref@\@tempa @name@plural}{%
-      \protect\G@refundefinedtrue%``
-      \nfss@text{\reset@font\bfseries ??}%
-      \@latex@warning{Reference name for label type `\@tempa' undefined}%
-    }{\csname Cref@\@tempa @name@plural\endcsname}%
-  \fi}
+  \@setnamecref{Cref}{#1}{@plural}{}}%
 \DeclareRobustCommand{\lcnamecrefs}[1]{%
-  \expandafter\ifx\csname r@cref@#1\endcsname\relax%
+  \@setnamecref{Cref}{#1}{@plural}{\MakeLowercase}}%
+\def\@setnamecref#1#2#3#4{%
+  \expandafter\ifx\csname r@#2@cref\endcsname\relax%
     \protect\G@refundefinedtrue%
     \nfss@text{\reset@font\bfseries ??}%
     \@latex@warning{Reference `#1' on page \thepage \space undefined}%
   \else%
-    \cref@gettype{#1}{\@tempa}%
-    \@ifundefined{cref@\@tempa @name@plural}{%
-      \protect\G@refundefinedtrue%``
+    \cref@gettype{#2}{\@tempa}%
+    \@ifundefined{#1@\@tempa @name#3}{%
+      \protect\G@refundefinedtrue%
       \nfss@text{\reset@font\bfseries ??}%
-      \@latex@warning{Reference name for label type `\@tempa' undefined}%
-    }{\expandafter\expandafter\expandafter%
-      \MakeLowercase\csname cref@\@tempa @name@plural\endcsname}%
-  \fi}
-\cref@stack@init{\cref@label@types}
-\newcommand{\crefdefaultlabelformat}[1]{%
-  \def\cref@default@label##1##2##3{#1}}
-\newcommand{\crefname}[3]{%
-  \@crefname{cref}{#1}{#2}{#3}{}}
-\newcommand{\Crefname}[3]{%
-  \@crefname{Cref}{#1}{#2}{#3}{}}
-\newcommand{\creflabelformat}[2]{%
+      \@latex@warning{Reference name forlabel type `\@tempa' undefined}%
+    }{%
+      \edef\@tempa{%
+        \expandafter\noexpand\csname #1@\@tempa @name#3\endcsname}%
+      \expandafter\@@setnamecref\expandafter{\@tempa}{#4}%
+    }%
+  \fi}%
+\def\@@setnamecref#1#2{%
+  \expandafter\def\expandafter\@tempa\expandafter{#1}%
+  \expandafter#2\@tempa}%
+\DeclareRobustCommand{\cpageref}[1]{%
+  \@cpageref{cref}{#1}{\@setcpageref}{\@setcpagerefrange}}%
+\DeclareRobustCommand{\Cpageref}[1]{%
+  \@cpageref{Cref}{#1}{\@setcpageref}{\@setcpagerefrange}}%
+\DeclareRobustCommand{\cpagerefrange}[2]{%
+  \@setcpagerefrange{#1}{#2}{cref}{}}%
+\DeclareRobustCommand{\Cpagerefrange}[2]{%
+  \@setcpagerefrange{#1}{#2}{Cref}{}}%
+\DeclareRobustCommand{\labelcpageref}[1]{%
+  \@cpageref{labelcref}{#1}{\@setcpageref}{\@setcpagerefrange}}%
+\def\@cpageref#1#2#3#4{%
+  \leavevmode%
+  \begingroup%
+  \countdef\count@consecutive=0%
+  \countdef\count@group=1%
+  \countdef\@counta=2%
+  \countdef\@countb=3%
+  \count@group=0%
+  \cref@stack@init{\@refstack}%
+  \edef\@tempa{#2}%
+  \expandafter\cref@stack@push\expandafter{\@tempa}{\@refstack}%
+  \if@cref@sort%
+    \cref@stack@sort{\@refstack}{\cref@pagecmp}%
+  \fi%
+  \cref@isstackfull{\@refstack}%
+  \@whilesw\if@cref@stackfull\fi{%
+    \if@cref@compress%
+      \cref@processconsecutive%
+        {\@refstack}{\@beginref}{\@endref}{\count@consecutive}%
+        {\cref@ispagerefconsecutive}%
+    \else%
+      \edef\@beginref{\cref@stack@top{\@refstack}}%
+      \cref@stack@pop{\@refstack}%
+      \@whilesw\ifx\@beginref\@empty\fi{%
+        \cref@stack@pop{\@refstack}%
+        \cref@isstackempty{\@refstack}%
+        \if@cref@stackempty%
+          \let\@beginref\relax%
+        \else%
+          \edef\@beginref{\cref@stack@top{\@refstack}}%
+        \fi}%
+      \let\@endref\relax%
+      \count@consecutive=1\relax%
+    \fi%
+    \ifx\@endref\relax\else%
+      \expandafter\ifx\csname r@\@beginref @cref\endcsname\relax\else%
+        \expandafter\ifx\csname r@\@endref @cref\endcsname\relax\else%
+          \cref@getpageref{\@beginref}{\@tempa}%
+          \cref@getpageref{\@endref}{\@tempb}%
+          \ifx\@tempa\@tempb\relax%
+            \count@consecutive=1%
+            \let\@endref\relax%
+          \else%
+            \@counta=\@tempa\relax%
+            \@countb=\@tempb\relax%
+            \advance\@counta 1\relax%
+            \ifnum\@counta=\@countb\relax%
+              \count@consecutive=2%
+            \fi%
+          \fi%
+        \fi%
+      \fi%
+    \fi%
+    \cref@isstackempty{\@refstack}%
+    \if@cref@stackempty%
+      \ifcase\count@group\relax%
+        \ifnum\count@consecutive=2\relax%
+          \def\@pos{@first}%
+        \else%
+          \def\@pos{}%
+        \fi%
+      \or%
+        \ifnum\count@consecutive=2\relax%
+          \def\@pos{@middle}%
+        \else%
+          \def\@pos{@second}%
+        \fi%
+      \else%
+        \def\@pos{@last}%
+      \fi%
+    \else%
+      \ifnum\count@group=0\relax%
+        \def\@pos{@first}%
+      \else%
+        \def\@pos{@middle}%
+      \fi%
+    \fi%
+    \ifnum\count@consecutive=1\relax%
+      \def\@tempa{#3}%
+      \edef\@tempb{{\@beginref}{#1}{\@pos}}%
+      \expandafter\@tempa\@tempb%
+    \else%
+      \ifnum\count@consecutive=2\relax%
+        \def\@tempa{#3}%
+        \edef\@tempb{{\@beginref}{#1}{\@pos}}%
+        \expandafter\@tempa\@tempb%
+        \expandafter\cref@stack@push\expandafter%
+          {\@endref,}{\@refstack}%
+      \else%
+        \def\@tempa{#4}%
+        \edef\@tempb{{\@beginref}{\@endref}{#1}{\@pos}}%
+        \expandafter\@tempa\@tempb%
+      \fi%
+    \fi%
+    \advance\count@group 1%
+    \cref@isstackfull{\@refstack}%
+  }% end loop over reference stack
+  \endgroup}%
+\def\@setcpageref#1#2#3{%
+  \expandafter\ifx\csname r@#1@cref\endcsname\relax%
+    \protect\G@refundefinedtrue%
+    \nfss@text{\reset@font\bfseries ??}%
+    \@latex@warning{Reference `#1' on page \thepage \space undefined}%
+  \else%
+    \cref@getpageref{#1}{\@temppage}%
+    \expandafter\ifx\csname #2@page@format#3\endcsname\relax%
+      \edef\@tempa{#2}\def\@tempb{labelcref}%
+      \ifx\@tempa\@tempb\relax%
+        \expandafter\@@setcpageref\expandafter%
+          {\csname #2@default@format#3\endcsname}{#1}%
+      \else%
+        \protect\G@refundefinedtrue%
+        \nfss@text{\reset@font\bfseries ??}~\@temppage%
+        \@latex@warning{#2 \space reference format for
+          page references undefined}%
+      \fi%
+    \else%
+      \expandafter\@@setcpageref\expandafter%
+        {\csname #2@page@format#3\endcsname}{#1}%
+    \fi%
+  \fi}%
+\def\@@setcpageref#1#2{%
+  \cref@getpageref{#2}{\@temppage}#1{\@temppage}{}{}}%
+\def\@setcpagerefrange#1#2#3#4{%
+  \begingroup%
+    \expandafter\ifx\csname r@#1@cref\endcsname\relax%
+      \protect\G@refundefinedtrue%
+      \@latex@warning{Reference `#1' on page \thepage \space%
+        undefined}%
+      \expandafter\ifx\csname r@#2@cref\endcsname\relax%
+        \nfss@text{\reset@font\bfseries ??}--%
+        \nfss@text{\reset@font\bfseries ??}%
+        \@latex@warning{Reference `#2' on page \thepage \space%
+          undefined}%
+      \else%
+        \cref@getpageref{#2}{\@pageb}%
+        \nfss@text{\reset@font\bfseries ??}--\@pageb%
+      \fi%
+    \else%
+      \expandafter\ifx\csname r@#2@cref\endcsname\relax%
+        \protect\G@refundefinedtrue%
+        \cref@getpageref{#1}{\@pagea}%
+        \@pagea--\nfss@text{\reset@font\bfseries ??}%
+        \@latex@warning{Reference `#2' on page \thepage %
+          \space undefined}%
+      \else%
+        \cref@getpageref{#1}{\@pagea}%
+        \cref@getpageref{#2}{\@pageb}%
+        \edef\@format{\expandafter\noexpand%
+          \csname #3range@page@format#4\endcsname}%
+        \expandafter\ifx\@format\relax%
+          \edef\@tempa{#3}\def\@tempb{labelcref}%
+          \ifx\@tempa\@tempb\relax%
+            \expandafter\@@setcpagerefrange\expandafter%
+              {\csname #3range@default@format#4\endcsname}{#1}{#2}%
+          \else%
+            \protect\G@refundefinedtrue%
+            \nfss@text{\reset@font\bfseries ??}~\@pagea--\@pageb%
+            \@latex@warning{#3\space reference range format for page
+              references undefined}%
+          \fi%
+        \else%
+          \expandafter\@@setcpagerefrange\expandafter{\@format}{#1}{#2}%
+        \fi%
+      \fi%
+    \fi%
+  \endgroup}%
+\def\@@setcpagerefrange#1#2#3{%
+  \cref@getpageref{#2}{\@pagea}%
+  \cref@getpageref{#3}{\@pageb}%
+  #1{\@pagea}{\@pageb}{}{}{}{}}%
+\cref@stack@init{\cref@label@types}%
+\newcommand\crefdefaultlabelformat[1]{%
+  \def\cref@default@label##1##2##3{#1}}%
+\newcommand\crefname[3]{%
+  \@crefname{cref}{#1}{#2}{#3}{}}%
+\newcommand\Crefname[3]{%
+  \@crefname{Cref}{#1}{#2}{#3}{}}%
+\newcommand\creflabelformat[2]{%
   \expandafter\def\csname cref@#1@label\endcsname##1##2##3{#2}%
-  \cref@stack@add{#1}{\cref@label@types}}
-\newcommand{\crefrangelabelformat}[2]{%
+  \cref@stack@add{#1}{\cref@label@types}}%
+\newcommand\crefrangelabelformat[2]{%
   \expandafter\def\csname cref@#1@rangelabel\endcsname%
     ##1##2##3##4##5##6{#2}%
-  \cref@stack@add{#1}{\cref@label@types}}
-\newcommand{\crefalias}[2]{%
-  \expandafter\def\csname cref@#1@alias\endcsname{#2}}
-\newcommand{\crefname@preamble}[3]{%
-  \@crefname{cref}{#1}{#2}{#3}{@preamble}}
-\newcommand{\Crefname@preamble}[3]{%
-  \@crefname{Cref}{#1}{#2}{#3}{@preamble}}
+  \cref@stack@add{#1}{\cref@label@types}}%
+\newcommand\crefalias[2]{%
+  \expandafter\def\csname cref@#1@alias\endcsname{#2}}%
+\newcommand\crefname@preamble[3]{%
+  \@crefname{cref}{#1}{#2}{#3}{@preamble}}%
+\newcommand\Crefname@preamble[3]{%
+  \@crefname{Cref}{#1}{#2}{#3}{@preamble}}%
+\def\cref@othervariant#1#2#3{\cref@@othervariant#1\@nil#2#3}%
+\def\cref@@othervariant#1#2\@nil#3#4{%
+  \if#1c%
+    \def#3{C#2}%
+    \def#4{\MakeUppercase}%
+  \else%
+    \def#3{c#2}%
+    \if@cref@capitalise%
+      \def#4{}%
+    \else%
+      \def#4{\MakeLowercase}%
+    \fi%
+  \fi}%
 \def\@crefname#1#2#3#4#5{%
   \expandafter\def\csname #1@#2@name#5\endcsname{#3}%
   \expandafter\def\csname #1@#2@name@plural#5\endcsname{#4}%
-  \def\@tempa##1##2\@nil{%
-    \if##1c%
-      \def\@other{C##2}%
-      \def\@tempc{\expandafter\MakeUppercase}%
-    \else%
-      \def\@other{c##2}%
-      \if@cref@capitalise%
-        \def\@tempc{}%
-      \else%
-        \def\@tempc{\MakeLowercase}%
-      \fi%
-    \fi}%
-  \@tempa#1\@nil%
-  \@ifundefined{\@other @#2@name#5}{%
+  \cref@othervariant{#1}{\@tempc}{\@tempd}%
+  \@ifundefined{\@tempc @#2@name#5}{%
     \expandafter\expandafter\expandafter\def%
     \expandafter\expandafter\expandafter\@tempa%
     \expandafter\expandafter\expandafter{%
@@ -1459,21 +1449,21 @@
       \expandafter\expandafter\expandafter\def%
       \expandafter\expandafter\expandafter\@tempa%
       \expandafter\expandafter\expandafter{%
-        \expandafter\@tempc\@tempa}%
+        \expandafter\@tempd\@tempa}%
       \expandafter\expandafter\expandafter\def%
       \expandafter\expandafter\expandafter\@tempb%
       \expandafter\expandafter\expandafter{%
-        \expandafter\@tempc\@tempb}%
+        \expandafter\@tempd\@tempb}%
     \fi%
     \toksdef\@toksa=0%
     \@toksa={%
-      \expandafter\def\csname\@other @#2@name#5\endcsname}%
+      \expandafter\def\csname\@tempc @#2@name#5\endcsname}%
     \expandafter\the\expandafter\@toksa\expandafter{\@tempa}%
     \@toksa={%
-      \expandafter\def\csname\@other @#2@name@plural#5\endcsname}%
+      \expandafter\def\csname\@tempc @#2@name@plural#5\endcsname}%
     \expandafter\the\expandafter\@toksa\expandafter{\@tempb}%
   }{}%
-  \cref@stack@add{#2}{\cref@label@types}}
+  \cref@stack@add{#2}{\cref@label@types}}%
 \def\@crefconstructcomponents#1{%
   \@ifundefined{cref@#1@label}{%
     \let\@templabel\cref@default@label%
@@ -1498,38 +1488,85 @@
     \expandafter\let\expandafter\@temprangelabel%
     \csname cref@#1@rangelabel\endcsname%
   }%
+  \if@cref@nameinlink%
+    \expandafter\def\expandafter\@templabel@first\expandafter{%
+      \@templabel{########1}{}{########3}}%
+    \expandafter\def\expandafter\@temprangelabel@first\expandafter{%
+      \@temprangelabel{########1}{########2}%
+        {}{########4}{########5}{########6}}%
+  \fi%
   \expandafter\def\expandafter\@templabel\expandafter{%
     \@templabel{########1}{########2}{########3}}%
   \expandafter\def\expandafter\@temprangelabel\expandafter{%
     \@temprangelabel{########1}{########2}{########3}%
     {########4}{########5}{########6}}%
-  \expandafter\def\expandafter\@tempname\expandafter{%
-    \csname cref@#1@name\endcsname}%
-  \expandafter\def\expandafter\@tempName\expandafter{%
-    \csname Cref@#1@name\endcsname}%
-  \expandafter\def\expandafter\@tempnameplural\expandafter{%
-    \csname cref@#1@name@plural\endcsname}%
-  \expandafter\def\expandafter\@tempNameplural\expandafter{%
-    \csname Cref@#1@name@plural\endcsname}%
-}
+  \if@cref@nameinlink\else%
+    \let\@templabel@first\@templabel%
+    \let\@temprangelabel@first\@temprangelabel%
+  \fi%
+  \if@cref@nameinlink%
+    \def\@tempa##1##2{##2##1}%
+    \expandafter\expandafter\expandafter\def%
+    \expandafter\expandafter\expandafter\@tempname%
+    \expandafter\expandafter\expandafter{%
+      \expandafter\@tempa\expandafter%
+        {\csname cref@#1@name\endcsname}{########2}}%
+    \expandafter\expandafter\expandafter\def%
+    \expandafter\expandafter\expandafter\@tempName%
+    \expandafter\expandafter\expandafter{%
+      \expandafter\@tempa\expandafter%
+        {\csname Cref@#1@name\endcsname}{########2}}%
+    \expandafter\expandafter\expandafter\def%
+    \expandafter\expandafter\expandafter\@tempnameplural%
+    \expandafter\expandafter\expandafter{%
+      \expandafter\@tempa\expandafter%
+        {\csname cref@#1@name@plural\endcsname}{########2}}%
+    \expandafter\expandafter\expandafter\def%
+    \expandafter\expandafter\expandafter\@tempNameplural%
+    \expandafter\expandafter\expandafter{%
+      \expandafter\@tempa\expandafter%
+        {\csname Cref@#1@name@plural\endcsname}{########2}}%
+    \expandafter\expandafter\expandafter\def%
+    \expandafter\expandafter\expandafter\@tempnameplural@range%
+    \expandafter\expandafter\expandafter{%
+      \expandafter\@tempa\expandafter%
+        {\csname cref@#1@name@plural\endcsname}{########3}}%
+    \expandafter\expandafter\expandafter\def%
+    \expandafter\expandafter\expandafter\@tempNameplural@range%
+    \expandafter\expandafter\expandafter{%
+      \expandafter\@tempa\expandafter%
+        {\csname Cref@#1@name@plural\endcsname}{########3}}%
+  \else%
+    \expandafter\def\expandafter\@tempname\expandafter{%
+      \csname cref@#1@name\endcsname}%
+    \expandafter\def\expandafter\@tempName\expandafter{%
+      \csname Cref@#1@name\endcsname}%
+    \expandafter\def\expandafter\@tempnameplural\expandafter{%
+      \csname cref@#1@name@plural\endcsname}%
+    \expandafter\def\expandafter\@tempNameplural\expandafter{%
+      \csname Cref@#1@name@plural\endcsname}%
+    \let\@tempnameplural@range\@tempnameplural%
+    \let\@tempNameplural@range\@tempNameplural%
+  \fi%
+}%
 \def\@crefdefineformat#1{%
   \begingroup%
     \@crefconstructcomponents{#1}%
-    \expandafter\ifx\@tempname\@empty\relax%
+    \expandafter\ifx\csname cref@#1@name\endcsname\@empty\relax%
       \expandafter\def\expandafter\@tempfirst\expandafter{\@templabel}%
     \else%
       \expandafter\expandafter\expandafter\def%
       \expandafter\expandafter\expandafter\@tempfirst%
       \expandafter\expandafter\expandafter{%
-        \expandafter\@tempname\expandafter\nobreakspace\@templabel}%
+        \expandafter\@tempname\expandafter\nobreakspace\@templabel@first}%
     \fi%
-    \expandafter\ifx\@tempName\@empty\relax%
+    \expandafter\ifx\csname Cref@#1@name\endcsname\@empty\relax%
       \expandafter\def\expandafter\@tempFirst\expandafter{\@templabel}%
     \else%
       \expandafter\expandafter\expandafter\def%
       \expandafter\expandafter\expandafter\@tempFirst%
       \expandafter\expandafter\expandafter{%
-        \expandafter\@tempName\expandafter\nobreakspace\@templabel}%
+        \expandafter\@tempName\expandafter\nobreakspace\@templabel@first}%
     \fi%
     \expandafter\def\expandafter\@templabel\expandafter{\@templabel}%
     \toksdef\@toksa=0%
@@ -1540,27 +1577,29 @@
     \@ifundefined{cref@#1@label}{}{%
       \@toksa={\labelcrefformat{#1}}%
       \expandafter\the\expandafter\@toksa\expandafter{\@templabel}}%
-  \endgroup}
+  \endgroup}%
 \def\@crefrangedefineformat#1{%
   \begingroup%
     \@crefconstructcomponents{#1}%
-    \expandafter\ifx\@tempname\@empty\relax%
+    \expandafter\ifx\csname cref@#1@name\endcsname\@empty\relax%
       \expandafter\def\expandafter\@tempfirst%
         \expandafter{\@temprangelabel}%
     \else%
       \expandafter\expandafter\expandafter\def%
       \expandafter\expandafter\expandafter\@tempfirst%
       \expandafter\expandafter\expandafter{%
-        \expandafter\@tempnameplural\expandafter\nobreakspace\@temprangelabel}%
+        \expandafter\@tempnameplural@range%
+        \expandafter\nobreakspace\@temprangelabel@first}%
     \fi%
-    \expandafter\ifx\@tempName\@empty\relax%
+    \expandafter\ifx\csname Cref@#1@name\endcsname\@empty\relax%
       \expandafter\def\expandafter\@tempFirst%
         \expandafter{\@temprangelabel}%
     \else%
       \expandafter\expandafter\expandafter\def%
       \expandafter\expandafter\expandafter\@tempFirst%
       \expandafter\expandafter\expandafter{%
-        \expandafter\@tempNameplural\expandafter\nobreakspace\@temprangelabel}%
+        \expandafter\@tempNameplural@range%
+        \expandafter\nobreakspace\@temprangelabel@first}%
     \fi%
     \expandafter\def\expandafter\@temprangelabel%
       \expandafter{\@temprangelabel}%
@@ -1571,33 +1610,35 @@
     \expandafter\the\expandafter\@toksa\expandafter{\@tempFirst}%
     \@ifundefined{cref@#1@rangelabel}{%
       \@ifundefined{cref@#1@label}{\let\@tempa\relax}{\def\@tempa{}}}%
-        {\def\@tempa{}}%
+      {\def\@tempa{}}%
     \ifx\@tempa\@empty\relax%
       \@toksa={\labelcrefrangeformat{#1}}%
       \expandafter\the\expandafter\@toksa\expandafter{%
         \@temprangelabel}%
     \fi%
-  \endgroup}
+  \endgroup}%
 \def\@crefdefinemultiformat#1{%
   \begingroup%
     \@crefconstructcomponents{#1}%
-    \expandafter\ifx\@tempnameplural\@empty\relax%
+    \expandafter\ifx\csname cref@#1@name@plural\endcsname\@empty\relax%
       \expandafter\def\expandafter\@tempfirst%
         \expandafter{\@templabel}%
     \else%
       \expandafter\expandafter\expandafter\def%
       \expandafter\expandafter\expandafter\@tempfirst%
       \expandafter\expandafter\expandafter{%
-        \expandafter\@tempnameplural\expandafter\nobreakspace\@templabel}%
+        \expandafter\@tempnameplural%
+        \expandafter\nobreakspace\@templabel@first}%
     \fi%
-    \expandafter\ifx\@tempNameplural\@empty\relax%
+    \expandafter\ifx\csname Cref@#1@name@plural\endcsname\@empty\relax%
       \expandafter\def\expandafter\@tempFirst%
         \expandafter{\@templabel}%
     \else%
       \expandafter\expandafter\expandafter\def%
       \expandafter\expandafter\expandafter\@tempFirst%
       \expandafter\expandafter\expandafter{%
-        \expandafter\@tempNameplural\expandafter\nobreakspace\@templabel}%
+        \expandafter\@tempNameplural%
+        \expandafter\nobreakspace\@templabel@first}%
     \fi%
     \expandafter\def\expandafter\@tempsecond\expandafter{%
       \expandafter\crefpairconjunction\@templabel}%
@@ -1642,27 +1683,29 @@
         \expandafter{\@templast}}%
       \@toksa={\labelcrefmultiformat{#1}}%
       \expandafter\the\expandafter\@toksa\the\@toksb}%
-  \endgroup}
+  \endgroup}%
 \def\@crefrangedefinemultiformat#1{%
   \begingroup%
     \@crefconstructcomponents{#1}%
-    \expandafter\ifx\@tempnameplural\@empty\relax%
+    \expandafter\ifx\csname cref@#1@name@plural\endcsname\@empty\relax%
       \expandafter\def\expandafter\@tempfirst%
         \expandafter{\@temprangelabel}%
     \else%
       \expandafter\expandafter\expandafter\def%
       \expandafter\expandafter\expandafter\@tempfirst%
       \expandafter\expandafter\expandafter{%
-        \expandafter\@tempnameplural\expandafter\nobreakspace\@temprangelabel}%
+        \expandafter\@tempnameplural@range%
+        \expandafter\nobreakspace\@temprangelabel@first}%
     \fi%
-    \expandafter\ifx\@tempNameplural\@empty\relax%
+    \expandafter\ifx\csname Cref@#1@name@plural\endcsname\@empty\relax%
       \expandafter\def\expandafter\@tempFirst%
         \expandafter{\@temprangelabel}%
     \else%
       \expandafter\expandafter\expandafter\def%
       \expandafter\expandafter\expandafter\@tempFirst%
       \expandafter\expandafter\expandafter{%
-        \expandafter\@tempNameplural\expandafter\nobreakspace\@temprangelabel}%
+        \expandafter\@tempNameplural@range%
+        \expandafter\nobreakspace\@temprangelabel@first}%
     \fi%
     \expandafter\def\expandafter\@tempsecond\expandafter{%
       \expandafter\crefpairconjunction\@temprangelabel}%
@@ -1712,7 +1755,7 @@
       \@toksa={\labelcrefrangemultiformat{#1}}%
       \expandafter\the\expandafter\@toksa\the\@toksb%
     \fi%
-  \endgroup}
+  \endgroup}%
 \def\@labelcrefdefinedefaultformats{%
   \begingroup%
     \toksdef\@toksa=0%
@@ -1768,37 +1811,37 @@
     \expandafter\cref@append@toks\expandafter\@toksb\expandafter{%
       \expandafter{\@temprangelabel}}%
     \expandafter\cref@append@toks\expandafter\@toksb\expandafter{%
-      \expandafter{\@tempsecond}}%
+      \expandafter{\@temprangesecond}}%
     \expandafter\cref@append@toks\expandafter\@toksb\expandafter{%
-      \expandafter{\@tempmiddle}}%
+      \expandafter{\@temprangemiddle}}%
     \expandafter\cref@append@toks\expandafter\@toksb\expandafter{%
-      \expandafter{\@templast}}%
+      \expandafter{\@temprangelast}}%
     \@toksa={\labelcrefrangemultiformat{default}}%
     \expandafter\the\expandafter\@toksa\the\@toksb%
-  \endgroup}
+  \endgroup}%
 \def\@crefdefineallformats#1{%
   \@crefdefineformat{#1}%
   \@crefrangedefineformat{#1}%
   \@crefdefinemultiformat{#1}%
-  \@crefrangedefinemultiformat{#1}}
-\newcommand{\crefformat}[2]{\@crefformat{cref}{#1}{#2}}
-\newcommand{\Crefformat}[2]{\@crefformat{Cref}{#1}{#2}}
-\newcommand{\crefrangeformat}[2]{\@crefrangeformat{crefrange}{#1}{#2}}
-\newcommand{\Crefrangeformat}[2]{\@crefrangeformat{Crefrange}{#1}{#2}}
-\newcommand{\crefmultiformat}[5]{%
-  \@crefmultiformat{cref}{#1}{#2}{#3}{#4}{#5}}
-\newcommand{\Crefmultiformat}[5]{%
-  \@crefmultiformat{Cref}{#1}{#2}{#3}{#4}{#5}}
-\newcommand{\crefrangemultiformat}[5]{%
-  \@crefrangemultiformat{crefrange}{#1}{#2}{#3}{#4}{#5}}
-\newcommand{\Crefrangemultiformat}[5]{%
-  \@crefrangemultiformat{Crefrange}{#1}{#2}{#3}{#4}{#5}}
-\newcommand{\labelcrefformat}[2]{%
-  \expandafter\gdef\csname labelcref@#1@format\endcsname##1##2##3{#2}}
-\newcommand{\labelcrefrangeformat}[2]{%
+  \@crefrangedefinemultiformat{#1}}%
+\newcommand\crefformat[2]{\@crefformat{cref}{#1}{#2}}%
+\newcommand\Crefformat[2]{\@crefformat{Cref}{#1}{#2}}%
+\newcommand\crefrangeformat[2]{\@crefrangeformat{crefrange}{#1}{#2}}%
+\newcommand\Crefrangeformat[2]{\@crefrangeformat{Crefrange}{#1}{#2}}%
+\newcommand\crefmultiformat[5]{%
+  \@crefmultiformat{cref}{#1}{#2}{#3}{#4}{#5}}%
+\newcommand\Crefmultiformat[5]{%
+  \@crefmultiformat{Cref}{#1}{#2}{#3}{#4}{#5}}%
+\newcommand\crefrangemultiformat[5]{%
+  \@crefrangemultiformat{crefrange}{#1}{#2}{#3}{#4}{#5}}%
+\newcommand\Crefrangemultiformat[5]{%
+  \@crefrangemultiformat{Crefrange}{#1}{#2}{#3}{#4}{#5}}%
+\newcommand\labelcrefformat[2]{%
+  \expandafter\gdef\csname labelcref@#1@format\endcsname##1##2##3{#2}}%
+\newcommand\labelcrefrangeformat[2]{%
   \expandafter\gdef\csname labelcrefrange@#1@format\endcsname%
-  ##1##2##3##4##5##6{#2}}
-\newcommand{\labelcrefmultiformat}[5]{%
+  ##1##2##3##4##5##6{#2}}%
+\newcommand\labelcrefmultiformat[5]{%
   \expandafter\gdef\csname labelcref@#1@format@first\endcsname%
     ##1##2##3{#2}%
   \expandafter\gdef\csname labelcref@#1@format@second\endcsname%
@@ -1806,8 +1849,8 @@
   \expandafter\gdef\csname labelcref@#1@format@middle\endcsname%
     ##1##2##3{#4}%
   \expandafter\gdef\csname labelcref@#1@format@last\endcsname%
-    ##1##2##3{#5}}
-\newcommand{\labelcrefrangemultiformat}[5]{%
+    ##1##2##3{#5}}%
+\newcommand\labelcrefrangemultiformat[5]{%
   \expandafter\gdef\csname labelcrefrange@#1@format@first\endcsname%
     ##1##2##3##4##5##6{#2}%
   \expandafter\gdef\csname labelcrefrange@#1@format@second\endcsname%
@@ -1815,23 +1858,11 @@
   \expandafter\gdef\csname labelcrefrange@#1@format@middle\endcsname%
     ##1##2##3##4##5##6{#4}%
   \expandafter\gdef\csname labelcrefrange@#1@format@last\endcsname%
-    ##1##2##3##4##5##6{#5}}
+    ##1##2##3##4##5##6{#5}}%
 \def\@crefformat#1#2#3{%
   \begingroup%
     \expandafter\gdef\csname #1@#2@format\endcsname##1##2##3{#3}%
-    \def\@tempa##1##2\@nil{%
-      \if##1c%
-        \def\@other{C##2}%
-        \def\@changecase{\expandafter\MakeUppercase}%
-      \else%
-        \def\@other{c##2}%
-        \if@cref@capitalise%
-          \def\@changecase{}%
-        \else%
-          \def\@changecase{\MakeLowercase}%
-        \fi%
-      \fi}%
-    \@tempa#1\@nil%
+    \cref@othervariant{#1}{\@other}{\@changecase}%
     \@ifundefined{\@other @#2@format}{%
       \toksdef\@toksa=0%
       \@toksa={\def\@tempa##1##2##3}%
@@ -1848,24 +1879,12 @@
       \expandafter\the\expandafter\@toksa\expandafter{%
         \@tempa{##1}{##2}{##3}}%
     }{}%
-  \endgroup}
+  \endgroup}%
 \def\@crefrangeformat#1#2#3{%
   \begingroup%
     \expandafter\gdef\csname #1@#2@format\endcsname%
       ##1##2##3##4##5##6{#3}%
-    \def\@tempa##1##2\@nil{%
-      \if##1c%
-        \def\@other{C##2}%
-        \def\@changecase{\expandafter\MakeUppercase}%
-      \else%
-        \def\@other{c##2}%
-        \if@cref@capitalise%
-          \def\@changecase{}%
-        \else%
-          \def\@changecase{\MakeLowercase}%
-        \fi%
-      \fi}%
-    \@tempa#1\@nil%
+    \cref@othervariant{#1}{\@other}{\@changecase}%
     \@ifundefined{\@other @#2@format}{%
       \toksdef\@toksa=0%
       \@toksa={\def\@tempa##1##2##3##4##5##6}%
@@ -1882,26 +1901,14 @@
       \expandafter\the\expandafter\@toksa\expandafter{%
         \@tempa{##1}{##2}{##3}{##4}{##5}{##6}}%
     }{}%
-  \endgroup}
+  \endgroup}%
 \def\@crefmultiformat#1#2#3#4#5#6{%
   \begingroup%
     \expandafter\gdef\csname #1@#2@format@first\endcsname##1##2##3{#3}%
     \expandafter\gdef\csname #1@#2@format@second\endcsname##1##2##3{#4}%
     \expandafter\gdef\csname #1@#2@format@middle\endcsname##1##2##3{#5}%
     \expandafter\gdef\csname #1@#2@format@last\endcsname##1##2##3{#6}%
-    \def\@tempa##1##2\@nil{%
-      \if##1c%
-        \def\@other{C##2}%
-        \def\@changecase{\expandafter\MakeUppercase}%
-      \else%
-        \def\@other{c##2}%
-        \if@cref@capitalise%
-          \def\@changecase{}%
-        \else%
-          \def\@changecase{\MakeLowercase}%
-        \fi%
-      \fi}%
-    \@tempa#1\@nil%
+    \cref@othervariant{#1}{\@other}{\@changecase}%
     \@ifundefined{\@other @#2@format@first}{%
       \toksdef\@toksa=0%
       \@toksa={\def\@tempa##1##2##3}%
@@ -1940,7 +1947,7 @@
       \expandafter\the\expandafter\@toksa%
         \csname #1@#2@format@last\endcsname%
     }{}%
-  \endgroup}
+  \endgroup}%
 \def\@crefrangemultiformat#1#2#3#4#5#6{%
   \begingroup%
     \expandafter\gdef\csname #1@#2@format@first\endcsname%
@@ -1951,19 +1958,7 @@
       ##1##2##3##4##5##6{#5}%
     \expandafter\gdef\csname #1@#2@format@last\endcsname%
       ##1##2##3##4##5##6{#6}%
-    \def\@tempa##1##2\@nil{%
-      \if##1c%
-        \def\@other{C##2}%
-        \def\@changecase{\expandafter\MakeUppercase}%
-      \else%
-        \def\@other{c##2}%
-        \if@cref@capitalise%
-          \def\@changecase{}%
-        \else%
-          \def\@changecase{\MakeLowercase}%
-        \fi%
-      \fi}%
-    \@tempa#1\@nil%
+    \cref@othervariant{#1}{\@other}{\@changecase}%
     \@ifundefined{\@other @#2@format@first}{%
       \toksdef\@toksa=0%
       \@toksa={\def\@tempa##1##2##3##4##5##6}%
@@ -2003,165 +1998,871 @@
       \expandafter\the\expandafter\@toksa%
         \csname #1@#2@format@last\endcsname%
     }{}%
-  \endgroup}
-\let\if@cref@hyperrefloaded\iffalse
+  \endgroup}%
+\let\if@cref@hyperrefloaded\iffalse%
 \@ifpackageloaded{hyperref}{%
-  \@ifpackagewith{hyperref}{implicit=false}{%
-    \let\if@cref@hyperrefloaded\iffalse%
-  }{%
+  \@ifpackagewith{hyperref}{implicit=false}{}{%
     \let\if@cref@hyperrefloaded\iftrue%
-    \PackageInfo{cleveref}{`hyperref' support loaded}
-    \def\cref@hyperref#1{\expandafter\expandafter\expandafter%
-      \@fourthoffive\csname r@#1\endcsname}
-    \let\cref@old@H@refstepcounter\H@refstepcounter
+    \PackageInfo{cleveref}{`hyperref' support loaded}%
+    \def\cref@hyperlinkname#1{\expandafter\expandafter\expandafter%
+      \@fourthoffive\csname r@#1\endcsname}%
+    \def\cref@hyperlinkurl#1{\expandafter\expandafter\expandafter%
+      \@fifthoffive\csname r@#1\endcsname}%
+    \def\cref@hyperlink#1#2#3\@nil{\hyper@@link[link]{#1}{#2}{#3}}
+    \let\cref@old@H@refstepcounter\H@refstepcounter%
     \def\H@refstepcounter#1{%
       \cref@old@H@refstepcounter{#1}%
       \cref@constructprefix{#1}{\cref@result}%
       \@ifundefined{cref@#1@alias}%
         {\def\@tempa{#1}}%
         {\def\@tempa{\csname cref@#1@alias\endcsname}}%
-      \protected@xdef\cref@currentlabel{%
+      \protected@edef\cref@currentlabel{%
         [\@tempa][\arabic{#1}][\cref@result]%
-        \csname p@#1\endcsname\csname the#1\endcsname}}
+        \csname p@#1\endcsname\csname the#1\endcsname}}%
     \let\refstepcounter@noarg\cref@old@refstepcounter%
     \def\refstepcounter@optarg[#1]#2{%
       \cref@old@refstepcounter{#2}%
-      \protected@xdef\cref@currentlabel{%
+      \protected@edef\cref@currentlabel{%
         \expandafter\cref@override@label@type%
-          \cref@currentlabel\@nil{#1}}}
-    \renewcommand\appendix{%
-      \cref@old@appendix%
-      \@ifundefined{chapter}{%
-        \def\H@refstepcounter##1{%
-          \cref@old@H@refstepcounter{##1}%
-          \cref@constructprefix{##1}{\cref@result}%
-          \ifx\cref@result\@empty%
-            \def\cref@result{2147483647}%
-          \else%
-            \edef\cref@result{2147483647,\cref@result}%
-          \fi%
-          \def\@tempa{##1}%
-          \def\@tempb{section}%
-          \ifx\@tempa\@tempb%
-            \protected@xdef\cref@currentlabel{%
-              [appendix][\arabic{##1}][\cref@result]%
-              \csname p@##1\endcsname\csname the##1\endcsname}%
-          \else%
-            \def\@tempa{##1}%
-            \def\@tempb{subsection}%
-            \ifx\@tempa\@tempb%
-              \protected@xdef\cref@currentlabel{%
-                [subappendix][\arabic{##1}][\cref@result]%
-                \csname p@##1\endcsname\csname the##1\endcsname}%
+          \cref@currentlabel\@nil{#1}}}%
+    \@ifundefined{appendix}{}{%
+      \g@addto@macro\appendix{%
+        \@ifundefined{chapter}{%
+          \def\H@refstepcounter#1{%
+            \cref@old@H@refstepcounter{#1}%
+            \cref@constructprefix{#1}{\cref@result}%
+            \ifx\cref@result\@empty%
+              \def\cref@result{2147483647}%
             \else%
-              \def\@tempa{##1}%
-              \def\@tempb{subsubsection}%
-              \ifx\@tempa\@tempb%
-                \protected@xdef\cref@currentlabel{%
-                  [subsubappendix][\arabic{##1}][\cref@result]%
-                  \csname p@##1\endcsname\csname the##1\endcsname}%
-              \else%
-                \@ifundefined{cref@##1@alias}%
-                  {\def\@tempa{##1}}%
-                  {\def\@tempa{\csname cref@##1@alias\endcsname}}%
-                \protected@xdef\cref@currentlabel{%
-                  [\@tempa][\arabic{##1}][\cref@result]%
-                  \csname p@##1\endcsname\csname the##1\endcsname}
-              \fi%
+              \edef\cref@result{2147483647,\cref@result}%
             \fi%
-          \fi}%
-      }{%
-        \def\H@refstepcounter##1{%
-          \cref@old@H@refstepcounter{##1}%
-          \cref@constructprefix{##1}{\cref@result}%
-          \ifx\cref@result\@empty%
-            \def\cref@result{2147483647}%
-          \else%
-            \edef\cref@result{2147483647,\cref@result}%
-          \fi%
-          \def\@tempa{##1}%
-          \def\@tempb{chapter}%
-          \ifx\@tempa\@tempb%
-            \protected@xdef\cref@currentlabel{%
-              [appendix][\arabic{##1}][\cref@result]%
-              \csname p@##1\endcsname\csname the##1\endcsname}%
-          \else%
-            \def\@tempa{##1}%
+            \def\@tempa{#1}%
             \def\@tempb{section}%
             \ifx\@tempa\@tempb%
-              \protected@xdef\cref@currentlabel{%
-                [subappendix][\arabic{##1}][\cref@result]%
-                \csname p@##1\endcsname\csname the##1\endcsname}%
+              \protected@edef\cref@currentlabel{%
+                [appendix][\arabic{#1}][\cref@result]%
+                \csname p@#1\endcsname\csname the#1\endcsname}%
             \else%
-              \def\@tempa{##1}%
+              \def\@tempa{#1}%
               \def\@tempb{subsection}%
               \ifx\@tempa\@tempb%
-                \protected@xdef\cref@currentlabel{%
-                  [subsubappendix][\arabic{##1}][\cref@result]%
-                  \csname p@##1\endcsname\csname the##1\endcsname}%
+                \protected@edef\cref@currentlabel{%
+                  [subappendix][\arabic{#1}][\cref@result]%
+                  \csname p@#1\endcsname\csname the#1\endcsname}%
               \else%
-                \def\@tempa{##1}%
+                \def\@tempa{#1}%
                 \def\@tempb{subsubsection}%
                 \ifx\@tempa\@tempb%
-                  \protected@xdef\cref@currentlabel{%
-                    [subsubsubappendix][\arabic{##1}][\cref@result]%
-                    \csname p@##1\endcsname\csname the##1\endcsname}%
+                  \protected@edef\cref@currentlabel{%
+                    [subsubappendix][\arabic{#1}][\cref@result]%
+                    \csname p@#1\endcsname\csname the#1\endcsname}%
                 \else%
-                  \@ifundefined{cref@##1@alias}%
-                    {\def\@tempa{##1}}%
-                    {\def\@tempa{\csname cref@##1@alias\endcsname}}%
-                  \protected@xdef\cref@currentlabel{%
-                    [\@tempa][\arabic{##1}][\cref@result]%
-                    \csname p@##1\endcsname\csname the##1\endcsname}
+                  \@ifundefined{cref@#1@alias}%
+                    {\def\@tempa{#1}}%
+                    {\def\@tempa{\csname cref@#1@alias\endcsname}}%
+                  \protected@edef\cref@currentlabel{%
+                    [\@tempa][\arabic{#1}][\cref@result]%
+                    \csname p@#1\endcsname\csname the#1\endcsname}%
                 \fi%
               \fi%
+            \fi}%
+        }{%
+          \def\H@refstepcounter#1{%
+            \cref@old@H@refstepcounter{#1}%
+            \cref@constructprefix{#1}{\cref@result}%
+            \ifx\cref@result\@empty%
+              \def\cref@result{2147483647}%
+            \else%
+              \edef\cref@result{2147483647,\cref@result}%
             \fi%
-          \fi}%
+            \def\@tempa{#1}%
+            \def\@tempb{chapter}%
+            \ifx\@tempa\@tempb%
+              \protected@edef\cref@currentlabel{%
+                [appendix][\arabic{#1}][\cref@result]%
+                \csname p@#1\endcsname\csname the#1\endcsname}%
+            \else%
+              \def\@tempa{#1}%
+              \def\@tempb{section}%
+              \ifx\@tempa\@tempb%
+                \protected@edef\cref@currentlabel{%
+                  [subappendix][\arabic{#1}][\cref@result]%
+                  \csname p@#1\endcsname\csname the#1\endcsname}%
+              \else%
+                \def\@tempa{#1}%
+                \def\@tempb{subsection}%
+                \ifx\@tempa\@tempb%
+                  \protected@edef\cref@currentlabel{%
+                    [subsubappendix][\arabic{#1}][\cref@result]%
+                    \csname p@#1\endcsname\csname the#1\endcsname}%
+                \else%
+                  \def\@tempa{#1}%
+                  \def\@tempb{subsubsection}%
+                  \ifx\@tempa\@tempb%
+                    \protected@edef\cref@currentlabel{%
+                      [subsubsubappendix][\arabic{#1}][\cref@result]%
+                      \csname p@#1\endcsname\csname the#1\endcsname}%
+                  \else%
+                    \@ifundefined{cref@#1@alias}%
+                      {\def\@tempa{#1}}%
+                      {\def\@tempa{\csname cref@#1@alias\endcsname}}%
+                    \protected@edef\cref@currentlabel{%
+                      [\@tempa][\arabic{#1}][\cref@result]%
+                      \csname p@#1\endcsname\csname the#1\endcsname}%
+                  \fi%
+                \fi%
+              \fi%
+            \fi}%
+        }%
       }%
-    }
+    }% end of \@ifundefined{appendix}
     \DeclareRobustCommand{\cref}{%
-      \@ifstar{\@crefstar{cref}}{\@crefnostar{cref}}}
+      \@ifstar{\@crefstar{cref}}{\@crefnostar{cref}}}%
     \DeclareRobustCommand{\Cref}{%
-      \@ifstar{\@crefstar{Cref}}{\@crefnostar{Cref}}}
-    \def\@crefnostar#1#2{\@cref{#1}{#2}}
+      \@ifstar{\@crefstar{Cref}}{\@crefnostar{Cref}}}%
+    \def\@crefnostar#1#2{\@cref{#1}{#2}}%
     \def\@crefstar#1#2{%
-      \@crefstarredtrue\@cref{#1}{#2}\@crefstarredfalse}
+      \@crefstarredtrue\@cref{#1}{#2}\@crefstarredfalse}%
     \DeclareRobustCommand{\crefrange}{%
-      \@ifstar{\@crefrangestar{cref}}{\@crefrangenostar{cref}}}
+      \@ifstar{\@crefrangestar{cref}}{\@crefrangenostar{cref}}}%
     \DeclareRobustCommand{\Crefrange}{%
-      \@ifstar{\@crefrangestar{Cref}}{\@crefrangenostar{Cref}}}
-    \def\@crefrangenostar#1#2#3{\@setcrefrange{#2}{#3}{#1}{}}
+      \@ifstar{\@crefrangestar{Cref}}{\@crefrangenostar{Cref}}}%
+    \def\@crefrangenostar#1#2#3{\@setcrefrange{#2}{#3}{#1}{}}%
     \def\@crefrangestar#1#2#3{%
-      \@crefstarredtrue\@setcrefrange{#2}{#3}{#1}{}\@crefstarredfalse}
+      \@crefstarredtrue\@setcrefrange{#2}{#3}{#1}{}\@crefstarredfalse}%
+    \DeclareRobustCommand{\cpageref}{%
+      \@ifstar{\@cpagerefstar{cref}}{\@cpagerefnostar{cref}}}%
+    \DeclareRobustCommand{\Cpageref}{%
+      \@ifstar{\@cpagerefstar{Cref}}{\@cpagerefnostar{Cref}}}%
+    \def\@cpagerefnostar#1#2{%
+      \@cpageref{#1}{#2}{\@setcpageref}{\@setcpagerefrange}}%
+    \def\@cpagerefstar#1#2{%
+      \@crefstarredtrue%
+      \@cpageref{#1}{#2}{\@setcpageref}{\@setcpagerefrange}%
+      \@crefstarredfalse}%
+    \DeclareRobustCommand{\cpagerefrange}{%
+      \@ifstar{\@cpagerefrangestar{cref}}{\@cpagerefrangenostar{cref}}}%
+    \DeclareRobustCommand{\Cpagerefrange}{%
+      \@ifstar{\@cpagerefrangestar{Cref}}{\@cpagerefrangenostar{Cref}}}%
+    \def\@cpagerefrangenostar#1#2#3{\@setcpagerefrange{#2}{#3}{#1}{}}%
+    \def\@cpagerefrangestar#1#2#3{%
+      \@crefstarredtrue%
+      \@setcpagerefrange{#2}{#3}{#1}{}%
+      \@crefstarredfalse}%
+    \DeclareRobustCommand{\labelcref}{%
+      \@ifstar{\@labelcrefstar}{\@labelcrefnostar}}%
+    \def\@labelcrefnostar#1{\@cref{labelcref}{#1}}%
+    \def\@labelcrefstar#1{%
+      \@crefstarredtrue%
+      \@cref{labelcref}{#1}%
+      \@crefstarredfalse}%
+    \DeclareRobustCommand{\labelcpageref}{%
+      \@ifstar{\@labelcpagerefstar}{\@labelcpagerefnostar}}%
+    \def\@labelcpagerefnostar#1{%
+      \@cpageref{labelcref}{#1}{\@setcpageref}{\@setcpagerefrange}}%
+    \def\@labelcpagerefstar#1{%
+      \@crefstarredtrue%
+      \@cpageref{labelcref}{#1}{\@setcpageref}{\@setcpagerefrange}%
+      \@crefstarredfalse}%
     \def\@@setcref#1#2{%
       \cref@getlabel{#2}{\@templabel}%
       \if@crefstarred%
         #1{\@templabel}{}{}%
       \else%
-        \edef\@templink{\cref@hyperref{#2}}%
-        #1{\@templabel}{\hyper@linkstart{link}{\@templink}}{\hyper@linkend}%
-      \fi}
+        \edef\@tempname{\cref@hyperlinkname{#2}}%
+        \edef\@tempurl{\cref@hyperlinkurl{#2}}%
+        #1{\@templabel}{\cref@hyperlink{\@tempurl}{\@tempname}}{\@nil}%
+      \fi}%
     \def\@@setcrefrange#1#2#3{%
       \cref@getlabel{#2}{\@labela}%
       \cref@getlabel{#3}{\@labelb}%
       \if@crefstarred%
         #1{\@labela}{\@labelb}{}{}{}{}%
       \else%
-        \edef\@linka{\cref@hyperref{#2}}%
-        \edef\@linkb{\cref@hyperref{#3}}%
+        \edef\@tempnamea{\cref@hyperlinkname{#2}}%
+        \edef\@tempurlb{\cref@hyperlinkurl{#3}}%
+        \edef\@tempnameb{\cref@hyperlinkname{#3}}%
+        \edef\@tempurla{\cref@hyperlinkurl{#2}}%
         #1{\@labela}{\@labelb}%
-          {\hyper@linkstart{link}{\@linka}}{\hyper@linkend}%
-          {\hyper@linkstart{link}{\@linkb}}{\hyper@linkend}%
+          {\cref@hyperlink{\@tempurla}{\@tempnamea}}{\@nil}%
+          {\cref@hyperlink{\@tempurlb}{\@tempnameb}}{\@nil}%
       \fi}%
-    }%  end of false case of \@ifpackagewith{hyperref}{implicit=false}
-  }{}%  end of \@ifpackageloaded{hyperref}
-  \@ifpackageloaded{ntheorem}{%
-  \PackageInfo{cleveref}{`ntheorem' support loaded}
+    \def\@@setcpageref#1#2{%
+      \cref@getpageref{#2}{\@temppage}%
+      \if@crefstarred%
+        #1{\@temppage}{}{}%
+      \else%
+        \edef\@tempname{\cref@hyperlinkname{#2}}%
+        \edef\@tempurl{\cref@hyperlinkurl{#2}}%
+        #1{\@temppage}{\cref@hyperlink{\@tempurl}{\@tempname}}{\@nil}%
+      \fi}%
+    \def\@@setcpagerefrange#1#2#3{%
+      \cref@getpageref{#2}{\@pagea}%
+      \cref@getpageref{#3}{\@pageb}%
+      \if@crefstarred%
+        #1{\@pagea}{\@pageb}{}{}{}{}%
+      \else%
+        \edef\@tempnamea{\cref@hyperlinkname{#2}}%
+        \edef\@tempurlb{\cref@hyperlinkurl{#3}}%
+        \edef\@tempnameb{\cref@hyperlinkname{#3}}%
+        \edef\@tempurla{\cref@hyperlinkurl{#2}}%
+        #1{\@pagea}{\@pageb}%
+          {\cref@hyperlink{\@tempurla}{\@tempnamea}}{\@nil}%
+          {\cref@hyperlink{\@tempurlb}{\@tempnameb}}{\@nil}%
+      \fi}%
+  }%  end of false case of \@ifpackagewith{hyperref}{implicit=false}
+}{% false case of \@ifpackageloaded{hyperref}
+  \@ifclassloaded{revtex4}{\let\if@cref@hyperrefloaded\iftrue}{}%
+  \@ifclassloaded{revtex4-1}{\let\if@cref@hyperrefloaded\iftrue}{}%
+  \if@cref@hyperrefloaded\relax%
+    \let\cref@old@H@refstepcounter\H@refstepcounter%
+    \def\H@refstepcounter#1{%
+      \cref@old@H@refstepcounter{#1}%
+      \cref@constructprefix{#1}{\cref@result}%
+      \@ifundefined{cref@#1@alias}%
+        {\def\@tempa{#1}}%
+        {\def\@tempa{\csname cref@#1@alias\endcsname}}%
+      \protected@edef\cref@currentlabel{%
+        [\@tempa][\arabic{#1}][\cref@result]%
+        \csname p@#1\endcsname\csname the#1\endcsname}}%
+  \fi%
+  \let\if@cref@hyperrefloaded\iffalse%
+}% end of \@ifpackageloaded{hyperref}
+\@ifpackageloaded{varioref}{%
+  \PackageInfo{cleveref}{`varioref' support loaded}%
+  \PackageInfo{cleveref}{`cleveref' supersedes `varioref's
+    \string\labelformat command}%
+  \def\cref@@vpageref#1[#2]#3{%
+    \@cpageref{cref}{#3}%
+      {\@setvpageref[#1][\vref@space]}{\@setvpagerefrange[#1]}}%
+  \def\cref@vref#1#2{%
+    \leavevmode%
+    \begingroup%
+      \def\reftextcurrent{}%
+      \@cref{#1}{#2}\@setcref@space%
+      \cref@@vpageref{\reftextcurrent}[]{#2}%
+    \endgroup}%
+  \def\cref@vrefrange#1#2#3{%
+    \@setcrefrange{#2}{#3}{#1}{}\@setcref@space\vpagerefrange{#2}{#3}}%
+  \def\cref@fullref#1#2{%
+    \@cref{#1}{#2}\@setcref@space%
+    \@cpageref{cref}{#2}{\@setfullpageref}{\@setfullpagerefrange}}%
+  \def\cref@vpagerefconjunction#1{%
+    \def\@tempa{#1}%
+    \def\@tempb{@second}%
+    \ifx\@tempa\@tempb\relax%
+      \@setcref@pairconjunction%
+    \else%
+      \def\@tempb{@middle}%
+      \ifx\@tempa\@tempb\relax%
+        \@setcref@middleconjunction%
+      \else%
+        \def\@tempb{@last}%
+        \ifx\@tempa\@tempb\relax%
+          \@setcref@lastconjunction%
+        \fi%
+      \fi%
+    \fi}%
+  \def\@setcref@space{ }%
+  \def\@setvpageref[#1][#2]#3#4#5{%
+    \cref@vpagerefconjunction{#5}%
+    \def\vref@space{}%
+    \begingroup%
+      \cref@patchreftexts{#5}%
+      \@@setvpageref{#1}[#2]{#3}%
+    \endgroup}%
+  \def\@@setvpageref#1[#2]#3{\cref@old@@vpageref{#1}[#2]{#3}}%
+  \def\@setvpagerefrange[#1]#2#3#4#5{%
+    \cref@vpagerefconjunction{#5}%
+    \let\vref@space\relax%
+    \begingroup%
+      \cref@patchreftexts{#5}%
+      \@@setvpagerefrange[#1]{#2}{#3}%
+    \endgroup}%
+  \def\@@setvpagerefrange[#1]#2#3{\vpagerefrange[#1]{#2}{#3}}%
+  \def\@setfullpageref#1#2#3{%
+    \cref@vpagerefconjunction{#3}%
+    \begingroup%
+      \cref@patchreftexts{#3}%
+      \@@setfullpageref{#1}%
+    \endgroup}%
+  \def\@@setfullpageref#1{\reftextfaraway{#1}}%
+  \def\@setfullpagerefrange#1#2#3#4{%
+    \cref@vpagerefconjunction{#4}%
+    \begingroup%
+      \cref@patchreftexts{#4}%
+      \@@setfullpagerefrange{#1}{#2}%
+    \endgroup}%
+  \def\@@setfullpagerefrange#1#2{\reftextpagerange{#1}{#2}}%
+  \def\cref@old@@vpageref#1[#2]#3{%
+    \leavevmode%\unskip  <<<
+    \global\advance\c@vrcnt\@ne%
+    \vref@pagenum\@tempa{\the\c@vrcnt @vr}%
+    \vref@pagenum\@tempb{\the\c@vrcnt @xvr}%
+    %\vref@label{\the\c@vrcnt @xvr}%  <<<
+    \ifx\@tempa\@tempb\else%
+      \vref@err{\noexpand\vref or \noexpand\vpageref at page boundary
+                \@tempb-\@tempa\space (may loop)%
+                }%
+    \fi%
+    \vrefpagenum\thevpagerefnum{#3}%
+    \vref@space%
+    \ifx\@tempa\thevpagerefnum%
+      \def\@tempc{#1}%
+      \ifx\@tempc\@empty%
+         \unskip%
+      \else%
+         #1%
+      \fi%
+    \else%
+      #2%
+      \is@pos@number\thevpagerefnum%
+         {%
+          \is@pos@number\@tempa%
+           {\@tempcnta\@tempa%
+            \advance\@tempcnta\@ne%
+           }%
+           {\@tempcnta\maxdimen}%
+          \ifnum \thevpagerefnum =\@tempcnta%
+           \ifodd\@tempcnta%
+             \if@twoside%
+               \reftextfaceafter%
+             \else%
+               \reftextafter%
+             \fi%
+           \else%
+             \reftextafter%
+           \fi%
+          \else%
+            \advance\@tempcnta-2%
+            \ifnum \thevpagerefnum =\@tempcnta%
+              \ifodd\@tempcnta%
+                \reftextbefore%
+              \else%
+                \if@twoside%
+                  \reftextfacebefore%
+                \else%
+                  \reftextbefore%
+                \fi%
+              \fi%
+            \else%
+              \reftextfaraway{#3}%
+            \fi%
+          \fi%
+         }%
+         {\reftextfaraway{#3}}%
+    \fi%
+    \vref@label{\the\c@vrcnt @xvr}%  <<<
+    \vref@label{\the\c@vrcnt @vr}%
+  }%
+  \let\creftextcurrent\reftextcurrent%
+  \let\creftextfaceafter\reftextfaceafter%
+  \let\creftextfacebefore\reftextfacebefore%
+  \let\creftextafter\reftextafter%
+  \let\creftextbefore\reftextbefore%
+  \let\creftextfaraway\reftextfaraway%
+  \let\creftextpagerange\reftextpagerange%
+  \def\cref@patchreftexts#1{%
+    \cref@patchreftext{reftextcurrent}{#1}%
+    \cref@patchreftext{reftextfaceafter}{#1}%
+    \cref@patchreftext{reftextfacebefore}{#1}%
+    \cref@patchreftext{reftextafter}{#1}%
+    \cref@patchreftext{reftextbefore}{#1}}%
+  \def\cref@patchreftext#1#2{%
+    \def\@tempa{#2}%
+    \ifx\@tempa\@empty%
+      \def\@tempc{}%
+      \expandafter\ifx\csname #1\endcsname\@tempc\relax%
+        \expandafter\def\csname #1\endcsname{\unskip}%
+          %{\advance\count@group -1\reftextcurrent@orig}%
+      \else%
+        \long\def\@tempc{}%
+        \expandafter\ifx\csname #1\endcsname\@tempc\relax%
+          \expandafter\def\csname #1\endcsname{\unskip}%
+            %{\advance\count@group -1\reftextcurrent@orig}%
+        \fi%
+      \fi%
+    \else%
+      \long\def\@tempc{\unskip}%
+      \expandafter\ifx\csname #1\endcsname\@tempc\relax%
+        \expandafter\expandafter\expandafter\def%
+        \expandafter\expandafter\csname #1\endcsname\expandafter{%
+          \csname c#1\endcsname}%
+      \else%
+        \long\def\@tempc{}%
+        \expandafter\ifx\csname #1\endcsname\@tempc\relax%
+          \expandafter\expandafter\expandafter\def%
+          \expandafter\expandafter\csname #1\endcsname\expandafter{%
+            \csname c#1\endcsname}%
+        \else%
+          \def\@tempc{\unskip}%
+          \expandafter\ifx\csname #1\endcsname\@tempc\relax%
+            \expandafter\expandafter\expandafter\def%
+            \expandafter\expandafter\csname #1\endcsname\expandafter{%
+              \csname c#1\endcsname}%
+          \else%
+            \def\@tempc{}%
+            \expandafter\ifx\csname #1\endcsname\@tempc\relax%
+              \expandafter\expandafter\expandafter\def%
+              \expandafter\expandafter\csname #1\endcsname\expandafter{%
+                \csname c#1\endcsname}%
+            \fi%
+          \fi%
+        \fi%
+      \fi%
+    \fi}%
+  \def\@setcref@pairconjunction{\crefpairconjunction}%
+  \def\@setcref@middleconjunction{\crefmiddleconjunction}%
+  \def\@setcref@lastconjunction{\creflastconjunction}%
+  \AtBeginDocument{%
+    \def\@@vpageref#1[#2]#3{\cref@@vpageref{#1}[#2]{#3}}%
+  }%
+  \if@cref@hyperrefloaded\relax%  hyperref loaded%
+    \DeclareRobustCommand{\vref}{%
+      \@ifstar{\cref@vrefstar{cref}}{\cref@vref{cref}}}%
+    \DeclareRobustCommand{\Vref}{%
+      \@ifstar{\cref@vrefstar{Cref}}{\cref@vref{Cref}}}%
+    \DeclareRobustCommand{\vrefrange}{%
+      \@ifstar{\cref@vrefrangestar{cref}}{\cref@vrefrange{cref}}}%
+    \DeclareRobustCommand{\Vrefrange}{%
+      \@ifstar{\cref@vrefrangestar{Cref}}{\cref@vrefrange{Cref}}}%
+    \DeclareRobustCommand{\fullref}{%
+      \@ifstar{\cref@fullrefstar{cref}}{\cref@fullref{cref}}}%
+    \DeclareRobustCommand{\Fullref}{%
+      \@ifstar{\cref@fullrefstar{Cref}}{\cref@fullref{Cref}}}%
+    \def\cref@vrefstar#1#2{%
+      \@crefstarredtrue%
+      \cref@vref{#1}{#2}%
+      \@crefstarredfalse}%
+    \def\cref@vrefrangestar#1#2#3{%
+      \@crefstarredtrue%
+      \cref@vrefrange{#1}{#2}{#3}%
+      \@crefstarredfalse}%
+    \def\cref@fullrefstar#1#2{%
+      \@crefstarredtrue%
+      \cref@fullref{#1}{#2}%
+      \@crefstarredfalse}%
+  \else%
+    \DeclareRobustCommand{\vref}{\cref@vref{cref}}%
+    \DeclareRobustCommand{\Vref}{\cref@vref{Cref}}%
+    \DeclareRobustCommand{\vrefrange}{\cref@vrefrange{cref}}%
+    \DeclareRobustCommand{\Vrefrange}{\cref@vrefrange{Cref}}%
+    \DeclareRobustCommand{\fullref}{\cref@fullref{cref}}%
+    \DeclareRobustCommand{\Fullref}{\cref@fullref{Cref}}%
+  \fi%  end of test for hyperref
+}{}%  end of \@ifpackageloaded{varioref}
+\@ifpackageloaded{amsmath}{%
+  \AtBeginDocument{%
+    \let\cref@old@label@in@display\label@in@display%
+    \def\label@in@display{%
+      \@ifnextchar[\label@in@display@optarg\label@in@display@noarg}%]
+    \def\label@in@display@noarg#1{\cref@old@label@in@display{{#1}}}%
+    \def\label@in@display@optarg[#1]#2{%
+      \cref@old@label@in@display{[#1]{#2}}}%
+    \def\ltx@label#1{\cref@label#1}%
+  }%  end of AtBeginDocument
+  \def\measure@#1{%
+    \begingroup%
+        \measuring@true%
+        \global\eqnshift@\z@%
+        \global\alignsep@\z@%
+        \global\let\tag@lengths\@empty%
+        \global\let\field@lengths\@empty%
+        \savecounters@%
+        \global\setbox0\vbox{%
+            \let\math@cr@@@\math@cr@@@align@measure%
+            \everycr{\noalign{\global\tag@false%
+              \global\let\raise@tag\@empty \global\column@\z@}}%
+            \let\label\@gobble@optarg%  <<< cleveref modification
+            \global\row@\z@%
+            \tabskip\z@%
+            \halign{\span\align@preamble\crcr%
+                #1%
+                \math@cr@@@%
+                \global\column@\z@%
+                \add@amps\maxfields@\cr%
+            }%
+        }%
+        \restorecounters@%
+        \ifodd\maxfields@%
+            \global\advance\maxfields@\@ne%
+        \fi%
+        \ifnum\xatlevel@=\tw@%
+            \ifnum\maxfields@<\thr@@%
+                \let\xatlevel@\z@%
+            \fi%
+        \fi%
+        \setbox\z@\vbox{%
+          \unvbox\z@ \unpenalty \global\setbox\@ne\lastbox%
+        }%
+        \global\totwidth@\wd\@ne%
+        \if@fleqn \global\advance\totwidth@\@mathmargin \fi%
+        \global\let\maxcolumn@widths\@empty%
+        \begingroup%
+          \let\or\relax%
+          \loop%
+            \global\setbox\@ne\hbox{%
+              \unhbox\@ne \unskip \global\setbox\thr@@\lastbox%
+            }%
+          \ifhbox\thr@@%
+           \xdef\maxcolumn@widths{ \or \the\wd\thr@@ \maxcolumn@widths}%
+          \repeat%
+        \endgroup%
+        \dimen@\displaywidth%
+        \advance\dimen@-\totwidth@%
+        \ifcase\xatlevel@%
+            \global\alignsep@\z@%
+            \let\minalignsep\z@%
+            \@tempcntb\z@%
+            \if@fleqn%
+                \@tempcnta\@ne%
+                \global\eqnshift@\@mathmargin%
+            \else%
+                \@tempcnta\tw@%
+                \global\eqnshift@\dimen@%
+                \global\divide\eqnshift@\@tempcnta%
+            \fi%
+        \or%
+            \@tempcntb\maxfields@%
+            \divide\@tempcntb\tw@%
+            \@tempcnta\@tempcntb%
+            \advance\@tempcntb\m@ne%
+            \if@fleqn%
+                \global\eqnshift@\@mathmargin%
+                \global\alignsep@\dimen@%
+                \global\divide\alignsep@\@tempcnta%
+            \else%
+                \global\advance\@tempcnta\@ne%
+                \global\eqnshift@\dimen@%
+                \global\divide\eqnshift@\@tempcnta%
+                \global\alignsep@\eqnshift@%
+            \fi%
+        \or%
+            \@tempcntb\maxfields@%
+            \divide\@tempcntb\tw@%
+            \global\advance\@tempcntb\m@ne%
+            \global\@tempcnta\@tempcntb%
+            \global\eqnshift@\z@%
+            \global\alignsep@\dimen@%
+            \if@fleqn%
+                \global\advance\alignsep@\@mathmargin\relax%
+            \fi%
+            \global\divide\alignsep@\@tempcntb%
+        \fi%
+        \ifdim\alignsep@<\minalignsep\relax%
+            \global\alignsep@\minalignsep\relax%
+            \ifdim\eqnshift@>\z@%
+                \if@fleqn\else%
+                    \global\eqnshift@\displaywidth%
+                    \global\advance\eqnshift@-\totwidth@%
+                    \global\advance\eqnshift@-\@tempcntb\alignsep@%
+                    \global\divide\eqnshift@\tw@%
+                \fi%
+            \fi%
+        \fi%
+        \ifdim\eqnshift@<\z@%
+            \global\eqnshift@\z@%
+        \fi%
+        \calc@shift@align%
+        \global\tagshift@\totwidth@%
+        \global\advance\tagshift@\@tempcntb\alignsep@%
+        \if@fleqn%
+            \ifnum\xatlevel@=\tw@%
+                \global\advance\tagshift@-\@mathmargin\relax%
+            \fi%
+        \else%
+            \global\advance\tagshift@\eqnshift@%
+        \fi%
+        \iftagsleft@ \else%
+            \global\advance\tagshift@-\displaywidth%
+        \fi%
+        \dimen@\minalignsep\relax%
+        \global\advance\totwidth@\@tempcntb\dimen@%
+        \ifdim\totwidth@>\displaywidth%
+            \global\let\displaywidth@\totwidth@%
+        \else%
+            \global\let\displaywidth@\displaywidth%
+        \fi%
+    \endgroup%
+  }%
+  \def\gmeasure@#1{%
+    \begingroup%
+        \measuring@true%
+        \totwidth@\z@%
+        \global\let\tag@lengths\@empty%
+        \savecounters@%
+        \setbox\@ne\vbox{%
+            \everycr{\noalign{\global\tag@false%
+              \global\let\raise@tag\@empty \global\column@\z@}}%
+            \let\label\@gobble%  <<< cleveref modification
+            \halign{%
+                \setboxz@h{$\m@th\displaystyle{##}$}%
+                \ifdim\wdz@>\totwidth@%
+                    \global\totwidth@\wdz@%
+                \fi%
+               &\setboxz@h{\strut@{##}}%
+                \savetaglength@%
+                \crcr%
+                #1%
+                \math@cr@@@%
+            }%
+        }%
+        \restorecounters@%
+        \if@fleqn%
+            \global\advance\totwidth@\@mathmargin%
+        \fi%
+        \iftagsleft@%
+            \ifdim\totwidth@>\displaywidth%
+                \global\let\gdisplaywidth@\totwidth@%
+            \else%
+                \global\let\gdisplaywidth@\displaywidth%
+            \fi%
+        \fi%
+    \endgroup%
+}%
+  \def\multline@#1{%
+    \Let@%
+    \@display@init{\global\advance\row@\@ne \global\dspbrk@lvl\m@ne}%
+    \chardef\dspbrk@context\z@%
+    \restore@math@cr%
+    \let\tag\tag@in@align%
+    \global\tag@false \global\let\raise@tag\@empty%
+    \mmeasure@{#1}%
+    \let\tag\gobble@tag \let\label\@gobble@optarg%  <<< cleveref modification
+    \tabskip \if@fleqn \@mathmargin \else \z@skip \fi%
+    \totwidth@\displaywidth%
+    \if@fleqn%
+        \advance\totwidth@-\@mathmargin%
+    \fi%
+    \halign\bgroup%
+        \hbox to\totwidth@{%
+            \if@fleqn%
+                \hskip \@centering \relax%
+            \else%
+                \hfil%
+            \fi%
+            \strut@%
+            $\m@th\displaystyle{}##\endmultline@math%
+            \hfil%
+        }% $
+        \crcr%
+        \if@fleqn%
+            \hskip-\@mathmargin%
+            \def\multline@indent{\hskip\@mathmargin}%
+        \else%
+            \hfilneg%
+            \def\multline@indent{\hskip\multlinegap}%
+        \fi%
+        \iftagsleft@%
+            \iftag@%
+                \begingroup%
+                    \ifshifttag@%
+                        \rlap{\vbox{%
+                                \normalbaselines%
+                                \hbox{%
+                                    \strut@%
+                                    \make@display@tag%
+                                }%
+                                \vbox to\lineht@{}%
+                                \raise@tag%
+                        }}%
+                        \multline@indent%
+                    \else%
+                        \setbox\z@\hbox{\make@display@tag}%
+                        \dimen@\@mathmargin \advance\dimen@-\wd\z@%
+                        \ifdim\dimen@<\multlinetaggap%
+                          \dimen@\multlinetaggap%
+                        \fi%
+                        \box\z@ \hskip\dimen@\relax%
+                    \fi%
+                \endgroup%
+            \else%
+                \multline@indent%
+            \fi%
+        \else%
+            \multline@indent%
+        \fi%
+    #1%
+  }%
+  \def\mmeasure@#1{%
+    \begingroup%
+        \measuring@true%
+        \def\label{%                  <<< cleveref modification
+          \@ifnextchar[\label@in@mmeasure@optarg%]
+            \label@in@mmeasure@noarg}%
+        \def\math@cr@@@{\cr}%
+        \let\shoveleft\@iden \let\shoveright\@iden%
+        \savecounters@%
+        \global\row@\z@%
+        \setbox\@ne\vbox{%
+            \global\let\df@tag\@empty%
+            \halign{%
+                \setboxz@h{\@lign$\m@th\displaystyle{}##$}%
+                \iftagsleft@%
+                    \ifnum\row@=\@ne%
+                        \global\totwidth@\wdz@%
+                        \global\lineht@\ht\z@%
+                    \fi%
+                \else%
+                    \global\totwidth@\wdz@%
+                    \global\lineht@\dp\z@%
+                \fi%
+                \crcr%
+                #1%
+                \crcr%
+            }%
+        }%
+        \ifx\df@tag\@empty\else\global\tag@true\fi%
+        \if@eqnsw\global\tag@true\fi%
+        \iftag@%
+            \setboxz@h{%
+                \if@eqnsw%
+                    \stepcounter{equation}%
+                    \tagform@\theequation%
+                \else%
+                    \df@tag%
+                \fi%
+            }%
+            \global\tagwidth@\wdz@%
+            \dimen@\totwidth@%
+            \advance\dimen@\tagwidth@%
+            \advance\dimen@\multlinetaggap%
+            \iftagsleft@\else%
+                \if@fleqn%
+                    \advance\dimen@\@mathmargin%
+                \fi%
+            \fi%
+            \ifdim\dimen@>\displaywidth%
+                \global\shifttag@true%
+            \else%
+                \global\shifttag@false%
+            \fi%
+        \fi%
+        \restorecounters@%
+    \endgroup%
+  }%
+  \def\label@in@mmeasure@noarg#1{%
+    \begingroup%
+      \measuring@false%
+      \cref@old@label@in@display{{#1}}%
+    \endgroup}%
+  \def\label@in@mmeasure@optarg[#1]#2{%
+    \begingroup%
+      \measuring@false%
+      \cref@old@label@in@display{[#1]{#2}}%
+    \endgroup}%
+  \let\cref@old@subequations\subequations%
+  \let\cref@old@endsubequations\endsubequations%
+  \cref@resetby{equation}{\cref@result}%
+  \ifx\cref@result\relax\else%
+    \@addtoreset{parentequation}{\cref@result}%
+  \fi%
+  \renewenvironment{subequations}{%
+    \@addtoreset{equation}{parentequation}%
+    \let\cref@orig@equation@alias\cref@equation@alias%
+    \@ifundefined{cref@subequation@alias}%
+      {\crefalias{equation}{subequation}}%
+      {\def\@tempa{{equation}}%
+       \expandafter\expandafter\expandafter\crefalias%
+       \expandafter\@tempa\expandafter{\cref@subequation@alias}}%
+    \cref@old@subequations%
+  }{%
+    \gdef\cl@parentequation{}%
+    \cref@old@endsubequations%
+    \setcounter{parentequation}{0}%
+    \@ifundefined{cref@orig@cref@equation@alias}%
+      {\let\cref@equation@alias\relax}%
+      {\let\cref@equation@alias\cref@orig@equation@alias\relax}%
+    \let\cref@orig@equation@alias\relax%
+  }%
+  \let\cref@old@make@df@tag@@\make@df@tag@@%
+  \def\make@df@tag@@#1{%
+    \cref@old@make@df@tag@@{#1}%
+    \let\cref@old@df@tag\df@tag%
+    \expandafter\gdef\expandafter\df@tag\expandafter{%
+      \cref@old@df@tag%
+      \def\cref@currentlabel{[equation][2147483647][]#1}}}%
+  \let\cref@old@make@df@tag@@@\make@df@tag@@@%
+  \def\make@df@tag@@@#1{%
+    \cref@old@make@df@tag@@@{#1}%
+    \let\cref@old@df@tag\df@tag%
+    \expandafter\gdef\expandafter\df@tag\expandafter{%
+      \cref@old@df@tag%
+      \toks@\@xp{\p@equation{#1}}%
+      \edef\cref@currentlabel{[equation][2147483647][]\the\toks@}}}%
+}{}%  end of \@ifpackageloaded{amsmath}
+\@ifpackageloaded{amsthm}{%
+  \PackageInfo{cleveref}{`amsthm' support loaded}%
+  \let\cref@thmnoarg\@thm%
+  \def\@thm{\@ifnextchar[{\cref@thmoptarg}{\cref@thmnoarg}}%]
+  \def\cref@thmoptarg[#1]#2#3#4{%
+    \ifhmode\unskip\unskip\par\fi%
+    \normalfont%
+    \trivlist%
+    \let\thmheadnl\relax%
+    \let\thm@swap\@gobble%
+    \thm@notefont{\fontseries\mddefault\upshape}%
+    \thm@headpunct{.}% add period after heading
+    \thm@headsep 5\p@ plus\p@ minus\p@\relax%
+    \thm@space@setup%
+    #2% style overrides
+    \@topsep \thm@preskip               % used by thm head
+    \@topsepadd \thm@postskip           % used by \@endparenv
+    \def\@tempa{#3}\ifx\@empty\@tempa%
+      \def\@tempa{\@oparg{\@begintheorem{#4}{}}[]}%
+    \else%
+      \refstepcounter[#1]{#3}%  <<< cleveref modification
+      \def\@tempa{\@oparg{\@begintheorem{#4}{\csname the#3\endcsname}}[]}%
+    \fi%
+    \@tempa}%
+  \def\@ynthm#1[#2]#3{%
+    \edef\@tempa{\expandafter\noexpand%
+      \csname cref@#1@name@preamble\endcsname}%
+    \edef\@tempb{\expandafter\noexpand%
+      \csname Cref@#1@name@preamble\endcsname}%
+    \def\@tempc{#3}%
+    \ifx\@tempc\@empty\relax%
+      \expandafter\gdef\@tempa{}%
+      \expandafter\gdef\@tempb{}%
+    \else%
+      \if@cref@capitalise%
+        \expandafter\expandafter\expandafter\gdef\expandafter%
+          \@tempa\expandafter{\MakeUppercase #3}%
+      \else%
+        \expandafter\expandafter\expandafter\gdef\expandafter%
+          \@tempa\expandafter{\MakeLowercase #3}%
+      \fi%
+      \expandafter\expandafter\expandafter\gdef\expandafter%
+        \@tempb\expandafter{\MakeUppercase #3}%
+    \fi%
+    \cref@stack@add{#1}{\cref@label@types}%
+    \ifx\relax#2\relax%
+      \def\@tempa{\@oparg{\@xthm{#1}{#3}}[]}%
+    \else%
+      \@ifundefined{c@#2}{%
+        \def\@tempa{\@nocounterr{#2}}%
+      }{%
+        \@xp\xdef\csname the#1\endcsname{\@xp\@nx\csname the#2\endcsname}%
+        \toks@{#3}%
+        \@xp\xdef\csname#1\endcsname{%
+          \@nx\@thm[#1]{%  <<< new optional argument for theorem name
+            \let\@nx\thm@swap%
+              \if S\thm@swap\@nx\@firstoftwo\else\@nx\@gobble\fi%
+            \@xp\@nx\csname th@\the\thm@style\endcsname}%
+              {#2}{\the\toks@}}%
+        \let\@tempa\relax%
+      }%
+    \fi%
+    \@tempa}%
+  \let\@xnthm\cref@old@xnthm%
+}{}%  end of \@ifpackageloaded{amsthm}
+\@ifpackageloaded{ntheorem}{%
+  \PackageInfo{cleveref}{`ntheorem' support loaded}%
   \@ifpackagewith{ntheorem}{thref}{%
     \PackageWarning{cleveref}{`cleveref' supersedes `ntheorem's `thref'
       option}%
-    \renewcommand{\thref}{\cref}}{}
-  \@ifundefined{theorem@prework}{\let\theorem@prework\relax}{}
+    \renewcommand{\thref}{\cref}}{}%
+  \@ifundefined{theorem@prework}{\let\theorem@prework\relax}{}%
   \gdef\@thm#1#2#3{%
     \if@thmmarks%
       \stepcounter{end\InTheoType ctr}%
@@ -2182,274 +2883,158 @@
     \advance\@totalleftmargin \theorem@indent%
     \parshape \@ne \@totalleftmargin \linewidth%
     \@ifnextchar[{\@ythm{#1}{#2}{#3}}{\@xthm{#1}{#2}{#3}}%]
-  }
-  }{}%  end of \@ifpackageloaded{ntheorem}
-\let\cref@old@othm\@othm
-\def\@othm#1[#2]#3{%
-  \edef\@tempa{\expandafter\noexpand%
-    \csname cref@#1@name@preamble\endcsname}%
-  \edef\@tempb{\expandafter\noexpand%
-      \csname Cref@#1@name@preamble\endcsname}%
-  \def\@tempc{#3}%
-  \ifx\@tempc\@empty\relax%
-    \expandafter\gdef\@tempa{}%
-    \expandafter\gdef\@tempb{}%
-  \else%
-    \expandafter\expandafter\expandafter\gdef\expandafter%
-      \@tempa\expandafter{\MakeLowercase #3}%
-    \expandafter\expandafter\expandafter\gdef\expandafter%
-      \@tempa\expandafter{\MakeUppercase #3}%
-  \fi%
-  \cref@stack@add{#1}{\cref@label@types}%
-  \cref@old@othm{#1}[#2]{#3}}
-\let\cref@old@xnthm\@xnthm
-\def\@xnthm#1#2[#3]{%
-  \edef\@tempa{\expandafter\noexpand%
-    \csname cref@#1@name@preamble\endcsname}%
-  \edef\@tempb{\expandafter\noexpand%
-      \csname Cref@#1@name@preamble\endcsname}%
-  \def\@tempc{#2}%
-  \ifx\@tempc\@empty\relax%
-    \expandafter\gdef\@tempa{}%
-    \expandafter\gdef\@tempb{}%
-  \else%
-    \expandafter\expandafter\expandafter\gdef\expandafter%
-      \@tempa\expandafter{\MakeLowercase #2}%
-    \expandafter\expandafter\expandafter\gdef\expandafter%
-      \@tempa\expandafter{\MakeUppercase #2}%
-  \fi%
-  \cref@stack@add{#1}{\cref@label@types}%
-  \cref@old@xnthm{#1}{#2}[#3]}
-\let\cref@old@ynthm\@ynthm
-\def\@ynthm#1#2{%
-  \edef\@tempa{\expandafter\noexpand%
-    \csname cref@#1@name@preamble\endcsname}%
-  \edef\@tempb{\expandafter\noexpand%
-      \csname Cref@#1@name@preamble\endcsname}%
-  \def\@tempc{#2}%
-  \ifx\@tempc\@empty\relax%
-    \expandafter\gdef\@tempa{}%
-    \expandafter\gdef\@tempb{}%
-  \else%
-    \expandafter\expandafter\expandafter\gdef\expandafter%
-      \@tempa\expandafter{\MakeLowercase #2}%
-    \expandafter\expandafter\expandafter\gdef\expandafter%
-      \@tempa\expandafter{\MakeUppercase #2}%
-  \fi%
-  \cref@stack@add{#1}{\cref@label@types}%
-  \cref@old@ynthm{#1}{#2}}
-  \@ifpackageloaded{amsthm}{%
-  \PackageInfo{cleveref}{`amsthm' support loaded}
-\let\cref@thmnoarg\@thm
-\def\@thm{\@ifnextchar[{\cref@thmoptarg}{\cref@thmnoarg}}%]
-\def\cref@thmoptarg[#1]#2#3#4{%
-  \ifhmode\unskip\unskip\par\fi%
-  \normalfont%
-  \trivlist%
-  \let\thmheadnl\relax%
-  \let\thm@swap\@gobble%
-  \thm@notefont{\fontseries\mddefault\upshape}%
-  \thm@headpunct{.}% add period after heading
-  \thm@headsep 5\p@ plus\p@ minus\p@\relax%
-  \thm@space@setup%
-  #2% style overrides
-  \@topsep \thm@preskip               % used by thm head
-  \@topsepadd \thm@postskip           % used by \@endparenv
-  \def\@tempa{#3}\ifx\@empty\@tempa%
-    \def\@tempa{\@oparg{\@begintheorem{#4}{}}[]}%
-  \else%
-    \refstepcounter[#1]{#3}%  <<< cleveref modification
-    \def\@tempa{\@oparg{\@begintheorem{#4}{\csname the#3\endcsname}}[]}%
-  \fi%
-  \@tempa}
-\def\@ynthm#1[#2]#3{%
-  \edef\@tempa{\expandafter\noexpand%
-    \csname cref@#1@name@preamble\endcsname}%
-  \edef\@tempb{\expandafter\noexpand%
-      \csname Cref@#1@name@preamble\endcsname}%
-  \def\@tempc{#3}%
-  \ifx\@tempc\@empty\relax%
-    \expandafter\gdef\@tempa{}%
-    \expandafter\gdef\@tempb{}%
-  \else%
-    \expandafter\expandafter\expandafter\gdef\expandafter%
-      \@tempa\expandafter{\MakeLowercase #3}%
-    \expandafter\expandafter\expandafter\gdef\expandafter%
-      \@tempa\expandafter{\MakeUppercase #3}%
-  \fi%
-  \cref@stack@add{#1}{\cref@label@types}%
-  \ifx\relax#2\relax%
-    \def\@tempa{\@oparg{\@xthm{#1}{#3}}[]}%
-  \else%
-    \@ifundefined{c@#2}{%
-      \def\@tempa{\@nocounterr{#2}}%
-    }{%
-      \@xp\xdef\csname the#1\endcsname{\@xp\@nx\csname the#2\endcsname}%
-      \toks@{#3}%
-      \@xp\xdef\csname#1\endcsname{%
-        \@nx\@thm[#1]{%  <<< new optional argument for theorem name
-          \let\@nx\thm@swap%
-            \if S\thm@swap\@nx\@firstoftwo\else\@nx\@gobble\fi%
-          \@xp\@nx\csname th@\the\thm@style\endcsname}%
-            {#2}{\the\toks@}}%
-      \let\@tempa\relax%
-    }%
-  \fi%
-  \@tempa}
-  \let\@xnthm\cref@old@xnthm
-  }{}%  end of \@ifpackageloaded{amsthm}
-  \@ifpackageloaded{algorithm}{%
-  \PackageInfo{cleveref}{`algorithm' support loaded}
-  \let\cref@old@ALG@step\ALG@step
-  \def\ALG@step{%
-    \cref@old@ALG@step%
+  }%
+}{}%  end of \@ifpackageloaded{ntheorem}
+\@ifpackageloaded{IEEEtrantools}{%
+  \PackageInfo{cleveref}{`IEEEtrantools' support loaded}%
+  \let\cref@orig@@IEEEeqnarray\@@IEEEeqnarray%
+  \def\@@IEEEeqnarray[#1]#2{%
+    \refstepcounter{equation}%
+    \addtocounter{equation}{-1}%
+    \cref@orig@@IEEEeqnarray[#1]{#2}}%
+  \let\cref@orig@IEEEeqnarrayXCR\@IEEEeqnarrayXCR%
+  \def\@IEEEeqnarrayXCR[#1]{%
+    \if@eqnsw%
+      \if@IEEEissubequation%
+        %\addtocounter{equation}{1}%
+        \refstepcounter{IEEEsubequation}%
+        \addtocounter{IEEEsubequation}{-1}%
+      \else%
+        \refstepcounter{equation}%
+        \addtocounter{equation}{-1}%
+      \fi%
+    \fi%
+  \cref@orig@IEEEeqnarrayXCR[#1]}%
+  \let\cref@orig@IEEEyessubnumber\IEEEyessubnumber%
+  \def\IEEEyessubnumber{%
+    \if@IEEEeqnarrayISinner%
+      \if@IEEElastlinewassubequation\else%
+        \setcounter{IEEEsubequation}{0}%
+        \refstepcounter{IEEEsubequation}%
+      \fi%
+    \fi%
+    \cref@orig@IEEEyessubnumber}%
+  \@addtoreset{IEEEsubequation}{equation}%
+  \crefalias{IEEEsubequation}{equation}%
+}{}% end of \@ifpackageloaded{IEEEtrantools}
+\@ifpackageloaded{breqn}{%
+  \PackageInfo{cleveref}{`breqn' support loaded}%
+  \let\cref@old@eq@setnumber\eq@setnumber%
+  \def\eq@setnumber{%
+    \cref@old@eq@setnumber%
+    \cref@constructprefix{equation}{\cref@result}%
+    \protected@xdef\cref@currentlabel{%
+      [equation][\arabic{equation}][\cref@result]\p@equation\theequation}}%
+}{}% end of \@ifpackageloaded{breqn}
+  \@ifpackageloaded{algorithmicx}{%
+  \PackageInfo{cleveref}{`algorithmicx' support loaded}%
+  \g@addto@macro\ALG@step{%
     \addtocounter{ALG@line}{-1}%
-    \refstepcounter[line]{ALG@line}}
-  }{}%  end of \@ifpackageloaded{algorithm}
+    \refstepcounter{ALG@line}%
+    \expandafter\@cref@getprefix\cref@currentlabel\@nil\cref@currentprefix%
+    \xdef\cref@currentprefix{\cref@currentprefix}}%
+  \g@addto@macro\ALG@beginalgorithmic{%
+    \def\cref@currentlabel{%
+      [line][\arabic{ALG@line}][\cref@currentprefix]\theALG@line}}%
+  }{}%  end of \@ifpackageloaded{algorithmicx}
   \@ifpackageloaded{listings}{%
-  \PackageInfo{cleveref}{`listings' support loaded}
-  \crefalias{lstnumber}{line}%
-  \crefalias{lstlisting}{listing}}{}%  end of \@ifpackageloaded{listings}
+    \PackageInfo{cleveref}{`listings' support loaded}%
+    \crefalias{lstlisting}{listing}%
+    \crefalias{lstnumber}{line}%
+    \lst@AddToHook{Init}{%
+      \def\cref@currentlabel{%
+        [line][\arabic{lstnumber}][\cref@currentprefix]\thelstnumber}}%
+    \lst@AddToHook{EveryPar}{%
+      \expandafter\@cref@getprefix\cref@currentlabel\@nil\cref@currentprefix%
+      \xdef\cref@currentprefix{\cref@currentprefix}}%
+  }{}%  end of \@ifpackageloaded{listings}
   \@ifpackageloaded{algorithm2e}{%
-  \PackageInfo{cleveref}{`algorithm2e' support loaded}
-  \crefalias{algocf}{algorithm}%
-  \crefalias{algocfline}{line}}{}%  end of \@ifpackageloaded{listings}
-  \@ifpackageloaded{subfig}{%
-  \PackageInfo{cleveref}{`subfig' support loaded}
-  \AtBeginDocument{
-    \let\cref@old@refsteponlycounter\refsteponlycounter
+    \PackageInfo{cleveref}{`algorithm2e' support loaded}%
+    \crefalias{algocf}{algorithm}%
+    \crefalias{algocfline}{line}%
+    \crefalias{AlgoLine}{line}%
+    \let\cref@old@algocf@nl@sethref\algocf@nl@sethref%
+    \renewcommand{\algocf@nl@sethref}[1]{%
+      \cref@old@algocf@nl@sethref{#1}%
+      \cref@constructprefix{AlgoLine}{\cref@result}%
+      \@ifundefined{cref@AlgoLine@alias}%
+        {\def\@tempa{AlgoLine}}%
+        {\def\@tempa{\csname cref@AlgoLine@alias\endcsname}}%
+      \xdef\cref@currentlabel{%
+        [\@tempa][\arabic{AlgoLine}][\cref@result]%
+        \csname p@AlgoLine\endcsname\csname theAlgoLine\endcsname}}%
+  }{}%  end of \@ifpackageloaded{algorithm2e}
+\@ifpackageloaded{subfig}{%
+  \PackageInfo{cleveref}{`subfig' support loaded}%
+  \AtBeginDocument{%
+    \let\cref@old@refsteponlycounter\refsteponlycounter%
     \def\refsteponlycounter{%
-      \@ifnextchar[{\refstepcounter@optarg}%
-        {\cref@old@refsteponlycounter}%]
-    }}
+      \@ifnextchar[\refstepcounter@optarg%
+        \cref@old@refsteponlycounter%]
+    }}%
+  \def\sf@sub@label(#1){%
+    \ifhyperrefloaded%
+      \protected@edef\@currentlabelname{%
+        \expandafter\strip@period #1\relax.\relax\@@@}%
+    \fi%
+    \let\sf@oldlabel\cref@old@label%
+    \let\cref@old@label\sf@@sub@label%
+    \cref@label}%
   }{}%  end of \@ifpackageloaded{subfig}
+\@ifclassloaded{memoir}{%
+  \AtBeginDocument{%
+    \def\sf@memsub@label(#1){%
+      \protected@edef\mem@currentlabelname{#1}%
+      \let\@memoldlabel\cref@old@label%
+      \let\cref@old@label\sf@@memsub@label%
+      \cref@label}}%
+}{}%
+\@ifpackageloaded{caption}{%
+  \@ifpackagelater{caption}{2011/08/19}{}{%
+    \PackageInfo{cleveref}{`caption' support loaded}%
+    \let\cref@old@caption@xlabel\caption@xlabel%
+    \def\caption@xlabel{%
+      \let\cref@ORI@label\cref@old@label%
+      \let\cref@old@label\cref@old@caption@xlabel%
+      \let\caption@ORI@label\cref@ORI@label%
+      \cref@label}%
+    }% end of \@ifpackagelater
+  }{}%  end of \@ifpackageloaded{caption}
 \@ifpackageloaded{aliascnt}{%
-  \PackageInfo{cleveref}{`aliascnt' support loaded}
-  \let\cref@old@newaliascnt\newaliascnt
+  \PackageInfo{cleveref}{`aliascnt' support loaded}%
+  \let\cref@old@newaliascnt\newaliascnt%
   \renewcommand*{\newaliascnt}[2]{%
     \cref@old@newaliascnt{#1}{#2}%
     \cref@resetby{#2}{\cref@result}%
     \ifx\cref@result\relax\else%
       \@addtoreset{#1}{\cref@result}%
-    \fi}
+    \fi}%
   }{}%  end of \@ifpackageloaded{aliascnt}
-\@ifpackageloaded{varioref}{%
-    \PackageInfo{cleveref}{`varioref' support loaded}
-    \PackageInfo{cleveref}{`cleveref' supersedes `varioref's %
-      \string\labelformat command}
-  \AtBeginDocument{%
-    \def\cref@vref#1#2{%
-      \if@cref@legacyvarioref%
-        \leavevmode\unskip\vref@space%
-      \fi%
-      \@cref{#1}{#2} % space here is deliberate
-      \begingroup%
-        \def\@tempstack{#2,\@nil}%
-        \cref@stack@topandbottom{\@tempstack}{\@firstref}{\@lastref}%
-        \ifx\@lastref\@empty%
-          \vpageref[\unskip]{#2}%
-        \else%
-          \edef\@tempa{{\@firstref}{\@lastref}}%
-          \expandafter\def\expandafter\@tempa\expandafter{%
-            \expandafter[\expandafter\unskip\expandafter]%
-            \@tempa}%
-          \expandafter\vpagerefrange\@tempa%
-        \fi%
-      \endgroup}
-    \def\cref@vrefrange#1#2#3{%
-      \@setcrefrange{#2}{#3}{#1}{} \vpagerefrange[\unskip]{#2}{#3}}
-    \def\cref@fullref#1#2{%
-      \@cref{#1}{#2} % space here is deliberate
-      \begingroup%
-        \def\@tempstack{#2,\@nil}%
-        \cref@stack@topandbottom{\@tempstack}{\@firstref}{\@lastref}%
-        \ifx\@lastref\@empty%
-          \reftextfaraway{#2}%
-        \else%
-          \expandafter\vrefpagenum\expandafter%
-            \@tempa\expandafter{\@firstref}%
-          \expandafter\vrefpagenum\expandafter%
-            \@tempb\expandafter{\@lastref}%
-          \ifx\@tempa\@tempb%
-            \expandafter\reftextfaraway\expandafter{\@firstref}%
-          \else%
-            \edef\@tempa{{\@firstref}{\@lastref}}%
-            \expandafter\reftextpagerange\@tempa%
-          \fi%
-        \fi%
-      \endgroup}
-    \if@cref@legacyvarioref%
-      \def\vr@f#1{\cref@vref{cref}{#1}}
-      \def\Vr@f#1{\cref@vref{Cref}{#1}}
-      \renewcommand\vrefrange[3][\reftextcurrent]{%
-        \crefrange{#2}{#3} \vpagerefrange[\unskip]{#2}{#3}}
-      \def\fullref#1{\cref@fullref{cref}{#1}}
-    \else%
-      \if@cref@hyperrefloaded\relax%  hyperref loaded
-          \DeclareRobustCommand{\vref}{%
-            \@ifstar{\cref@vrefstar{cref}}{\cref@vref{cref}}}
-          \DeclareRobustCommand{\Vref}{%
-            \@ifstar{\cref@vrefstar{Cref}}{\cref@vref{Cref}}}
-          \DeclareRobustCommand{\vrefrange}{%
-            \@ifstar{\cref@vrefrangestar{cref}}{\cref@vrefrange{cref}}}
-          \DeclareRobustCommand{\Vrefrange}{%
-            \@ifstar{\cref@vrefrangestar{Cref}}{\cref@vrefrange{Cref}}}
-          \DeclareRobustCommand{\fullref}{%
-            \@ifstar{\cref@fullrefstar{cref}}{\cref@fullref{cref}}}
-          \DeclareRobustCommand{\Fullref}{%
-            \@ifstar{\cref@fullrefstar{Cref}}{\cref@fullref{Cref}}}
-          \def\cref@vrefstar#1#2{%
-            \@crefstarredtrue%
-            \cref@vref{#1}{#2}%
-            \@crefstarredfalse}
-          \def\cref@vrefrangestar#1#2#3{%
-            \@crefstarredtrue%
-            \cref@vrefrange{#1}{#2}{#3}%
-            \@crefstarredfalse}
-          \def\cref@fullrefstar#1#2{%
-            \@crefstarredtrue%
-            \cref@fullref{#1}{#2}%
-            \@crefstarredfalse}
-        \else%
-          \DeclareRobustCommand{\vref}{\cref@vref{cref}}
-          \DeclareRobustCommand{\Vref}{\cref@vref{Cref}}
-          \DeclareRobustCommand{\vrefrange}{\cref@vrefrange{cref}}
-          \DeclareRobustCommand{\Vrefrange}{\cref@vrefrange{Cref}}
-          \DeclareRobustCommand{\fullref}{\cref@fullref{cref}}
-          \DeclareRobustCommand{\Fullref}{\cref@fullref{Cref}}
-        \fi%  end of test for hyperref
-    \fi%
-   }%  end of \AtBeginDocument
- }{}%  end of \@ifpackageloaded{varioref}
-\let\if@cref@legacyvarioref\iffalse
-\DeclareOption{legacyvarioref}{%
-  \PackageInfo{cleveref}{legacy `varioref' compatibility enabled}
-  \let\if@cref@legacyvarioref\iftrue}
 \DeclareOption{poorman}{%
-  \PackageInfo{cleveref}{option `poorman' loaded}
-  \gdef\cref@poorman@text{}
+  \PackageInfo{cleveref}{option `poorman' loaded}%
+  \gdef\cref@poorman@text{}%
   \AtBeginDocument{%
     \newwrite\@crefscript%
-    \immediate\openout\@crefscript=\jobname.sed}
-  \newif\if@cref@switched@language
+    \immediate\openout\@crefscript=\jobname.sed}%
+  \newif\if@cref@switched@language%
   \@ifpackageloaded{babel}{%
     \AtBeginDocument{%
-      \let\cref@old@select@language\select@language
+      \let\cref@old@select@language\select@language%
       \def\select@language{%
         \@cref@switched@languagetrue%
         \cref@writelanguagerules%
-        \cref@old@select@language}
-      \let\cref@old@foreign@language\foreign@language
+        \cref@old@select@language}%
+      \let\cref@old@foreign@language\foreign@language%
       \def\foreign@language{%
         \@cref@switched@languagetrue%
         \cref@writelanguagerules%
-        \cref@old@foreign@language}
+        \cref@old@foreign@language}%
       \edef\cref@inputlineno{\the\inputlineno}}%
-    }{}
+    }{}%
   \AtEndDocument{%
     \let\select@language\cref@old@select@language%
     \let\foreign@language\cref@old@foreign@language%
-    \cref@writelanguagerules}
+    \cref@writelanguagerules}%
   \def\cref@writelanguagerules{%
     \begingroup%
       \if@cref@switched@language%
@@ -2574,12 +3159,12 @@
     \begingroup%
       \newif\if@not@eof%
       \def\@eof{\par }%
-      \catcode`.=13 \catcode`*=13
-      \catcode`[=13 \catcode`]=13
+      \catcode`.=13 \catcode`*=13%
+      \catcode`[=13 \catcode`]=13%
       \catcode`^=13 \catcode`$=13 %$
-      \catcode`\=0 \catcode`<=1 \catcode`>=2
-      \catcode`\\=13 \catcode`\{=12 \catcode`\}=12 \catcode`_=12
-      \lccode`/=92
+      \catcode`\=0 \catcode`<=1 \catcode`>=2%
+      \catcode`\\=13 \catcode`\{=12 \catcode`\}=12 \catcode`_=12%
+      \lccode`/=92%
       \lccode`~=92\lowercase{\def~{\string/\string/}}%
       \lccode`~=42\lowercase{\def~{\string/\string*}}%
       \lccode`~=46\lowercase{\def~{\string/\string.}}%
@@ -2587,7 +3172,7 @@
       \lccode`~=93\lowercase{\def~{\string/\string]}}%
       \lccode`~=94\lowercase{\def~{\string/\string^}}%
       \lccode`~=36\lowercase{\def~{\string/\string$}}% $
-      \lccode`~=0 \lccode`/=0 \catcode`~=12
+      \lccode`~=0 \lccode`/=0 \catcode`~=12%
       \def\cref@poorman@text{}%
       \immediate\read\@crefscript to \@tempa%
       \ifx\@tempa\@eof%
@@ -2609,9 +3194,9 @@
     \endgroup%
     \immediate\closein\@crefscript%
     \begingroup%
-      \lccode`|=92 \lccode`<=123 \lccode`>=125 \lccode`C=67
-      \lowercase{\def\@tempa{%[
-          s/||label|[[^]]*|]/||label/g}}
+      \lccode`|=92 \lccode`<=123 \lccode`>=125 \lccode`C=67%
+      \lowercase{\def\@tempa{%[|
+          s/||label|[[^]]*|]/||label/g}}%
       \expandafter\g@addto@macro\expandafter%
         \cref@poorman@text\expandafter{\@tempa^^J}%
       \lowercase{\edef\@tempa{s/||usepackage|(|[.*|]|)|<0,1|><cleveref>//g}}%
@@ -2678,11 +3263,11 @@
     \immediate\write\@crefscript{\cref@poorman@text}%
     \immediate\closeout\@crefscript%
   }%  end of \AtEndDocument
-  \def\cref@getmeaning#1{\expandafter\@cref@getmeaning\meaning#1\@nil}
-  \def\@cref@getmeaning#1->#2\@nil{#2}
+  \def\cref@getmeaning#1{\expandafter\@cref@getmeaning\meaning#1\@nil}%
+  \def\@cref@getmeaning#1->#2\@nil{#2}%
   \def\cref@writescript#1#2{%
     \edef\@tempa{\cref@getmeaning{\cref@poorman@text}}%
-    \immediate\write\@crefscript{#1 s/#2/\@tempa/g}}
+    \immediate\write\@crefscript{#1 s/#2/\@tempa/g}}%
   \if@cref@hyperrefloaded\relax%  hyperref loaded
     \def\@crefnostar#1#2{%
       \gdef\cref@poorman@text{}%
@@ -2693,7 +3278,7 @@
         \else%
           \cref@writescript{}{\string\Cref\string{#2\string}}%
         \fi}%
-      \@tempa#1\@nil}
+      \@tempa#1\@nil}%
     \def\@crefstar#1#2{%
       \gdef\cref@poorman@text{}%
       \@crefstarredtrue\@cref{#1}{#2}\@crefstarredfalse%
@@ -2703,7 +3288,7 @@
         \else%
           \cref@writescript{}{\string\Cref*\string{#2\string}}%
         \fi}%
-      \@tempa#1\@nil}
+      \@tempa#1\@nil}%
     \def\@crefrangenostar#1#2#3{%
       \gdef\cref@poorman@text{}%
       \@setcrefrange{#2}{#3}{#1}{}%
@@ -2715,7 +3300,7 @@
           \cref@writescript{}{%
             \string\Crefrange\string{#2\string}\string{#3\string}}%
         \fi}%
-      \@tempa#1\@nil}
+      \@tempa#1\@nil}%
     \def\@crefrangestar#1#2#3{%
       \gdef\cref@poorman@text{}%
       \@crefstarredtrue\@setcrefrange{#2}{#3}{#1}{}\@crefstarredfalse%
@@ -2727,81 +3312,278 @@
           \cref@writescript{}{%
             \string\Crefrange*\string{#2\string}\string{#3\string}}%
         \fi}%
-      \@tempa#1\@nil}
+      \@tempa#1\@nil}%
+    \def\@cpagerefnostar#1#2{%
+      \gdef\cref@poorman@text{}%
+      \@cpageref{#1}{#2}{\@setcpageref}{\@setcpagerefrange}%
+      \def\@tempa##1##2\@nil{%
+        \if##1c%
+          \cref@writescript{}{\string\cpageref\string{#2\string}}%
+        \else%
+          \cref@writescript{}{\string\Cpageref\string{#2\string}}%
+        \fi}%
+      \@tempa#1\@nil}%
+    \def\@cpagerefstar#1#2{%
+      \gdef\cref@poorman@text{}%
+      \@crefstarredtrue%
+      \@cpageref{#1}{#2}{\@setcpageref}{\@setcpagerefrange}%
+      \@crefstarredfalse%
+      \def\@tempa##1##2\@nil{%
+        \if##1c%
+          \cref@writescript{}{\string\cpageref*\string{#2\string}}%
+        \else%
+          \cref@writescript{}{\string\Cpageref*\string{#2\string}}%
+        \fi}%
+      \@tempa#1\@nil}%
+    \def\@cpagerefrangenostar#1#2#3{%
+      \gdef\cref@poorman@text{}%
+      \@setcpagerefrange{#2}{#3}{#1}{}%
+      \def\@tempa##1##2\@nil{%
+        \if##1c%
+          \cref@writescript{}{%
+            \string\cpagerefrange\string{#2\string}\string{#3\string}}%
+        \else%
+          \cref@writescript{}{%
+            \string\Cpagerefrange\string{#2\string}\string{#3\string}}%
+        \fi}%
+      \@tempa#1\@nil}%
+    \def\@cpagerefrangestar#1#2#3{%
+      \gdef\cref@poorman@text{}%
+      \@crefstarredtrue%
+      \@setcpagerefrange{#2}{#3}{#1}{}%
+      \@crefstarredfalse%
+      \def\@tempa##1##2\@nil{%
+        \if##1c%
+          \cref@writescript{}{%
+            \string\cpagerefrange*\string{#2\string}\string{#3\string}}%
+        \else%
+          \cref@writescript{}{%
+            \string\Cpagerefrange*\string{#2\string}\string{#3\string}}%
+        \fi}%
+      \@tempa#1\@nil}%
+    \def\@labelcrefnostar#1{%
+      \gdef\cref@poorman@text{}%
+      \@cref{labelcref}{#1}%
+      \cref@writescript{}{\string\labelcref\string{#1\string}}}%
+    \def\@labelcrefstar#1{%
+      \gdef\cref@poorman@text{}%
+      \@crefstarredtrue%
+      \@cref{labelcref}{#1}%
+      \@crefstarredfalse%
+      \cref@writescript{}{\string\labelcref*\string{#1\string}}}%
+    \def\@labelcpagerefnostar#1{%
+      \gdef\cref@poorman@text{}%
+      \@cpageref{labelcref}{#1}{\@setcpageref}{\@setcpagerefrange}%
+      \cref@writescript{}{\string\labelcpageref\string{#1\string}}}%
+    \def\@labelcpagerefstar#1{%
+      \gdef\cref@poorman@text{}%
+      \@crefstarredtrue%
+      \@cpageref{labelcref}{#1}{\@setcpageref}{\@setcpagerefrange}%
+      \@crefstarredfalse%
+      \cref@writescript{}{\string\labelcpageref*\string{#1\string}}}%
   \else%  hyperref not loaded
     \DeclareRobustCommand{\cref}[1]{%
-      \edef\cref@poorman@text{}%
+      \gdef\cref@poorman@text{}%
       \@cref{cref}{#1}%
-      \cref@writescript{}{\string\cref\string{#1\string}}}
+      \cref@writescript{}{\string\cref\string{#1\string}}}%
     \DeclareRobustCommand{\Cref}[1]{%
-      \edef\cref@poorman@text{}%
+      \gdef\cref@poorman@text{}%
       \@cref{Cref}{#1}%
-      \cref@writescript{}{\string\Cref\string{#1\string}}}
+      \cref@writescript{}{\string\Cref\string{#1\string}}}%
     \DeclareRobustCommand{\crefrange}[2]{%
-      \edef\cref@poorman@text{}%
+      \gdef\cref@poorman@text{}%
       \@setcrefrange{#1}{#2}{cref}{}%
       \cref@writescript{}{%
-        \string\crefrange\string{#1\string}\string{#2\string}}}
+        \string\crefrange\string{#1\string}\string{#2\string}}}%
     \DeclareRobustCommand{\Crefrange}[2]{%
-      \edef\cref@poorman@text{}%
+      \gdef\cref@poorman@text{}%
       \@setcrefrange{#1}{#2}{Cref}{}%
       \cref@writescript{}{%
-        \string\Crefrange\string{#1\string}\string{#2\string}}}
+        \string\Crefrange\string{#1\string}\string{#2\string}}}%
+    \DeclareRobustCommand{\cpageref}[1]{%
+      \gdef\cref@poorman@text{}%
+      \@cpageref{cref}{#1}{\@setcpageref}{\@setcpagerefrange}%
+      \cref@writescript{}{\string\cpageref\string{#1\string}}}%
+    \DeclareRobustCommand{\Cpageref}[1]{%
+      \gdef\cref@poorman@text{}%
+      \@cpageref{Cref}{#1}{\@setcpageref}{\@setcpagerefrange}%
+      \cref@writescript{}{\string\Cpageref\string{#1\string}}}%
+    \DeclareRobustCommand{\cpagerefrange}[2]{%
+      \gdef\cref@poorman@text{}%
+      \@setcpagerefrange{#1}{#2}{cref}{}%
+      \cref@writescript{}{%
+        \string\cpagerefrange\string{#1\string}\string{#2\string}}}%
+    \DeclareRobustCommand{\Cpagerefrange}[2]{%
+      \gdef\cref@poorman@text{}%
+      \@setcpagerefrange{#1}{#2}{Cref}{}%
+      \cref@writescript{}{%
+        \string\Cpagerefrange\string{#1\string}\string{#2\string}}}%
+    \DeclareRobustCommand{\labelcref}[1]{%
+      \gdef\cref@poorman@text{}%
+      \@cref{labelcref}{#1}%
+      \cref@writescript{}{\string\labelcref\string{#1\string}}}%
+    \DeclareRobustCommand{\labelcpageref}[1]{%
+      \gdef\cref@poorman@text{}%
+      \@cpageref{labelcref}{#1}{\@setcpageref}{\@setcpagerefrange}%
+      \cref@writescript{}{\string\labelcpageref\string{#1\string}}}%
   \fi%  end of test for hyperref
+  \DeclareRobustCommand{\namecref}[1]{%
+    \gdef\cref@poorman@text{}%
+    \@setnamecref{cref}{#1}{}{}%
+    \cref@writescript{}{\string\namecref\string{#1\string}}}%
+  \DeclareRobustCommand{\nameCref}[1]{%
+    \gdef\cref@poorman@text{}%
+    \@setnamecref{Cref}{#1}{}{}%
+    \cref@writescript{}{\string\nameCref\string{#1\string}}}%
+  \DeclareRobustCommand{\lcnamecref}[1]{%
+    \gdef\cref@poorman@text{}%
+    \@setnamecref{Cref}{#1}{}{\MakeLowercase}%
+    \cref@writescript{}{\string\lcnamecref\string{#1\string}}}%
+  \DeclareRobustCommand{\namecrefs}[1]{%
+    \gdef\cref@poorman@text{}%
+    \@setnamecref{cref}{#1}{@plural}{}%
+    \cref@writescript{}{\string\namecrefs\string{#1\string}}}%
+  \DeclareRobustCommand{\nameCrefs}[1]{%
+    \gdef\cref@poorman@text{}%
+    \@setnamecref{Cref}{#1}{@plural}{}%
+    \cref@writescript{}{\string\nameCrefs\string{#1\string}}}%
+  \DeclareRobustCommand{\lcnamecrefs}[1]{%
+    \gdef\cref@poorman@text{}%
+    \@setnamecref{Cref}{#1}{@plural}{\MakeLowercase}%
+    \cref@writescript{}{\string\lcnamecrefs\string{#1\string}}}%
+  \def\@setcref@pairgroupconjunction{%
+    \crefpairgroupconjunction%
+    \expandafter\g@addto@macro\expandafter\cref@poorman@text%
+      \expandafter{\crefpairgroupconjunction}}%
+  \def\@setcref@middlegroupconjunction{%
+    \crefmiddlegroupconjunction%
+    \expandafter\g@addto@macro\expandafter\cref@poorman@text%
+      \expandafter{\crefmiddlegroupconjunction}}%
+  \def\@setcref@lastgroupconjunction{%
+    \creflastgroupconjunction%
+    \expandafter\g@addto@macro\expandafter\cref@poorman@text%
+      \expandafter{\creflastgroupconjunction}}%
+  \let\old@@setcref\@@setcref%
+  \let\old@@setcrefrange\@@setcrefrange%
+  \let\old@@setcpageref\@@setcpageref%
+  \let\old@@setcpagerefrange\@@setcpagerefrange%
+  \if@cref@hyperrefloaded\relax%  hyperref loaded
+    \def\@@setcref#1#2{%
+      \old@@setcref{#1}{#2}%
+      \if@crefstarred%
+        \expandafter\g@addto@macro\expandafter\cref@poorman@text%
+          \expandafter{#1{\ref*{#2}}{}{}}%
+      \else%
+        \expandafter\g@addto@macro\expandafter\cref@poorman@text%
+          \expandafter{#1{\ref{#2}}{}{}}%
+      \fi}%
+    \def\@@setcrefrange#1#2#3{%
+      \old@@setcrefrange{#1}{#2}{#3}%
+      \if@crefstarred%
+        \expandafter\g@addto@macro\expandafter\cref@poorman@text%
+          \expandafter{#1{\ref*{#2}}{\ref*{#3}}{}{}{}{}}%
+      \else%
+        \expandafter\g@addto@macro\expandafter\cref@poorman@text%
+          \expandafter{#1{\ref{#2}}{\ref{#3}}{}{}{}{}}%
+      \fi}%
+    \def\@@setcpageref#1#2{%
+      \old@@setcpageref{#1}{#2}%
+      \if@crefstarred%
+        \expandafter\g@addto@macro\expandafter\cref@poorman@text%
+          \expandafter{#1{\pageref*{#2}}{}{}}%
+      \else%
+        \expandafter\g@addto@macro\expandafter\cref@poorman@text%
+          \expandafter{#1{\pageref{#2}}{}{}}%
+      \fi}%
+    \def\@@setcpagerefrange#1#2#3{%
+      \old@@setcpagerefrange{#1}{#2}{#3}%
+      \if@crefstarred%
+        \expandafter\g@addto@macro\expandafter\cref@poorman@text%
+          \expandafter{#1{\pageref*{#2}}{\pageref*{#3}}{}{}{}{}}%
+      \else%
+        \expandafter\g@addto@macro\expandafter\cref@poorman@text%
+          \expandafter{#1{\pageref{#2}}{\pageref{#3}}{}{}{}{}}%
+      \fi}%
+  \else%  hyperref not loaded
+    \def\@@setcref#1#2{%
+      \old@@setcref{#1}{#2}%
+      \expandafter\g@addto@macro\expandafter{%
+        \expandafter\cref@poorman@text\expandafter}%
+        \expandafter{#1{\ref{#2}}{}{}}}%
+    \def\@@setcrefrange#1#2#3{%
+      \old@@setcrefrange{#1}{#2}{#3}%
+      \expandafter\g@addto@macro%
+        \expandafter{\expandafter\cref@poorman@text\expandafter}%
+        \expandafter{#1{\ref{#2}}{\ref{#3}}{}{}{}{}}}%
+    \def\@@setcpageref#1#2{%
+      \old@@setcpageref{#1}{#2}%
+      \expandafter\g@addto@macro\expandafter{%
+        \expandafter\cref@poorman@text\expandafter}%
+        \expandafter{#1{\pageref{#2}}{}{}}}%
+    \def\@@setcpagerefrange#1#2#3{%
+      \old@@setcpagerefrange{#1}{#2}{#3}%
+      \expandafter\g@addto@macro%
+        \expandafter{\expandafter\cref@poorman@text\expandafter}%
+        \expandafter{#1{\pageref{#2}}{\pageref{#3}}{}{}{}{}}}%
+  \fi%  end of hyperref test
+  \let\old@@setnamecref\@@setnamecref%
+  \def\@@setnamecref#1#2{%
+    \old@@setnamecref{#1}{#2}%
+    \expandafter\def\expandafter\@tempa\expandafter{#1}%
+    \def\@tempb{#2}%
+    \expandafter\expandafter\expandafter\g@addto@macro%
+      \expandafter\expandafter\expandafter{%
+      \expandafter\expandafter\expandafter\cref@poorman@text%
+      \expandafter\expandafter\expandafter}%
+      \expandafter\expandafter\expandafter{\expandafter\@tempb\@tempa}}%
   \@ifpackageloaded{varioref}{%
     \AtBeginDocument{%
-      \if@cref@legacyvarioref%
-        \DeclareRobustCommand{\vref}{%
-          \@ifstar{\cref@vrefstar{cref}}{\cref@vref{cref}}}
-        \def\cref@vrefstar#1#2{%
-          \@crefstarredtrue\cref@vref{#1}{#2}\@crefstarredfalse}
-      \fi%
+      \def\@@vpageref#1[#2]#3{%
+        \gdef\cref@poorman@text{}%
+        \cref@@vpageref{#1}[#2]{#3}%
+        \cref@writescript{}{\string\vpageref\string{#3\string}}}%
+      \let\old@cref@vref\cref@vref%
       \def\cref@vref#1#2{%
         \gdef\cref@poorman@text{}%
-        \if@cref@legacyvarioref%
-          \leavevmode\unskip\vref@space%
-        \fi%
-        \begingroup%
-          \let\if@tmp\if@crefstarred%
-          \if@cref@legacyvarioref\@crefstarredfalse\fi%
-          \@cref{#1}{#2} % space here is deliberate
-          \let\if@crefstarred\if@tmp%
-          \def\@tempstack{#2,\@nil}%
-          \cref@stack@topandbottom{\@tempstack}{\@firstref}{\@lastref}%
-          \ifx\@lastref\@empty%
-            \vpageref[\unskip]{#2}%
-            \g@addto@macro\cref@poorman@text{ \vpageref[\unskip]{#2}}%
-          \else%
-            \g@addto@macro\cref@poorman@text{ }%
-            \edef\@tempa{{\@firstref}{\@lastref}}%
-            \expandafter\def\expandafter\@tempa\expandafter{%
-              \expandafter[\expandafter\unskip\expandafter]%
-              \@tempa}%
-            \expandafter\vpagerefrange\@tempa%
-            \expandafter\g@addto@macro\expandafter\cref@poorman@text%
-              \expandafter{\expandafter\vpagerefrange\@tempa}%
-          \fi%
-          \def\@tempa##1##2\@nil{%
-            \if##1c%
-              \if@crefstarred%
-                \cref@writescript{}{\string\vref*\string{#2\string}}%
-              \else%
-                \cref@writescript{}{\string\vref\string{#2\string}}%
-              \fi%
+        \old@cref@vref{#1}{#2}%
+        \def\@tempa##1##2\@nil{%
+          \if##1c%
+            \if@crefstarred%
+              \cref@writescript{}{\string\vref*\string{#2\string}}%
             \else%
-              \if@crefstarred%
-                \cref@writescript{}{\string\Vref*\string{#2\string}}%
-              \else%
-                \cref@writescript{}{\string\Vref\string{#2\string}}%
-              \fi%
-            \fi}%
-          \@tempa#1\@nil%
-        \endgroup}
+              \cref@writescript{}{\string\vref\string{#2\string}}%
+            \fi%
+          \else%
+            \if@crefstarred%
+              \cref@writescript{}{\string\Vref*\string{#2\string}}%
+            \else%
+              \cref@writescript{}{\string\Vref\string{#2\string}}%
+            \fi%
+          \fi}%
+        \@tempa#1\@nil}%
+      \let\old@cref@fullref\cref@fullref%
+      \def\cref@fullref#1#2{%
+        \gdef\cref@poorman@text{}%
+        \old@cref@fullref{#1}{#2}%
+        \def\@tempa##1##2\@nil{%
+          \if##1c%
+            \if@crefstarred%
+              \cref@writescript{}{\string\fullref*\string{#2\string}}%
+            \else%
+              \cref@writescript{}{\string\fullref\string{#2\string}}%
+            \fi%
+          \else%
+            \if@crefstarred%
+              \cref@writescript{}{\string\Fullref*\string{#2\string}}%
+            \else%
+              \cref@writescript{}{\string\Fullref\string{#2\string}}%
+            \fi%
+          \fi}%
+        \@tempa#1\@nil}%
+      \let\old@cref@vrefrange\cref@vrefrange%
       \def\cref@vrefrange#1#2#3{%
         \gdef\cref@poorman@text{}%
-        \@setcrefrange{#2}{#3}{#1}{} \vpagerefrange[\unskip]{#2}{#3}%
-        \g@addto@macro\cref@poorman@text%
-          { \vpagerefrange[\unskip]{#2}{#3}}%
+        \old@cref@vrefrange{#1}{#2}{#3}%
         \def\@tempa##1##2\@nil{%
           \if##1c%
             \if@crefstarred%
@@ -2820,141 +3602,74 @@
                 \string\Vrefrange\string{#2\string}\string{#3\string}}%
             \fi%
           \fi}%
-        \@tempa#1\@nil}
-      \def\cref@fullref#1#2{%
-        \gdef\cref@poorman@text{}%
-        \begingroup%
-          \@cref{#1}{#2} % space here is deliberate
-          \def\@tempstack{#2,\@nil}%
-          \cref@stack@topandbottom{\@tempstack}{\@firstref}{\@lastref}%
-          \ifx\@lastref\@empty%
-            \reftextfaraway{#2}%
-            \def\@pageref{\reftextfaraway{#1}}%
-          \else%
-            \expandafter\vrefpagenum\expandafter%
-              \@tempa\expandafter{\@firstref}%
-            \expandafter\vrefpagenum\expandafter%
-              \@tempb\expandafter{\@lastref}%
-            \ifx\@tempa\@tempb%
-              \expandafter\reftextfaraway\expandafter{\@firstref}%
-              \expandafter\def\expandafter\@pageref\expandafter{%
-                \expandafter\reftextfaraway\expandafter{\@firstref}}%
-            \else%
-              \edef\@tempa{{\@firstref}{\@lastref}}%
-              \expandafter\reftextpagerange\@tempa%
-              \expandafter\def\expandafter\@pageref\expandafter{%
-                \expandafter\reftextpagerange\@tempa}%
-            \fi%
-          \fi%
-          \g@addto@macro\cref@poorman@text{ }%
-          \expandafter\g@addto@macro\expandafter\cref@poorman@text%
-            \expandafter{\@pageref}%
-          \def\@tempa##1##2\@nil{%
-            \if##1c%
-              \if@crefstarred%
-                \cref@writescript{}{\string\fullref*\string{#2\string}}%
-              \else%
-                \cref@writescript{}{\string\fullref\string{#2\string}}%
-              \fi%
-            \else%
-              \if@crefstarred%
-                \cref@writescript{}{\string\Fullref*\string{#2\string}}%
-              \else%
-                \cref@writescript{}{\string\Fullref\string{#2\string}}%
-              \fi%
-            \fi}%
-          \@tempa#1\@nil%
-        \endgroup}
+        \@tempa#1\@nil}%
+      \def\@@setvpageref#1[#2]#3{%
+        \cref@old@@vpageref{#1}[#2]{#3}%
+        \g@addto@macro\cref@poorman@text{\vpageref{#3}}}%
+      \def\@@setvpagerefrange[#1]#2#3{%
+        \vpagerefrange[#1]{#2}{#3}%
+        \g@addto@macro\cref@poorman@text{\vpagerefrange{#2}{#3}}}%
+      \def\@@setfullpageref#1{%
+        \reftextfaraway{#1}%
+        \g@addto@macro\cref@poorman@text{\reftextfaraway{#1}}}%
+      \def\@@setfullpagerefrange#1#2{%
+        \reftextpagerange{#1}{#2}%
+        \g@addto@macro\cref@poorman@text{\reftextpagerange{#1}{#2}}}%
+      \def\@setcref@space{ % space here is deliberate
+        \g@addto@macro\cref@poorman@text{ }}%
+      \def\@setcref@pairconjunction{%
+        \crefpairconjunction%
+        \expandafter\g@addto@macro\expandafter\cref@poorman@text%
+          \expandafter{\crefpairconjunction}}%
+      \def\@setcref@middleconjunction{%
+        \crefmiddleconjunction%
+        \expandafter\g@addto@macro\expandafter\cref@poorman@text%
+          \expandafter{\crefmiddleconjunction}}%
+      \def\@setcref@lastconjunction{%
+        \creflastconjunction%
+        \expandafter\g@addto@macro\expandafter\cref@poorman@text%
+          \expandafter{\creflastconjunction}}%
     }% end of \AtBeginDocument
   }{}% end of \@ifpackageloaded{varioref}
-  \def\@setcref@pairgroupconjunction{%
-    \crefpairgroupconjunction%
-    \expandafter\g@addto@macro\expandafter\cref@poorman@text%
-      \expandafter{\crefpairgroupconjunction}}
-  \def\@setcref@middlegroupconjunction{%
-    \crefmiddlegroupconjunction%
-    \expandafter\g@addto@macro\expandafter\cref@poorman@text%
-      \expandafter{\crefmiddlegroupconjunction}}
-  \def\@setcref@lastgroupconjunction{%
-    \creflastgroupconjunction%
-    \expandafter\g@addto@macro\expandafter\cref@poorman@text%
-      \expandafter{\creflastgroupconjunction}}
-  \if@cref@hyperrefloaded\relax%  hyperref loaded
-    \def\@@setcref#1#2{%
-      \cref@getlabel{#2}{\@templabel}%
-      \if@crefstarred%
-        #1{\@templabel}{}{}%
-        \expandafter\g@addto@macro\expandafter\cref@poorman@text%
-          \expandafter{#1{\ref*{#2}}{}{}}%
-      \else%
-        \edef\@templink{\cref@hyperref{#2}}%
-        #1{\@templabel}{\hyper@linkstart{link}{\@templink}}%
-          {\hyper@linkend}%
-        \expandafter\g@addto@macro\expandafter\cref@poorman@text%
-          \expandafter{#1{\ref{#2}}{}{}}%
-      \fi}
-    \def\@@setcrefrange#1#2#3{%
-      \cref@getlabel{#2}{\@labela}%
-      \cref@getlabel{#3}{\@labelb}%
-      \if@crefstarred%
-        #1{\@labela}{\@labelb}{}{}{}{}%
-        \expandafter\g@addto@macro\expandafter\cref@poorman@text%
-          \expandafter{#1{\ref*{#2}}{\ref*{#3}}{}{}{}{}}%
-      \else%
-        \edef\@linka{\cref@hyperref{#2}}%
-        \edef\@linkb{\cref@hyperref{#3}}%
-        #1{\@labela}{\@labelb}%
-          {\hyper@linkstart{link}{\@linka}}{\hyper@linkend}%
-          {\hyper@linkstart{link}{\@linkb}}{\hyper@linkend}%
-        \expandafter\g@addto@macro\expandafter\cref@poorman@text%
-          \expandafter{#1{\ref{#2}}{\ref{#3}}{}{}{}{}}%
-      \fi}
-  \else%  hyperref not loaded
-    \let\old@@setcref\@@setcref%
-    \let\old@@setcrefrange\@@setcrefrange%
-    \def\@@setcref#1#2{%
-      \old@@setcref{#1}{#2}%
-      \expandafter\g@addto@macro\expandafter{%
-        \expandafter\cref@poorman@text\expandafter}\expandafter{%
-        #1{\ref{#2}}{}{}}}
-    \def\@@setcrefrange#1#2#3{%
-      \old@@setcrefrange{#1}{#2}{#3}%
-      \expandafter\g@addto@macro%
-        \expandafter{\expandafter\cref@poorman@text\expandafter}%
-        \expandafter{#1{\ref{#2}}{\ref{#3}}{}{}{}{}}}
-  \fi%  end of hyperref test
 }%  end of poorman option
-\newif\if@cref@sort
-\newif\if@cref@compress
-\@cref@sorttrue
-\@cref@compresstrue
+\newif\if@cref@sort%
+\newif\if@cref@compress%
+\@cref@sorttrue%
+\@cref@compresstrue%
 \DeclareOption{sort}{%
-  \PackageInfo{cleveref}{sorting but not compressing references}
-  \@cref@sorttrue
-  \@cref@compressfalse}
+  \PackageInfo{cleveref}{sorting but not compressing references}%
+  \@cref@sorttrue%
+  \@cref@compressfalse}%
 \DeclareOption{compress}{%
-  \PackageInfo{cleveref}{compressing but not sorting references}
-  \@cref@sortfalse
-  \@cref@compresstrue}
+  \PackageInfo{cleveref}{compressing but not sorting references}%
+  \@cref@sortfalse%
+  \@cref@compresstrue}%
 \DeclareOption{sort&compress}{%
-  \PackageInfo{cleveref}{sorting and compressing references}
-  \@cref@sorttrue
-  \@cref@compresstrue}
+  \PackageInfo{cleveref}{sorting and compressing references}%
+  \@cref@sorttrue%
+  \@cref@compresstrue}%
 \DeclareOption{nosort}{%
-  \PackageInfo{cleveref}{neither sorting nor compressing references}
-  \@cref@sortfalse
-  \@cref@compressfalse}
-\newif\if@cref@capitalise
-\@cref@capitalisefalse
+  \PackageInfo{cleveref}{neither sorting nor compressing references}%
+  \@cref@sortfalse%
+  \@cref@compressfalse}%
+\newif\if@cref@capitalise%
+\@cref@capitalisefalse%
 \DeclareOption{capitalise}{%
-  \PackageInfo{cleveref}{always capitalise cross-reference names}
-  \@cref@capitalisetrue}
+  \PackageInfo{cleveref}{always capitalise cross-reference names}%
+  \@cref@capitalisetrue}%
 \DeclareOption{capitalize}{%
-  \PackageInfo{cleveref}{always capitalise cross-reference names}
-  \@cref@capitalisetrue}
-\crefdefaultlabelformat{#2#1#3}
-\creflabelformat{equation}{\textup{(#2#1#3)}}
-\@labelcrefdefinedefaultformats
+  \PackageInfo{cleveref}{always capitalise cross-reference names}%
+  \@cref@capitalisetrue}%
+\newif\if@cref@nameinlink%
+\@cref@nameinlinkfalse%
+\DeclareOption{nameinlink}{%
+  \PackageInfo{cleveref}{include cross-reference names in hyperlinks}%
+  \@cref@nameinlinktrue}%
+\newif\if@cref@abbrev%
+\@cref@abbrevtrue%
+\DeclareOption{noabbrev}{%
+  \PackageInfo{cleveref}{no abbreviation of names}%
+  \@cref@abbrevfalse}%
 \def\cref@addto#1#2{%
   \@temptokena{#2}%
   \ifx#1\undefined%
@@ -2963,11 +3678,21 @@
     \toks@\expandafter{#1}%
     \edef#1{\the\toks@\the\@temptokena}%
   \fi%
-  \@temptokena{}\toks@\@temptokena%
-}
-\@onlypreamble\cref@addto
+  \@temptokena{}\toks@\@temptokena}%
+\@onlypreamble\cref@addto%
+\long\def\cref@addlanguagedefs#1#2{%
+  \@ifpackageloaded{polyglossia}%
+    {\AtBeginDocument{%
+        \ifcsdef{#1@loaded}{%
+          \expandafter\cref@addto\csname captions#1\endcsname{#2}}{}}}%
+    {\@ifpackageloaded{babel}{%
+      \edef\@curroptions{\@ptionlist{\@currname.\@currext}}%
+      \@expandtwoargs\in@{,#1,}{,\@classoptionslist,\@curroptions,}%
+      \ifin@%
+        \AtBeginDocument{%
+          \expandafter\cref@addto\csname extras#1\endcsname{#2}}%
+      \fi}{}}}%
 \DeclareOption{english}{%
-  \PackageInfo{cleveref}{loaded `english' language definitions}
   \AtBeginDocument{%
     \def\crefrangeconjunction@preamble{ to\nobreakspace}%
     \def\crefrangepreconjunction@preamble{}%
@@ -2978,15 +3703,17 @@
     \def\crefpairgroupconjunction@preamble{ and\nobreakspace}%
     \def\crefmiddlegroupconjunction@preamble{, }%
     \def\creflastgroupconjunction@preamble{, and\nobreakspace}%
+ %
     \Crefname@preamble{equation}{Equation}{Equations}%
+    \Crefname@preamble{figure}{Figure}{Figures}%
+    \Crefname@preamble{table}{Table}{Tables}%
+    \Crefname@preamble{page}{Page}{Pages}%
     \Crefname@preamble{part}{Part}{Parts}%
     \Crefname@preamble{chapter}{Chapter}{Chapters}%
     \Crefname@preamble{section}{Section}{Sections}%
     \Crefname@preamble{appendix}{Appendix}{Appendices}%
     \Crefname@preamble{enumi}{Item}{Items}%
     \Crefname@preamble{footnote}{Footnote}{Footnotes}%
-    \Crefname@preamble{figure}{Figure}{Figures}%
-    \Crefname@preamble{table}{Table}{Tables}%
     \Crefname@preamble{theorem}{Theorem}{Theorems}%
     \Crefname@preamble{lemma}{Lemma}{Lemmas}%
     \Crefname@preamble{corollary}{Corollary}{Corollaries}%
@@ -2999,16 +3726,23 @@
     \Crefname@preamble{algorithm}{Algorithm}{Algorithms}%
     \Crefname@preamble{listing}{Listing}{Listings}%
     \Crefname@preamble{line}{Line}{Lines}%
-    \if@cref@capitalise%
-      \crefname@preamble{equation}{Eq.}{Eqs.}%
+ %
+    \if@cref@capitalise%  capitalise set
+      \if@cref@abbrev%
+        \crefname@preamble{equation}{Eq.}{Eqs.}%
+        \crefname@preamble{figure}{Fig.}{Figs.}%
+      \else%
+        \crefname@preamble{equation}{Equation}{Equations}%
+        \crefname@preamble{figure}{Figure}{Figures}%
+      \fi%
+      \crefname@preamble{page}{Page}{Pages}%
+      \crefname@preamble{table}{Table}{Tables}%
       \crefname@preamble{part}{Part}{Parts}%
       \crefname@preamble{chapter}{Chapter}{Chapters}%
       \crefname@preamble{section}{Section}{Sections}%
       \crefname@preamble{appendix}{Appendix}{Appendices}%
       \crefname@preamble{enumi}{Item}{Items}%
       \crefname@preamble{footnote}{Footnote}{Footnotes}%
-      \crefname@preamble{figure}{Fig.}{Figs.}%
-      \crefname@preamble{table}{Table}{Tables}%
       \crefname@preamble{theorem}{Theorem}{Theorems}%
       \crefname@preamble{lemma}{Lemma}{Lemmas}%
       \crefname@preamble{corollary}{Corollary}{Corollaries}%
@@ -3021,16 +3755,23 @@
       \crefname@preamble{algorithm}{Algorithm}{Algorithms}%
       \crefname@preamble{listing}{Listing}{Listings}%
       \crefname@preamble{line}{Line}{Lines}%
-    \else%
-      \crefname@preamble{equation}{eq.}{eqs.}%
+ %
+    \else%  capitalise unset
+      \if@cref@abbrev%
+        \crefname@preamble{equation}{eq.}{eqs.}%
+        \crefname@preamble{figure}{fig.}{figs.}%
+      \else%
+        \crefname@preamble{equation}{equation}{equations}%
+        \crefname@preamble{figure}{figure}{figures}%
+      \fi%
+      \crefname@preamble{page}{page}{pages}%
+      \crefname@preamble{table}{table}{tables}%
       \crefname@preamble{part}{part}{parts}%
       \crefname@preamble{chapter}{chapter}{chapters}%
       \crefname@preamble{section}{section}{sections}%
       \crefname@preamble{appendix}{appendix}{appendices}%
       \crefname@preamble{enumi}{item}{items}%
       \crefname@preamble{footnote}{footnote}{footnotes}%
-      \crefname@preamble{figure}{fig.}{figs.}%
-      \crefname@preamble{table}{table}{tables}%
       \crefname@preamble{theorem}{theorem}{theorems}%
       \crefname@preamble{lemma}{lemma}{lemmas}%
       \crefname@preamble{corollary}{corollary}{corollaries}%
@@ -3045,118 +3786,136 @@
       \crefname@preamble{line}{line}{lines}%
     \fi%
     \def\cref@language{english}%
-    \cref@addto\extrasenglish{%
-      \renewcommand{\crefrangeconjunction}{ to\nobreakspace}%
-      \renewcommand\crefrangepreconjunction{}%
-      \renewcommand\crefrangepostconjunction{}%
-      \renewcommand{\crefpairconjunction}{ and\nobreakspace}%
-      \renewcommand{\crefmiddleconjunction}{, }%
-      \renewcommand{\creflastconjunction}{ and\nobreakspace}%
-      \renewcommand{\crefpairgroupconjunction}{ and\nobreakspace}%
-      \renewcommand{\crefmiddlegroupconjunction}{, }%
-      \renewcommand{\creflastgroupconjunction}{, and\nobreakspace}%
-      \Crefname{equation}{Equation}{Equations}%
-      \Crefname{part}{Part}{Parts}%
-      \Crefname{chapter}{Chapter}{Chapters}%
-      \Crefname{section}{Section}{Sections}%
-      \Crefname{subsection}{Section}{Sections}%
-      \Crefname{subsubsection}{Section}{Sections}%
-      \Crefname{appendix}{Appendix}{Appendices}%
-      \Crefname{subappendix}{Appendix}{Appendices}%
-      \Crefname{subsubappendix}{Appendix}{Appendices}%
-      \Crefname{subsubsubappendix}{Appendix}{Appendices}%
-      \Crefname{enumi}{Item}{Items}%
-      \Crefname{enumii}{Item}{Items}%
-      \Crefname{enumiii}{Item}{Items}%
-      \Crefname{enumiv}{Item}{Items}%
-      \Crefname{enumv}{Item}{Items}%
-      \Crefname{footnote}{Footnote}{Footnotes}%
-      \Crefname{figure}{Figure}{Figures}%
-      \Crefname{subfigure}{Figure}{Figures}%
-      \Crefname{table}{Table}{Tables}%
-      \Crefname{subtable}{Table}{Tables}%
-      \Crefname{theorem}{Theorem}{Theorems}%
-      \Crefname{lemma}{Lemma}{Lemmas}%
-      \Crefname{corollary}{Corollary}{Corollaries}%
-      \Crefname{proposition}{Proposition}{Propositions}%
-      \Crefname{definition}{Definition}{Definitions}%
-      \Crefname{result}{Result}{Results}%
-      \Crefname{example}{Example}{Examples}%
-      \Crefname{remark}{Remark}{Remarks}%
-      \Crefname{note}{Note}{Notes}%
-      \Crefname{algorithm}{Algorithm}{Algorithms}%
-      \Crefname{listing}{Listing}{Listings}%
-      \Crefname{line}{Line}{Lines}%
-      \if@cref@capitalise%
-        \crefname{equation}{Eq.}{Eqs.}%
-        \crefname{part}{Part}{Parts}%
-        \crefname{chapter}{Chapter}{Chapters}%
-        \crefname{section}{Section}{Sections}%
-        \crefname{subsection}{Section}{Sections}%
-        \crefname{subsubsection}{Section}{Sections}%
-        \crefname{appendix}{Appendix}{Appendices}%
-        \crefname{subappendix}{Appendix}{Appendices}%
-        \crefname{subsubappendix}{Appendix}{Appendices}%
-        \crefname{subsubsubappendix}{Appendix}{Appendices}%
-        \crefname{enumi}{Item}{Items}%
-        \crefname{enumii}{Item}{Items}%
-        \crefname{enumiii}{Item}{Items}%
-        \crefname{enumiv}{Item}{Items}%
-        \crefname{enumv}{Item}{Items}%
-        \crefname{footnote}{Footnote}{Footnotes}%
-        \crefname{figure}{Fig.}{Figs.}%
-        \crefname{subfigure}{Fig.}{Figs.}%
-        \crefname{table}{Table}{Tables}%
-        \crefname{subtable}{Table}{Tables}%
-        \crefname{theorem}{Theorem}{Theorems}%
-        \crefname{lemma}{Lemma}{Lemmas}%
-        \crefname{corollary}{Corollary}{Corollaries}%
-        \crefname{proposition}{Proposition}{Propositions}%
-        \crefname{definition}{Definition}{Definitions}%
-        \crefname{result}{Result}{Results}%
-        \crefname{example}{Example}{Examples}%
-        \crefname{remark}{Remark}{Remarks}%
-        \crefname{note}{Note}{Notes}%
-        \crefname{algorithm}{Algorithm}{Algorithms}%
-        \crefname{listing}{Listing}{Listings}%
-        \crefname{line}{Line}{Lines}%
-      \else%
-        \crefname{equation}{eq.}{eqs.}%
-        \crefname{part}{part}{parts}%
-        \crefname{chapter}{chapter}{chapters}%
-        \crefname{section}{section}{sections}%
-        \crefname{subsection}{section}{sections}%
-        \crefname{subsubsection}{section}{sections}%
-        \crefname{appendix}{appendix}{appendices}%
-        \crefname{subappendix}{appendix}{appendices}%
-        \crefname{subsubappendix}{appendix}{appendices}%
-        \crefname{subsubsubappendix}{appendix}{appendices}%
-        \crefname{enumi}{item}{items}%
-        \crefname{enumii}{item}{items}%
-        \crefname{enumiii}{item}{items}%
-        \crefname{enumiv}{item}{items}%
-        \crefname{enumv}{item}{items}%
-        \crefname{footnote}{footnote}{footnotes}%
-        \crefname{figure}{fig.}{figs.}%
-        \crefname{subfigure}{fig.}{figs.}%
-        \crefname{table}{table}{tables}%
-        \crefname{subtable}{table}{tables}%
-        \crefname{theorem}{theorem}{theorems}%
-        \crefname{lemma}{lemma}{lemmas}%
-        \crefname{corollary}{corollary}{corollaries}%
-        \crefname{proposition}{proposition}{propositions}%
-        \crefname{definition}{definition}{definitions}%
-        \crefname{result}{result}{results}%
-        \crefname{example}{example}{examples}%
-        \crefname{remark}{remark}{remarks}%
-        \crefname{note}{note}{notes}%
-        \crefname{algorithm}{algorithm}{algorithms}%
-        \crefname{listing}{listing}{listings}%
-        \crefname{line}{line}{lines}%
-      \fi%
-    }}}
+  }}% end \AtBeginDocument and \DeclareOption
+\cref@addlanguagedefs{english}{%
+  \PackageInfo{cleveref}{loaded `english' language definitions}%
+  \renewcommand{\crefrangeconjunction}{ to\nobreakspace}%
+  \renewcommand\crefrangepreconjunction{}%
+  \renewcommand\crefrangepostconjunction{}%
+  \renewcommand{\crefpairconjunction}{ and\nobreakspace}%
+  \renewcommand{\crefmiddleconjunction}{, }%
+  \renewcommand{\creflastconjunction}{ and\nobreakspace}%
+  \renewcommand{\crefpairgroupconjunction}{ and\nobreakspace}%
+  \renewcommand{\crefmiddlegroupconjunction}{, }%
+  \renewcommand{\creflastgroupconjunction}{, and\nobreakspace}%
+ %
+  \Crefname{equation}{Equation}{Equations}%
+  \Crefname{figure}{Figure}{Figures}%
+  \Crefname{subfigure}{Figure}{Figures}%
+  \Crefname{table}{Table}{Tables}%
+  \Crefname{subtable}{Table}{Tables}%
+  \Crefname{page}{Page}{Pages}%
+  \Crefname{part}{Part}{Parts}%
+  \Crefname{chapter}{Chapter}{Chapters}%
+  \Crefname{section}{Section}{Sections}%
+  \Crefname{subsection}{Section}{Sections}%
+  \Crefname{subsubsection}{Section}{Sections}%
+  \Crefname{appendix}{Appendix}{Appendices}%
+  \Crefname{subappendix}{Appendix}{Appendices}%
+  \Crefname{subsubappendix}{Appendix}{Appendices}%
+  \Crefname{subsubsubappendix}{Appendix}{Appendices}%
+  \Crefname{enumi}{Item}{Items}%
+  \Crefname{enumii}{Item}{Items}%
+  \Crefname{enumiii}{Item}{Items}%
+  \Crefname{enumiv}{Item}{Items}%
+  \Crefname{enumv}{Item}{Items}%
+  \Crefname{footnote}{Footnote}{Footnotes}%
+  \Crefname{theorem}{Theorem}{Theorems}%
+  \Crefname{lemma}{Lemma}{Lemmas}%
+  \Crefname{corollary}{Corollary}{Corollaries}%
+  \Crefname{proposition}{Proposition}{Propositions}%
+  \Crefname{definition}{Definition}{Definitions}%
+  \Crefname{result}{Result}{Results}%
+  \Crefname{example}{Example}{Examples}%
+  \Crefname{remark}{Remark}{Remarks}%
+  \Crefname{note}{Note}{Notes}%
+  \Crefname{algorithm}{Algorithm}{Algorithms}%
+  \Crefname{listing}{Listing}{Listings}%
+  \Crefname{line}{Line}{Lines}%
+ %
+  \if@cref@capitalise%  capitalise set
+    \if@cref@abbrev%
+      \crefname{equation}{Eq.}{Eqs.}%
+      \crefname{figure}{Fig.}{Figs.}%
+      \crefname{subfigure}{Fig.}{Figs.}%
+    \else%
+      \crefname{equation}{Equation}{Equations}%
+      \crefname{figure}{Figure}{Figures}%
+      \crefname{subfigure}{Figure}{Figures}%
+    \fi%
+    \crefname{page}{Page}{Pages}%
+    \crefname{table}{Table}{Tables}%
+    \crefname{subtable}{Table}{Tables}%
+    \crefname{part}{Part}{Parts}%
+    \crefname{chapter}{Chapter}{Chapters}%
+    \crefname{section}{Section}{Sections}%
+    \crefname{subsection}{Section}{Sections}%
+    \crefname{subsubsection}{Section}{Sections}%
+    \crefname{appendix}{Appendix}{Appendices}%
+    \crefname{subappendix}{Appendix}{Appendices}%
+    \crefname{subsubappendix}{Appendix}{Appendices}%
+    \crefname{subsubsubappendix}{Appendix}{Appendices}%
+    \crefname{enumi}{Item}{Items}%
+    \crefname{enumii}{Item}{Items}%
+    \crefname{enumiii}{Item}{Items}%
+    \crefname{enumiv}{Item}{Items}%
+    \crefname{enumv}{Item}{Items}%
+    \crefname{footnote}{Footnote}{Footnotes}%
+    \crefname{theorem}{Theorem}{Theorems}%
+    \crefname{lemma}{Lemma}{Lemmas}%
+    \crefname{corollary}{Corollary}{Corollaries}%
+    \crefname{proposition}{Proposition}{Propositions}%
+    \crefname{definition}{Definition}{Definitions}%
+    \crefname{result}{Result}{Results}%
+    \crefname{example}{Example}{Examples}%
+    \crefname{remark}{Remark}{Remarks}%
+    \crefname{note}{Note}{Notes}%
+    \crefname{algorithm}{Algorithm}{Algorithms}%
+    \crefname{listing}{Listing}{Listings}%
+    \crefname{line}{Line}{Lines}%
+ %
+  \else%  capitalise unset
+    \if@cref@abbrev%
+      \crefname{equation}{eq.}{eqs.}%
+      \crefname{figure}{fig.}{figs.}%
+      \crefname{subfigure}{fig.}{figs.}%
+    \else%
+      \crefname{equation}{equation}{equations}%
+      \crefname{figure}{figure}{figures}%
+      \crefname{subfigure}{figure}{figures}%
+    \fi%
+    \crefname{table}{table}{tables}%
+    \crefname{subtable}{table}{tables}%
+    \crefname{page}{page}{pages}%
+    \crefname{part}{part}{parts}%
+    \crefname{chapter}{chapter}{chapters}%
+    \crefname{section}{section}{sections}%
+    \crefname{subsection}{section}{sections}%
+    \crefname{subsubsection}{section}{sections}%
+    \crefname{appendix}{appendix}{appendices}%
+    \crefname{subappendix}{appendix}{appendices}%
+    \crefname{subsubappendix}{appendix}{appendices}%
+    \crefname{subsubsubappendix}{appendix}{appendices}%
+    \crefname{enumi}{item}{items}%
+    \crefname{enumii}{item}{items}%
+    \crefname{enumiii}{item}{items}%
+    \crefname{enumiv}{item}{items}%
+    \crefname{enumv}{item}{items}%
+    \crefname{footnote}{footnote}{footnotes}%
+    \crefname{theorem}{theorem}{theorems}%
+    \crefname{lemma}{lemma}{lemmas}%
+    \crefname{corollary}{corollary}{corollaries}%
+    \crefname{proposition}{proposition}{propositions}%
+    \crefname{definition}{definition}{definitions}%
+    \crefname{result}{result}{results}%
+    \crefname{example}{example}{examples}%
+    \crefname{remark}{remark}{remarks}%
+    \crefname{note}{note}{notes}%
+    \crefname{algorithm}{algorithm}{algorithms}%
+    \crefname{listing}{listing}{listings}%
+    \crefname{line}{line}{lines}%
+  \fi}% end \cref@addlangagedefs
 \DeclareOption{german}{%
-  \PackageInfo{cleveref}{loaded `german' language definitions}
   \AtBeginDocument{%
     \def\crefrangeconjunction@preamble{ bis\nobreakspace}%
     \def\crefrangepreconjunction@preamble{}%
@@ -3167,18 +3926,20 @@
     \def\crefpairgroupconjunction@preamble{ und\nobreakspace}%
     \def\crefmiddlegroupconjunction@preamble{, }%
     \def\creflastgroupconjunction@preamble{ und\nobreakspace}%
+ %
     \Crefname@preamble{equation}{Gleichung}{Gleichungen}%
-    \Crefname@preamble{part}{Teil}{Teilen}%
+    \Crefname@preamble{figure}{Abbildung}{Abbildungen}%
+    \Crefname@preamble{table}{Tabelle}{Tabellen}%
+    \Crefname@preamble{page}{Seite}{Seiten}%
+    \Crefname@preamble{part}{Teil}{Teile}%
     \Crefname@preamble{chapter}{Kapitel}{Kapitel}%
     \Crefname@preamble{section}{Abschnitt}{Abschnitte}%
     \Crefname@preamble{appendix}{Anhang}{Anh\"ange}%
     \Crefname@preamble{enumi}{Punkt}{Punkte}%
     \Crefname@preamble{footnote}{Fu\ss note}{Fu\ss noten}%
-    \Crefname@preamble{figure}{Abbildung}{Abbildungen}%
-    \Crefname@preamble{table}{Tabelle}{Tabellen}%
-    \Crefname@preamble{theorem}{Theorem}{Theoremen}%
+    \Crefname@preamble{theorem}{Theorem}{Theoreme}%
     \Crefname@preamble{lemma}{Lemma}{Lemmata}%
-    \Crefname@preamble{corollary}{Korollar}{Korollaren}%
+    \Crefname@preamble{corollary}{Korollar}{Korollare}%
     \Crefname@preamble{proposition}{Satz}{S\"atze}%
     \Crefname@preamble{definition}{Definition}{Definitionen}%
     \Crefname@preamble{result}{Ergebnis}{Ergebnisse}%
@@ -3188,279 +3949,207 @@
     \Crefname@preamble{algorithm}{Algorithmus}{Algorithmen}%
     \Crefname@preamble{listing}{Listing}{Listings}%
     \Crefname@preamble{line}{Zeile}{Zeilen}%
-    \if@cref@capitalise%
-      \crefname@preamble{equation}{Gleichung}{Gleichungen}%
-      \crefname@preamble{part}{Teil}{Teilen}%
-      \crefname@preamble{chapter}{Kapitel}{Kapitel}%
-      \crefname@preamble{section}{Abschnitt}{Abschnitte}%
-      \crefname@preamble{appendix}{Anhang}{Anh\"ange}%
-      \crefname@preamble{enumi}{Punkt}{Punkte}%
-      \crefname@preamble{footnote}{Fu\ss note}{Fu\ss noten}%
-      \crefname@preamble{figure}{Abbildung}{Abbildungen}%
-      \crefname@preamble{table}{Tabelle}{Tabellen}%
-      \crefname@preamble{theorem}{Theorem}{Theoremen}%
-      \crefname@preamble{lemma}{Lemma}{Lemmata}%
-      \crefname@preamble{corollary}{Korollar}{Korollaren}%
-      \crefname@preamble{proposition}{Satz}{S\"atze}%
-      \crefname@preamble{definition}{Definition}{Definitionen}%
-      \crefname@preamble{result}{Ergebnis}{Ergebnisse}%
-      \crefname@preamble{example}{Beispiel}{Beispiele}%
-      \crefname@preamble{remark}{Bemerkung}{Bemerkungen}%
-      \crefname@preamble{note}{Anmerkung}{Anmerkungen}%
-      \crefname@preamble{algorithm}{Algorithmus}{Algorithmen}%
-      \crefname@preamble{listing}{Listing}{Listings}%
-      \crefname@preamble{line}{Zeile}{Zeilen}%
+ %
+    \if@cref@abbrev%
+      \crefname@preamble{figure}{Abb.}{Abb.}%
     \else%
-      \crefname@preamble{equation}{Gleichung}{Gleichungen}%
-      \crefname@preamble{part}{Teil}{Teilen}%
-      \crefname@preamble{chapter}{Kapitel}{Kapitel}%
-      \crefname@preamble{section}{Abschnitt}{Abschnitte}%
-      \crefname@preamble{appendix}{Anhang}{Anh\"ange}%
-      \crefname@preamble{enumi}{Punkt}{Punkte}%
-      \crefname@preamble{footnote}{Fu\ss note}{Fu\ss noten}%
       \crefname@preamble{figure}{Abbildung}{Abbildungen}%
-      \crefname@preamble{table}{Tabelle}{Tabellen}%
-      \crefname@preamble{theorem}{Theorem}{Theoremen}%
-      \crefname@preamble{lemma}{Lemma}{Lemmata}%
-      \crefname@preamble{corollary}{Korollar}{Korollaren}%
-      \crefname@preamble{proposition}{Satz}{S\"atze}%
-      \crefname@preamble{definition}{Definition}{Definitionen}%
-      \crefname@preamble{result}{Ergebnis}{Ergebnisse}%
-      \crefname@preamble{example}{Beispiel}{Beispiele}%
-      \crefname@preamble{remark}{Bemerkung}{Bemerkungen}%
-      \crefname@preamble{note}{Anmerkung}{Anmerkungen}%
-      \crefname@preamble{algorithm}{Algorithmus}{Algorithmen}%
-      \crefname@preamble{listing}{Listing}{Listings}%
-      \crefname@preamble{line}{Zeile}{Zeilen}%
     \fi%
+    \crefname@preamble{equation}{Gleichung}{Gleichungen}%
+    \crefname@preamble{table}{Tabelle}{Tabellen}%
+    \crefname@preamble{page}{Seite}{Seiten}%
+    \crefname@preamble{part}{Teil}{Teile}%
+    \crefname@preamble{chapter}{Kapitel}{Kapitel}%
+    \crefname@preamble{section}{Abschnitt}{Abschnitte}%
+    \crefname@preamble{appendix}{Anhang}{Anh\"ange}%
+    \crefname@preamble{enumi}{Punkt}{Punkte}%
+    \crefname@preamble{footnote}{Fu\ss note}{Fu\ss noten}%
+    \crefname@preamble{theorem}{Theorem}{Theoreme}%
+    \crefname@preamble{lemma}{Lemma}{Lemmata}%
+    \crefname@preamble{corollary}{Korollar}{Korollare}%
+    \crefname@preamble{proposition}{Satz}{S\"atze}%
+    \crefname@preamble{definition}{Definition}{Definitionen}%
+    \crefname@preamble{result}{Ergebnis}{Ergebnisse}%
+    \crefname@preamble{example}{Beispiel}{Beispiele}%
+    \crefname@preamble{remark}{Bemerkung}{Bemerkungen}%
+    \crefname@preamble{note}{Anmerkung}{Anmerkungen}%
+    \crefname@preamble{algorithm}{Algorithmus}{Algorithmen}%
+    \crefname@preamble{listing}{Listing}{Listings}%
+    \crefname@preamble{line}{Zeile}{Zeilen}%
     \def\cref@language{german}%
-    \cref@addto\extrasgerman{%
-      \renewcommand{\crefrangeconjunction}{ bis\nobreakspace}%
-      \renewcommand\crefrangepreconjunction{}%
-      \renewcommand\crefrangepostconjunction{}%
-      \renewcommand{\crefpairconjunction}{ und\nobreakspace}%
-      \renewcommand{\crefmiddleconjunction}{, }%
-      \renewcommand{\creflastconjunction}{ und\nobreakspace}%
-      \renewcommand{\crefpairgroupconjunction}{ und\nobreakspace}%
-      \renewcommand{\crefmiddlegroupconjunction}{, }%
-      \renewcommand{\creflastgroupconjunction}{ und\nobreakspace}%
-      \Crefname{equation}{Gleichung}{Gleichungen}%
-      \Crefname{part}{Teil}{Teilen}%
-      \Crefname{chapter}{Kapitel}{Kapitel}%
-      \Crefname{section}{Abschnitt}{Abschnitte}%
-      \Crefname{subsection}{Abschnitt}{Abschnitte}%
-      \Crefname{subsubsection}{Abschnitt}{Abschnitte}%
-      \Crefname{appendix}{Anhang}{Anh\"ange}%
-      \Crefname{subappendix}{Anhang}{Anh\"ange}%
-      \Crefname{subsubappendix}{Anhang}{Anh\"ange}%
-      \Crefname{subsubsubappendix}{Anhang}{Anh\"ange}%
-      \Crefname{enumi}{Punkt}{Punkte}%
-      \Crefname{enumii}{Punkt}{Punkte}%
-      \Crefname{enumiii}{Punkt}{Punkte}%
-      \Crefname{enumiv}{Punkt}{Punkte}%
-      \Crefname{enumv}{Punkt}{Punkte}%
-      \Crefname{footnote}{Fu\ss note}{Fu\ss noten}%
-      \Crefname{figure}{Abbildung}{Abbildungen}%
-      \Crefname{subfigure}{Abbildung}{Abbildungen}%
-      \Crefname{table}{Tabelle}{Tabellen}%
-      \Crefname{subtable}{Tabelle}{Tabellen}%
-      \Crefname{theorem}{Theorem}{Theoremen}%
-      \Crefname{lemma}{Lemma}{Lemmata}%
-      \Crefname{corollary}{Korollar}{Korollaren}%
-      \Crefname{proposition}{Satz}{S\"atze}%
-      \Crefname{definition}{Definition}{Definitionen}%
-      \Crefname{result}{Ergebnis}{Ergebnisse}%
-      \Crefname{example}{Beispiel}{Beispiele}%
-      \Crefname{remark}{Bemerkung}{Bemerkungen}%
-      \Crefname{note}{Anmerkung}{Anmerkungen}%
-      \Crefname{algorithm}{Algorithmus}{Algorithmen}%
-      \Crefname{listing}{Listing}{Listings}%
-      \Crefname{line}{Zeile}{Zeilen}%
-      \if@cref@capitalise%
-        \crefname{equation}{Gleichung}{Gleichungen}%
-        \crefname{part}{Teil}{Teilen}%
-        \crefname{chapter}{Kapitel}{Kapitel}%
-        \crefname{section}{Abschnitt}{Abschnitte}%
-        \crefname{subsection}{Abschnitt}{Abschnitte}%
-        \crefname{subsubsection}{Abschnitt}{Abschnitte}%
-        \crefname{appendix}{Anhang}{Anh\"ange}%
-        \crefname{subappendix}{Anhang}{Anh\"ange}%
-        \crefname{subsubappendix}{Anhang}{Anh\"ange}%
-        \crefname{subsubsubappendix}{Anhang}{Anh\"ange}%
-        \crefname{enumi}{Punkt}{Punkte}%
-        \crefname{enumii}{Punkt}{Punkte}%
-        \crefname{enumiii}{Punkt}{Punkte}%
-        \crefname{enumiv}{Punkt}{Punkte}%
-        \crefname{enumv}{Punkt}{Punkte}%
-        \crefname{footnote}{Fu\ss note}{Fu\ss noten}%
-        \crefname{figure}{Abbildung}{Abbildungen}%
-        \crefname{subfigure}{Abbildung}{Abbildungen}%
-        \crefname{table}{Tabelle}{Tabellen}%
-        \crefname{subtable}{Tabelle}{Tabellen}%
-        \crefname{theorem}{Theorem}{Theoremen}%
-        \crefname{lemma}{Lemma}{Lemmata}%
-        \crefname{corollary}{Korollar}{Korollaren}%
-        \crefname{proposition}{Satz}{S\"atze}%
-        \crefname{definition}{Definition}{Definitionen}%
-        \crefname{result}{Ergebnis}{Ergebnisse}%
-        \crefname{example}{Beispiel}{Beispiele}%
-        \crefname{remark}{Bemerkung}{Bemerkungen}%
-        \crefname{note}{Anmerkung}{Anmerkungen}%
-        \crefname{algorithm}{Algorithmus}{Algorithmen}%
-        \crefname{listing}{Listing}{Listings}%
-        \crefname{line}{Zeile}{Zeilen}%
-      \else%
-        \crefname{equation}{Gleichung}{Gleichungen}%
-        \crefname{part}{Teil}{Teilen}%
-        \crefname{chapter}{Kapitel}{Kapitel}%
-        \crefname{section}{Abschnitt}{Abschnitte}%
-        \crefname{subsection}{Abschnitt}{Abschnitte}%
-        \crefname{subsubsection}{Abschnitt}{Abschnitte}%
-        \crefname{appendix}{Anhang}{Anh\"ange}%
-        \crefname{subappendix}{Anhang}{Anh\"ange}%
-        \crefname{subsubappendix}{Anhang}{Anh\"ange}%
-        \crefname{subsubsubappendix}{Anhang}{Anh\"ange}%
-        \crefname{enumi}{Punkt}{Punkte}%
-        \crefname{enumii}{Punkt}{Punkte}%
-        \crefname{enumiii}{Punkt}{Punkte}%
-        \crefname{enumiv}{Punkt}{Punkte}%
-        \crefname{enumv}{Punkt}{Punkte}%
-        \crefname{footnote}{Fu\ss note}{Fu\ss noten}%
-        \crefname{figure}{Abbildung}{Abbildungen}%
-        \crefname{subfigure}{Abbildung}{Abbildungen}%
-        \crefname{table}{Tabelle}{Tabellen}%
-        \crefname{subtable}{Tabelle}{Tabellen}%
-        \crefname{theorem}{Theorem}{Theoremen}%
-        \crefname{lemma}{Lemma}{Lemmata}%
-        \crefname{corollary}{Korollar}{Korollaren}%
-        \crefname{proposition}{Satz}{S\"atze}%
-        \crefname{definition}{Definition}{Definitionen}%
-        \crefname{result}{Ergebnis}{Ergebnisse}%
-        \crefname{example}{Beispiel}{Beispiele}%
-        \crefname{remark}{Bemerkung}{Bemerkungen}%
-        \crefname{note}{Anmerkung}{Anmerkungen}%
-        \crefname{algorithm}{Algorithmus}{Algorithmen}%
-        \crefname{listing}{Listing}{Listings}%
-        \crefname{line}{Zeile}{Zeilen}%
-      \fi%
-    }}}
+  }}% end \AtBeginDocument and \DeclareOption
+\cref@addlanguagedefs{german}{%
+  \PackageInfo{cleveref}{loaded `german language definitions}%
+  \renewcommand{\crefrangeconjunction}{ bis\nobreakspace}%
+  \renewcommand\crefrangepreconjunction{}%
+  \renewcommand\crefrangepostconjunction{}%
+  \renewcommand{\crefpairconjunction}{ und\nobreakspace}%
+  \renewcommand{\crefmiddleconjunction}{, }%
+  \renewcommand{\creflastconjunction}{ und\nobreakspace}%
+  \renewcommand{\crefpairgroupconjunction}{ und\nobreakspace}%
+  \renewcommand{\crefmiddlegroupconjunction}{, }%
+  \renewcommand{\creflastgroupconjunction}{ und\nobreakspace}%
+ %
+  \Crefname{equation}{Gleichung}{Gleichungen}%
+  \Crefname{figure}{Abbildung}{Abbildungen}%
+  \Crefname{subfigure}{Abbildung}{Abbildungen}%
+  \Crefname{table}{Tabelle}{Tabellen}%
+  \Crefname{subtable}{Tabelle}{Tabellen}%
+  \Crefname{page}{Seite}{Seiten}%
+  \Crefname{part}{Teil}{Teile}%
+  \Crefname{chapter}{Kapitel}{Kapitel}%
+  \Crefname{section}{Abschnitt}{Abschnitte}%
+  \Crefname{subsection}{Abschnitt}{Abschnitte}%
+  \Crefname{subsubsection}{Abschnitt}{Abschnitte}%
+  \Crefname{appendix}{Anhang}{Anh\"ange}%
+  \Crefname{subappendix}{Anhang}{Anh\"ange}%
+  \Crefname{subsubappendix}{Anhang}{Anh\"ange}%
+  \Crefname{subsubsubappendix}{Anhang}{Anh\"ange}%
+  \Crefname{enumi}{Punkt}{Punkte}%
+  \Crefname{enumii}{Punkt}{Punkte}%
+  \Crefname{enumiii}{Punkt}{Punkte}%
+  \Crefname{enumiv}{Punkt}{Punkte}%
+  \Crefname{enumv}{Punkt}{Punkte}%
+  \Crefname{footnote}{Fu\ss note}{Fu\ss noten}%
+  \Crefname{theorem}{Theorem}{Theoreme}%
+  \Crefname{lemma}{Lemma}{Lemmata}%
+  \Crefname{corollary}{Korollar}{Korollare}%
+  \Crefname{proposition}{Satz}{S\"atze}%
+  \Crefname{definition}{Definition}{Definitionen}%
+  \Crefname{result}{Ergebnis}{Ergebnisse}%
+  \Crefname{example}{Beispiel}{Beispiele}%
+  \Crefname{remark}{Bemerkung}{Bemerkungen}%
+  \Crefname{note}{Anmerkung}{Anmerkungen}%
+  \Crefname{algorithm}{Algorithmus}{Algorithmen}%
+  \Crefname{listing}{Listing}{Listings}%
+  \Crefname{line}{Zeile}{Zeilen}%
+ %
+  \if@cref@abbrev%
+    \crefname{figure}{Abb.}{Abb.}%
+    \crefname{subfigure}{Abb.}{Abb.}%
+  \else%
+    \crefname{figure}{Abbildung}{Abbildungen}%
+    \crefname{subfigure}{Abbildung}{Abbildungen}%
+  \fi%
+  \crefname{equation}{Gleichung}{Gleichungen}%
+  \crefname{table}{Tabelle}{Tabellen}%
+  \crefname{subtable}{Tabelle}{Tabellen}%
+  \crefname{page}{Seite}{Seiten}%
+  \crefname{part}{Teil}{Teile}%
+  \crefname{chapter}{Kapitel}{Kapitel}%
+  \crefname{section}{Abschnitt}{Abschnitte}%
+  \crefname{subsection}{Abschnitt}{Abschnitte}%
+  \crefname{subsubsection}{Abschnitt}{Abschnitte}%
+  \crefname{appendix}{Anhang}{Anh\"ange}%
+  \crefname{subappendix}{Anhang}{Anh\"ange}%
+  \crefname{subsubappendix}{Anhang}{Anh\"ange}%
+  \crefname{subsubsubappendix}{Anhang}{Anh\"ange}%
+  \crefname{enumi}{Punkt}{Punkte}%
+  \crefname{enumii}{Punkt}{Punkte}%
+  \crefname{enumiii}{Punkt}{Punkte}%
+  \crefname{enumiv}{Punkt}{Punkte}%
+  \crefname{enumv}{Punkt}{Punkte}%
+  \crefname{footnote}{Fu\ss note}{Fu\ss noten}%
+  \crefname{theorem}{Theorem}{Theoreme}%
+  \crefname{lemma}{Lemma}{Lemmata}%
+  \crefname{corollary}{Korollar}{Korollare}%
+  \crefname{proposition}{Satz}{S\"atze}%
+  \crefname{definition}{Definition}{Definitionen}%
+  \crefname{result}{Ergebnis}{Ergebnisse}%
+  \crefname{example}{Beispiel}{Beispiele}%
+  \crefname{remark}{Bemerkung}{Bemerkungen}%
+  \crefname{note}{Anmerkung}{Anmerkungen}%
+  \crefname{algorithm}{Algorithmus}{Algorithmen}%
+  \crefname{listing}{Listing}{Listings}%
+  \crefname{line}{Zeile}{Zeilen}}% end \cref@addlangagedefs
 \DeclareOption{ngerman}{%
-  \PackageInfo{cleveref}{loaded `ngerman' language definitions}
-  \ExecuteOptions{german}
-  \def\cref@language{ngerman}
-  \AtBeginDocument{%
-    \cref@addto\extrasngerman{%
-      \renewcommand{\crefrangeconjunction}{ bis\nobreakspace}%
-      \renewcommand\crefrangepreconjunction{}%
-      \renewcommand\crefrangepostconjunction{}%
-      \renewcommand{\crefpairconjunction}{ und\nobreakspace}%
-      \renewcommand{\crefmiddleconjunction}{, }%
-      \renewcommand{\creflastconjunction}{ und\nobreakspace}%
-      \renewcommand{\crefpairgroupconjunction}{ und\nobreakspace}%
-      \renewcommand{\crefmiddlegroupconjunction}{, }%
-      \renewcommand{\creflastgroupconjunction}{ und\nobreakspace}%
-      \Crefname{equation}{Gleichung}{Gleichungen}%
-      \Crefname{part}{Teil}{Teilen}%
-      \Crefname{chapter}{Kapitel}{Kapitel}%
-      \Crefname{section}{Abschnitt}{Abschnitte}%
-      \Crefname{subsection}{Abschnitt}{Abschnitte}%
-      \Crefname{subsubsection}{Abschnitt}{Abschnitte}%
-      \Crefname{appendix}{Anhang}{Anh\"ange}%
-      \Crefname{subappendix}{Anhang}{Anh\"ange}%
-      \Crefname{subsubappendix}{Anhang}{Anh\"ange}%
-      \Crefname{subsubsubappendix}{Anhang}{Anh\"ange}%
-      \Crefname{enumi}{Punkt}{Punkte}%
-      \Crefname{enumii}{Punkt}{Punkte}%
-      \Crefname{enumiii}{Punkt}{Punkte}%
-      \Crefname{enumiv}{Punkt}{Punkte}%
-      \Crefname{enumv}{Punkt}{Punkte}%
-      \Crefname{footnote}{Fu\ss note}{Fu\ss noten}%
-      \Crefname{figure}{Abbildung}{Abbildungen}%
-      \Crefname{subfigure}{Abbildung}{Abbildungen}%
-      \Crefname{table}{Tabelle}{Tabellen}%
-      \Crefname{subtable}{Tabelle}{Tabellen}%
-      \Crefname{theorem}{Theorem}{Theoremen}%
-      \Crefname{lemma}{Lemma}{Lemmata}%
-      \Crefname{corollary}{Korollar}{Korollaren}%
-      \Crefname{proposition}{Satz}{S\"atze}%
-      \Crefname{definition}{Definition}{Definitionen}%
-      \Crefname{result}{Ergebnis}{Ergebnisse}%
-      \Crefname{example}{Beispiel}{Beispiele}%
-      \Crefname{remark}{Bemerkung}{Bemerkungen}%
-      \Crefname{note}{Anmerkung}{Anmerkungen}%
-      \Crefname{algorithm}{Algorithmus}{Algorithmen}%
-      \Crefname{listing}{Listing}{Listings}%
-      \Crefname{line}{Zeile}{Zeilen}%
-      \if@cref@capitalise%
-        \crefname{equation}{Gleichung}{Gleichungen}%
-        \crefname{part}{Teil}{Teilen}%
-        \crefname{chapter}{Kapitel}{Kapitel}%
-        \crefname{section}{Abschnitt}{Abschnitte}%
-        \crefname{subsection}{Abschnitt}{Abschnitte}%
-        \crefname{subsubsection}{Abschnitt}{Abschnitte}%
-        \crefname{appendix}{Anhang}{Anh\"ange}%
-        \crefname{subappendix}{Anhang}{Anh\"ange}%
-        \crefname{subsubappendix}{Anhang}{Anh\"ange}%
-        \crefname{subsubsubappendix}{Anhang}{Anh\"ange}%
-        \crefname{enumi}{Punkt}{Punkte}%
-        \crefname{enumii}{Punkt}{Punkte}%
-        \crefname{enumiii}{Punkt}{Punkte}%
-        \crefname{enumiv}{Punkt}{Punkte}%
-        \crefname{enumv}{Punkt}{Punkte}%
-        \crefname{footnote}{Fu\ss note}{Fu\ss noten}%
-        \crefname{figure}{Abbildung}{Abbildungen}%
-        \crefname{subfigure}{Abbildung}{Abbildungen}%
-        \crefname{table}{Tabelle}{Tabellen}%
-        \crefname{subtable}{Tabelle}{Tabellen}%
-        \crefname{theorem}{Theorem}{Theoremen}%
-        \crefname{lemma}{Lemma}{Lemmata}%
-        \crefname{corollary}{Korollar}{Korollaren}%
-        \crefname{proposition}{Satz}{S\"atze}%
-        \crefname{definition}{Definition}{Definitionen}%
-        \crefname{result}{Ergebnis}{Ergebnisse}%
-        \crefname{example}{Beispiel}{Beispiele}%
-        \crefname{remark}{Bemerkung}{Bemerkungen}%
-        \crefname{note}{Anmerkung}{Anmerkungen}%
-        \crefname{algorithm}{Algorithmus}{Algorithmen}%
-        \crefname{listing}{Listing}{Listings}%
-        \crefname{line}{Zeile}{Zeilen}%
-      \else%
-        \crefname{equation}{Gleichung}{Gleichungen}%
-        \crefname{part}{Teil}{Teilen}%
-        \crefname{chapter}{Kapitel}{Kapitel}%
-        \crefname{section}{Abschnitt}{Abschnitte}%
-        \crefname{subsection}{Abschnitt}{Abschnitte}%
-        \crefname{subsubsection}{Abschnitt}{Abschnitte}%
-        \crefname{appendix}{Anhang}{Anh\"ange}%
-        \crefname{subappendix}{Anhang}{Anh\"ange}%
-        \crefname{subsubappendix}{Anhang}{Anh\"ange}%
-        \crefname{subsubsubappendix}{Anhang}{Anh\"ange}%
-        \crefname{enumi}{Punkt}{Punkte}%
-        \crefname{enumii}{Punkt}{Punkte}%
-        \crefname{enumiii}{Punkt}{Punkte}%
-        \crefname{enumiv}{Punkt}{Punkte}%
-        \crefname{enumv}{Punkt}{Punkte}%
-        \crefname{footnote}{Fu\ss note}{Fu\ss noten}%
-        \crefname{figure}{Abbildung}{Abbildungen}%
-        \crefname{subfigure}{Abbildung}{Abbildungen}%
-        \crefname{table}{Tabelle}{Tabellen}%
-        \crefname{subtable}{Tabelle}{Tabellen}%
-        \crefname{theorem}{Theorem}{Theoremen}%
-        \crefname{lemma}{Lemma}{Lemmata}%
-        \crefname{corollary}{Korollar}{Korollaren}%
-        \crefname{proposition}{Satz}{S\"atze}%
-        \crefname{definition}{Definition}{Definitionen}%
-        \crefname{result}{Ergebnis}{Ergebnisse}%
-        \crefname{example}{Beispiel}{Beispiele}%
-        \crefname{remark}{Bemerkung}{Bemerkungen}%
-        \crefname{note}{Anmerkung}{Anmerkungen}%
-        \crefname{algorithm}{Algorithmus}{Algorithmen}%
-        \crefname{listing}{Listing}{Listings}%
-        \crefname{line}{Zeile}{Zeilen}%
-      \fi%
-    }}}
+  \ExecuteOptions{german}%
+  \def\cref@language{ngerman}}%
+\cref@addlanguagedefs{ngerman}{%
+  \PackageInfo{cleveref}{loaded `ngerman' language definitions}%
+  \renewcommand{\crefrangeconjunction}{ bis\nobreakspace}%
+  \renewcommand\crefrangepreconjunction{}%
+  \renewcommand\crefrangepostconjunction{}%
+  \renewcommand{\crefpairconjunction}{ und\nobreakspace}%
+  \renewcommand{\crefmiddleconjunction}{, }%
+  \renewcommand{\creflastconjunction}{ und\nobreakspace}%
+  \renewcommand{\crefpairgroupconjunction}{ und\nobreakspace}%
+  \renewcommand{\crefmiddlegroupconjunction}{, }%
+  \renewcommand{\creflastgroupconjunction}{ und\nobreakspace}%
+ %
+  \Crefname{equation}{Gleichung}{Gleichungen}%
+  \Crefname{figure}{Abbildung}{Abbildungen}%
+  \Crefname{subfigure}{Abbildung}{Abbildungen}%
+  \Crefname{table}{Tabelle}{Tabellen}%
+  \Crefname{subtable}{Tabelle}{Tabellen}%
+  \Crefname{page}{Seite}{Seiten}%
+  \Crefname{part}{Teil}{Teile}%
+  \Crefname{chapter}{Kapitel}{Kapitel}%
+  \Crefname{section}{Abschnitt}{Abschnitte}%
+  \Crefname{subsection}{Abschnitt}{Abschnitte}%
+  \Crefname{subsubsection}{Abschnitt}{Abschnitte}%
+  \Crefname{appendix}{Anhang}{Anh\"ange}%
+  \Crefname{subappendix}{Anhang}{Anh\"ange}%
+  \Crefname{subsubappendix}{Anhang}{Anh\"ange}%
+  \Crefname{subsubsubappendix}{Anhang}{Anh\"ange}%
+  \Crefname{enumi}{Punkt}{Punkte}%
+  \Crefname{enumii}{Punkt}{Punkte}%
+  \Crefname{enumiii}{Punkt}{Punkte}%
+  \Crefname{enumiv}{Punkt}{Punkte}%
+  \Crefname{enumv}{Punkt}{Punkte}%
+  \Crefname{footnote}{Fu\ss note}{Fu\ss noten}%
+  \Crefname{theorem}{Theorem}{Theoreme}%
+  \Crefname{lemma}{Lemma}{Lemmata}%
+  \Crefname{corollary}{Korollar}{Korollare}%
+  \Crefname{proposition}{Satz}{S\"atze}%
+  \Crefname{definition}{Definition}{Definitionen}%
+  \Crefname{result}{Ergebnis}{Ergebnisse}%
+  \Crefname{example}{Beispiel}{Beispiele}%
+  \Crefname{remark}{Bemerkung}{Bemerkungen}%
+  \Crefname{note}{Anmerkung}{Anmerkungen}%
+  \Crefname{algorithm}{Algorithmus}{Algorithmen}%
+  \Crefname{listing}{Listing}{Listings}%
+  \Crefname{line}{Zeile}{Zeilen}%
+ %
+  \if@cref@abbrev%
+    \crefname{figure}{Abb.}{Abb.}%
+    \crefname{subfigure}{Abb.}{Abb.}%
+  \else%
+    \crefname{figure}{Abbildung}{Abbildungen}%
+    \crefname{subfigure}{Abbildung}{Abbildungen}%
+  \fi%
+  \crefname{equation}{Gleichung}{Gleichungen}%
+  \crefname{table}{Tabelle}{Tabellen}%
+  \crefname{subtable}{Tabelle}{Tabellen}%
+  \crefname{page}{Seite}{Seiten}%
+  \crefname{part}{Teil}{Teile}%
+  \crefname{chapter}{Kapitel}{Kapitel}%
+  \crefname{section}{Abschnitt}{Abschnitte}%
+  \crefname{subsection}{Abschnitt}{Abschnitte}%
+  \crefname{subsubsection}{Abschnitt}{Abschnitte}%
+  \crefname{appendix}{Anhang}{Anh\"ange}%
+  \crefname{subappendix}{Anhang}{Anh\"ange}%
+  \crefname{subsubappendix}{Anhang}{Anh\"ange}%
+  \crefname{subsubsubappendix}{Anhang}{Anh\"ange}%
+  \crefname{enumi}{Punkt}{Punkte}%
+  \crefname{enumii}{Punkt}{Punkte}%
+  \crefname{enumiii}{Punkt}{Punkte}%
+  \crefname{enumiv}{Punkt}{Punkte}%
+  \crefname{enumv}{Punkt}{Punkte}%
+  \crefname{footnote}{Fu\ss note}{Fu\ss noten}%
+  \crefname{theorem}{Theorem}{Theoreme}%
+  \crefname{lemma}{Lemma}{Lemmata}%
+  \crefname{corollary}{Korollar}{Korollare}%
+  \crefname{proposition}{Satz}{S\"atze}%
+  \crefname{definition}{Definition}{Definitionen}%
+  \crefname{result}{Ergebnis}{Ergebnisse}%
+  \crefname{example}{Beispiel}{Beispiele}%
+  \crefname{remark}{Bemerkung}{Bemerkungen}%
+  \crefname{note}{Anmerkung}{Anmerkungen}%
+  \crefname{algorithm}{Algorithmus}{Algorithmen}%
+  \crefname{listing}{Listing}{Listings}%
+  \crefname{line}{Zeile}{Zeilen}}% end \cref@addlangagedefs
 \DeclareOption{dutch}{%
-  \PackageInfo{cleveref}{loaded `dutch' language definitions}
   \AtBeginDocument{%
     \def\crefrangeconjunction@preamble{ tot\nobreakspace}%
     \def\crefrangepreconjunction@preamble{}%
@@ -3471,13 +4160,15 @@
     \def\crefpairgroupconjunction@preamble{ en\nobreakspace}%
     \def\crefmiddlegroupconjunction@preamble{, }%
     \def\creflastgroupconjunction@preamble{ en\nobreakspace}%
+ %
     \Crefname@preamble{equation}{Vergel\ij{}king}{Vergel\ij{}kingen}%
+    \Crefname@preamble{figure}{Figuur}{Figuren}%
+    \Crefname@preamble{table}{Tabel}{Tabellen}%
+    \Crefname@preamble{page}{Pagina}{Pagina's}%
     \Crefname@preamble{part}{Deel}{Delen}%
     \Crefname@preamble{chapter}{Hoofdstuk}{Hoofdstuken}%
     \Crefname@preamble{section}{Paragraaf}{Paragrafen}%
     \Crefname@preamble{appendix}{Appendix}{Appendices}%
-    \Crefname@preamble{figure}{Figuur}{Figuren}%
-    \Crefname@preamble{table}{Tabel}{Tabellen}%
     \Crefname@preamble{enumi}{Punt}{Punten}%
     \Crefname@preamble{footnote}{Voetnote}{Voetnoten}%
     \Crefname@preamble{lemma}{Lemma}{Lemma's}%
@@ -3491,16 +4182,23 @@
     \Crefname@preamble{algorithm}{Algoritme}{Algoritmen}%
     \Crefname@preamble{listing}{Listing}{Listings}%
     \Crefname@preamble{line}{Lijn}{Lijnen}%
-    \if@cref@capitalise%
-      \crefname@preamble{equation}{Verg.}{Verg's.}%
+ %
+    \if@cref@capitalise%  capitalise set
+      \if@cref@abbrev%
+        \crefname@preamble{equation}{Verg.}{Verg's.}%
+        \crefname@preamble{figure}{Fig.}{Fig's.}%
+      \else%
+        \crefname@preamble{equation}{Vergel\ij{}king}{Vergel\ij{}kingen}%
+        \crefname@preamble{figure}{Figuur}{Figuren}%
+      \fi%
+      \crefname@preamble{page}{Pagina}{Pagina's}%
+      \crefname@preamble{table}{Tabel}{Tabellen}%
       \crefname@preamble{part}{Deel}{Delen}%
       \crefname@preamble{chapter}{Hoofdstuk}{Hoofdstukken}%
       \crefname@preamble{section}{Paragraaf}{Paragrafen}%
       \crefname@preamble{appendix}{Appendix}{Appendices}%
       \crefname@preamble{enumi}{Punt}{Punten}%
       \crefname@preamble{footnote}{Voetnote}{Voetnoten}%
-      \crefname@preamble{figure}{Fig.}{Fig's.}%
-      \crefname@preamble{table}{Tabel}{Tabellen}%
       \crefname@preamble{theorem}{Theorema}{Theorema's}%
       \crefname@preamble{lemma}{Lemma}{Lemma's}%
       \crefname@preamble{corollary}{Corollarium}{Corollaria}%
@@ -3513,16 +4211,23 @@
       \crefname@preamble{algorithm}{Algoritme}{Algoritmen}%
       \crefname@preamble{listing}{Listing}{Listings}%
       \crefname@preamble{line}{Lijn}{Lijnen}%
-    \else%
-      \crefname@preamble{equation}{verg.}{verg's.}%
+ %
+    \else%  capitalise unset
+      \if@cref@abbrev%
+        \crefname@preamble{equation}{verg.}{verg's.}%
+        \crefname@preamble{figure}{fig.}{fig's.}%
+      \else%
+        \crefname@preamble{equation}{vergel\ij{}king}{vergel\ij{}kingen}%
+        \crefname@preamble{figure}{figuur}{figuren}%
+      \fi%
+      \crefname@preamble{page}{pagina}{pagina's}%
+      \crefname@preamble{table}{tabel}{tabellen}%
       \crefname@preamble{part}{deel}{delen}%
       \crefname@preamble{chapter}{hoofdstuk}{hoofdstukken}%
       \crefname@preamble{section}{paragraaf}{paragrafen}%
       \crefname@preamble{appendix}{appendix}{appendices}%
       \crefname@preamble{enumi}{punt}{punten}%
       \crefname@preamble{footnote}{voetnote}{voetnoten}%
-      \crefname@preamble{figure}{fig.}{fig's.}%
-      \crefname@preamble{table}{tabel}{tabellen}%
       \crefname@preamble{theorem}{theorema}{theorema's}%
       \crefname@preamble{lemma}{lemma}{lemma's}%
       \crefname@preamble{corollary}{corollarium}{corollaria}%
@@ -3537,96 +4242,118 @@
       \crefname@preamble{line}{lijn}{lijnen}%
     \fi%
     \def\cref@language{dutch}%
-    \cref@addto\extrasdutch{%
-      \renewcommand{\crefrangeconjunction}{ tot\nobreakspace}%
-      \renewcommand\crefrangepreconjunction{}%
-      \renewcommand\crefrangepostconjunction{}%
-      \renewcommand{\crefpairconjunction}{ en\nobreakspace}%
-      \renewcommand{\crefmiddleconjunction}{, }%
-      \renewcommand{\creflastconjunction}{ en\nobreakspace}%
-      \renewcommand{\crefpairgroupconjunction}{ en\nobreakspace}%
-      \renewcommand{\crefmiddlegroupconjunction}{, }%
-      \renewcommand{\creflastgroupconjunction}{ en\nobreakspace}%
-      \Crefname{equation}{Vergel\ij{}king}{Vergel\ij{}kingen}%
-      \Crefname{part}{Deel}{Delen}%
-      \Crefname{chapter}{Hoofdstuk}{Hoofdstuken}%
-      \Crefname{section}{Paragraaf}{Paragrafen}%
-      \Crefname{subsection}{Paragraaf}{Paragrafen}%
-      \Crefname{subsubsection}{Paragraaf}{Paragrafen}%
-      \Crefname{appendix}{Appendix}{Appendices}%
-      \Crefname{subappendix}{Appendix}{Appendices}%
-      \Crefname{subsubappendix}{Appendix}{Appendices}%
-      \Crefname{subsubsubappendix}{Appendix}{Appendices}%
-      \Crefname{enumi}{Punt}{Punten}%
-      \Crefname{enumii}{Punt}{Punten}%
-      \Crefname{enumiii}{Punt}{Punten}%
-      \Crefname{enumiv}{Punt}{Punten}%
-      \Crefname{enumv}{Punt}{Punten}%
-      \Crefname{footnote}{Voetnote}{Voetnoten}%
-      \Crefname{figure}{Figuur}{Figuren}%
-      \Crefname{subfigure}{Figuur}{Figuren}%
-      \Crefname{table}{Tabel}{Tabellen}%
-      \Crefname{subtable}{Tabel}{Tabellen}%
-      \Crefname{theorem}{Theorema}{Theorema's}%
-      \Crefname{lemma}{Lemma}{Lemma's}%
-      \Crefname{corollary}{Corollarium}{Corollaria}%
-      \Crefname{proposition}{Bewering}{Beweringen}%
-      \Crefname{definition}{Definitie}{Definities}%
-      \Crefname{result}{Resultaat}{Resultaten}%
-      \Crefname{example}{Voorbeeld}{Voorbeelden}%
-      \Crefname{remark}{Opmerking}{Opmerkingen}%
-      \Crefname{note}{Aantekening}{Aantekeningen}%
-      \Crefname{algorithm}{Algoritme}{Algoritmen}%
-      \Crefname{listing}{Listing}{Listings}%
-      \Crefname{line}{Lijn}{Lijnen}%
-      \if@cref@capitalise%
-        \crefname{equation}{Verg.}{Verg's.}%
-        \crefname{part}{Deel}{Delen}%
-        \crefname{chapter}{Hoofdstuk}{Hoofdstukken}%
-        \crefname{section}{Paragraaf}{Paragrafen}%
-        \crefname{appendix}{Appendix}{Appendices}%
-        \crefname{enumi}{Punt}{Punten}%
-        \crefname{footnote}{Voetnote}{Voetnoten}%
-        \crefname{figure}{Fig.}{Fig's.}%
-        \crefname{table}{Tabel}{Tabellen}%
-        \crefname{theorem}{Theorema}{Theorema's}%
-        \crefname{lemma}{Lemma}{Lemma's}%
-        \crefname{corollary}{Corollarium}{Corollaria}%
-        \crefname{proposition}{Bewering}{Beweringen}%
-        \crefname{definition}{Definitie}{Definities}%
-        \crefname{result}{Resultaat}{Resultaten}%
-        \crefname{example}{Voorbeeld}{Voorbeelden}%
-        \crefname{remark}{Opmerking}{Opmerkingen}%
-        \crefname{note}{Aantekening}{Aantekeningen}%
-        \crefname{algorithm}{Algoritme}{Algoritmen}%
-        \crefname{listing}{Listing}{Listings}%
-        \crefname{line}{Lijn}{Lijnen}%
-      \else%
-        \crefname{equation}{verg.}{verg's.}%
-        \crefname{part}{deel}{delen}%
-        \crefname{chapter}{hoofdstuk}{hoofdstukken}%
-        \crefname{section}{paragraaf}{paragrafen}%
-        \crefname{appendix}{appendix}{appendices}%
-        \crefname{enumi}{punt}{punten}%
-        \crefname{footnote}{voetnote}{voetnoten}%
-        \crefname{figure}{fig.}{fig's.}%
-        \crefname{table}{tabel}{tabellen}%
-        \crefname{theorem}{theorema}{theorema's}%
-        \crefname{lemma}{lemma}{lemma's}%
-        \crefname{corollary}{corollarium}{corollaria}%
-        \crefname{proposition}{bewering}{beweringen}%
-        \crefname{definition}{definitie}{definities}%
-        \crefname{result}{resultaat}{resultaten}%
-        \crefname{example}{voorbeeld}{voorbeelden}%
-        \crefname{remark}{opmerking}{opmerkingen}%
-        \crefname{note}{aantekening}{aantekeningen}%
-        \crefname{algorithm}{algoritme}{algoritmen}%
-        \crefname{listing}{listing}{listings}%
-        \crefname{line}{lijn}{lijnen}%
-      \fi%
-    }}}
+  }}% end \DeclareOption and \AtBeginDocument
+\cref@addlanguagedefs{dutch}{%
+  \PackageInfo{cleveref}{loaded `dutch' language definitions}%
+  \renewcommand{\crefrangeconjunction}{ tot\nobreakspace}%
+  \renewcommand\crefrangepreconjunction{}%
+  \renewcommand\crefrangepostconjunction{}%
+  \renewcommand{\crefpairconjunction}{ en\nobreakspace}%
+  \renewcommand{\crefmiddleconjunction}{, }%
+  \renewcommand{\creflastconjunction}{ en\nobreakspace}%
+  \renewcommand{\crefpairgroupconjunction}{ en\nobreakspace}%
+  \renewcommand{\crefmiddlegroupconjunction}{, }%
+  \renewcommand{\creflastgroupconjunction}{ en\nobreakspace}%
+ %
+  \Crefname{equation}{Vergel\ij{}king}{Vergel\ij{}kingen}%
+  \Crefname{figure}{Figuur}{Figuren}%
+  \Crefname{subfigure}{Figuur}{Figuren}%
+  \Crefname{table}{Tabel}{Tabellen}%
+  \Crefname{subtable}{Tabel}{Tabellen}%
+  \Crefname{page}{Pagina}{Pagina's}%
+  \Crefname{part}{Deel}{Delen}%
+  \Crefname{chapter}{Hoofdstuk}{Hoofdstuken}%
+  \Crefname{section}{Paragraaf}{Paragrafen}%
+  \Crefname{subsection}{Paragraaf}{Paragrafen}%
+  \Crefname{subsubsection}{Paragraaf}{Paragrafen}%
+  \Crefname{appendix}{Appendix}{Appendices}%
+  \Crefname{subappendix}{Appendix}{Appendices}%
+  \Crefname{subsubappendix}{Appendix}{Appendices}%
+  \Crefname{subsubsubappendix}{Appendix}{Appendices}%
+  \Crefname{enumi}{Punt}{Punten}%
+  \Crefname{enumii}{Punt}{Punten}%
+  \Crefname{enumiii}{Punt}{Punten}%
+  \Crefname{enumiv}{Punt}{Punten}%
+  \Crefname{enumv}{Punt}{Punten}%
+  \Crefname{footnote}{Voetnote}{Voetnoten}%
+  \Crefname{theorem}{Theorema}{Theorema's}%
+  \Crefname{lemma}{Lemma}{Lemma's}%
+  \Crefname{corollary}{Corollarium}{Corollaria}%
+  \Crefname{proposition}{Bewering}{Beweringen}%
+  \Crefname{definition}{Definitie}{Definities}%
+  \Crefname{result}{Resultaat}{Resultaten}%
+  \Crefname{example}{Voorbeeld}{Voorbeelden}%
+  \Crefname{remark}{Opmerking}{Opmerkingen}%
+  \Crefname{note}{Aantekening}{Aantekeningen}%
+  \Crefname{algorithm}{Algoritme}{Algoritmen}%
+  \Crefname{listing}{Listing}{Listings}%
+  \Crefname{line}{Lijn}{Lijnen}%
+ %
+  \if@cref@capitalise%  capitalise set
+    \if@cref@abbrev%
+      \crefname{equation}{Verg.}{Verg's.}%
+      \crefname{figure}{Fig.}{Fig's.}%
+      \crefname{subfigure}{Fig.}{Fig's.}%
+    \else%
+      \crefname{equation}{Vergel\ij{}king}{Vergel\ij{}kingen}%
+      \crefname{figure}{Figuur}{Figuren}%
+      \crefname{subfigure}{Figuur}{Figuren}%
+    \fi%
+    \crefname{table}{Tabel}{Tabellen}%
+    \crefname{subtable}{Tabel}{Tabellen}%
+    \crefname{page}{Pagina}{Pagina's}%
+    \crefname{part}{Deel}{Delen}%
+    \crefname{chapter}{Hoofdstuk}{Hoofdstukken}%
+    \crefname{section}{Paragraaf}{Paragrafen}%
+    \crefname{appendix}{Appendix}{Appendices}%
+    \crefname{enumi}{Punt}{Punten}%
+    \crefname{footnote}{Voetnote}{Voetnoten}%
+    \crefname{theorem}{Theorema}{Theorema's}%
+    \crefname{lemma}{Lemma}{Lemma's}%
+    \crefname{corollary}{Corollarium}{Corollaria}%
+    \crefname{proposition}{Bewering}{Beweringen}%
+    \crefname{definition}{Definitie}{Definities}%
+    \crefname{result}{Resultaat}{Resultaten}%
+    \crefname{example}{Voorbeeld}{Voorbeelden}%
+    \crefname{remark}{Opmerking}{Opmerkingen}%
+    \crefname{note}{Aantekening}{Aantekeningen}%
+    \crefname{algorithm}{Algoritme}{Algoritmen}%
+    \crefname{listing}{Listing}{Listings}%
+    \crefname{line}{Lijn}{Lijnen}%
+ %
+  \else%  capitalise unset
+    \if@cref@abbrev%
+      \crefname{equation}{verg.}{verg's.}%
+      \crefname{figure}{fig.}{fig's.}%
+      \crefname{subfigure}{fig.}{fig's.}%
+    \else%
+      \crefname{equation}{vergel\ij{}king}{vergel\ij{}kingen}%
+      \crefname{figure}{figuur}{figuren}%
+      \crefname{subfigure}{figuur}{figuren}%
+    \fi%
+    \crefname{table}{tabel}{tabellen}%
+    \crefname{subtable}{tabel}{tabellen}%
+    \crefname{page}{pagina}{pagina's}%
+    \crefname{part}{deel}{delen}%
+    \crefname{chapter}{hoofdstuk}{hoofdstukken}%
+    \crefname{section}{paragraaf}{paragrafen}%
+    \crefname{appendix}{appendix}{appendices}%
+    \crefname{enumi}{punt}{punten}%
+    \crefname{footnote}{voetnote}{voetnoten}%
+    \crefname{theorem}{theorema}{theorema's}%
+    \crefname{lemma}{lemma}{lemma's}%
+    \crefname{corollary}{corollarium}{corollaria}%
+    \crefname{proposition}{bewering}{beweringen}%
+    \crefname{definition}{definitie}{definities}%
+    \crefname{result}{resultaat}{resultaten}%
+    \crefname{example}{voorbeeld}{voorbeelden}%
+    \crefname{remark}{opmerking}{opmerkingen}%
+    \crefname{note}{aantekening}{aantekeningen}%
+    \crefname{algorithm}{algoritme}{algoritmen}%
+    \crefname{listing}{listing}{listings}%
+    \crefname{line}{lijn}{lijnen}%
+  \fi}% end \cref@addlanguagedefs
 \DeclareOption{french}{%
-  \PackageInfo{cleveref}{loaded `french' language definitions}
   \AtBeginDocument{%
     \def\crefrangeconjunction@preamble{ \`a\nobreakspace}%
     \def\crefrangepreconjunction@preamble{}%
@@ -3637,15 +4364,17 @@
     \def\crefpairgroupconjunction@preamble{ et\nobreakspace}%
     \def\crefmiddlegroupconjunction@preamble{, }%
     \def\creflastgroupconjunction@preamble{, et\nobreakspace}%
+ %
     \Crefname@preamble{equation}{{\'E}quation}{{\'E}quations}%
+    \Crefname@preamble{figure}{Figure}{Figures}%
+    \Crefname@preamble{table}{Tableau}{Tableaux}%
+    \Crefname@preamble{page}{Page}{Pages}%
     \Crefname@preamble{part}{Partie}{Parties}%
     \Crefname@preamble{chapter}{Chapitre}{Chapitres}%
     \Crefname@preamble{section}{Section}{Sections}%
     \Crefname@preamble{appendix}{Annexe}{Annexes}%
     \Crefname@preamble{enumi}{Point}{Points}%
     \Crefname@preamble{footnote}{Note}{Notes}%
-    \Crefname@preamble{figure}{Figure}{Figures}%
-    \Crefname@preamble{table}{Tableau}{Tableaux}%
     \Crefname@preamble{theorem}{Th\'eor\`eme}{Th\'eor\`emes}%
     \Crefname@preamble{lemma}{Lemme}{Lemmes}%
     \Crefname@preamble{corollary}{Corollaire}{Corollaires}%
@@ -3657,16 +4386,18 @@
     \Crefname@preamble{algorithm}{Algorithme}{Algorithmes}%
     \Crefname@preamble{listing}{Liste}{Listes}%
     \Crefname@preamble{line}{Ligne}{Lignes}%
-    \if@cref@capitalise%
+ %
+    \if@cref@capitalise%  capitalise set
       \crefname@preamble{equation}{{\'E}quation}{{\'E}quations}%
+      \crefname@preamble{figure}{Figure}{Figures}%
+      \crefname@preamble{table}{Tableau}{Tableaux}%
+      \crefname@preamble{page}{Page}{Pages}%
       \crefname@preamble{part}{Partie}{Parties}%
       \crefname@preamble{chapter}{Chapitre}{Chapitres}%
       \crefname@preamble{section}{Section}{Sections}%
       \crefname@preamble{appendix}{Annexe}{Annexes}%
       \crefname@preamble{enumi}{Point}{Points}%
       \crefname@preamble{footnote}{Note}{Notes}%
-      \crefname@preamble{figure}{Figure}{Figures}%
-      \crefname@preamble{table}{Tableau}{Tableaux}%
       \crefname@preamble{theorem}{Th\'eor\`eme}{Th\'eor\`emes}%
       \crefname@preamble{lemma}{Lemme}{Lemmes}%
       \crefname@preamble{corollary}{Corollaire}{Corollaires}%
@@ -3679,16 +4410,18 @@
       \crefname@preamble{algorithm}{Algorithme}{Algorithmes}%
       \crefname@preamble{listing}{Liste}{Listes}%
       \crefname@preamble{line}{Ligne}{Lignes}%
-    \else%
+ %
+    \else%  capitalise unset
       \crefname@preamble{equation}{{\'e}quation}{{\'e}quations}%
+      \crefname@preamble{figure}{figure}{figures}%
+      \crefname@preamble{table}{tableau}{tableaux}%
+      \crefname@preamble{page}{page}{pages}%
       \crefname@preamble{part}{partie}{parties}%
       \crefname@preamble{chapter}{chapitre}{chapitres}%
       \crefname@preamble{section}{section}{sections}%
       \crefname@preamble{appendix}{annexe}{annexes}%
       \crefname@preamble{enumi}{point}{points}%
       \crefname@preamble{footnote}{note}{notes}%
-      \crefname@preamble{figure}{figure}{figures}%
-      \crefname@preamble{table}{tableau}{tableaux}%
       \crefname@preamble{theorem}{th\'eor\`eme}{th\'eor\`emes}%
       \crefname@preamble{lemma}{lemme}{lemmes}%
       \crefname@preamble{corollary}{corollaire}{corollaires}%
@@ -3703,118 +4436,124 @@
       \crefname@preamble{line}{ligne}{lignes}%
     \fi%
     \def\cref@language{french}%
-    \cref@addto\extrasfrench{%
-      \renewcommand{\crefrangeconjunction}{ \`a\nobreakspace}%
-      \renewcommand\crefrangepreconjunction{}%
-      \renewcommand\crefrangepostconjunction{}%
-      \renewcommand{\crefpairconjunction}{ et\nobreakspace}%
-      \renewcommand{\crefmiddleconjunction}{, }%
-      \renewcommand{\creflastconjunction}{ et\nobreakspace}%
-      \renewcommand{\crefpairgroupconjunction}{ et\nobreakspace}%
-      \renewcommand{\crefmiddlegroupconjunction}{, }%
-      \renewcommand{\creflastgroupconjunction}{ et\nobreakspace}%
-      \Crefname{equation}{{\'E}quation}{{\'E}quations}%
-      \Crefname{part}{Partie}{Parties}%
-      \Crefname{chapter}{Chapitre}{Chapitres}%
-      \Crefname{section}{Section}{Sections}%
-      \Crefname{subsection}{Section}{Sections}%
-      \Crefname{subsubsection}{Section}{Sections}%
-      \Crefname{appendix}{Annexe}{Annexes}%
-      \Crefname{subappendix}{Annexe}{Annexes}%
-      \Crefname{subsubappendix}{Annexe}{Annexes}%
-      \Crefname{subsubsubappendix}{Annexe}{Annexes}%
-      \Crefname{enumi}{Point}{Points}%
-      \Crefname{enumii}{Point}{Points}%
-      \Crefname{enumiii}{Point}{Points}%
-      \Crefname{enumiv}{Point}{Points}%
-      \Crefname{enumv}{Point}{Points}%
-      \Crefname{footnote}{Note}{Notes}%
-      \Crefname{figure}{Figure}{Figures}%
-      \Crefname{subfigure}{Figure}{Figures}%
-      \Crefname{table}{Tableau}{Tableaux}%
-      \Crefname{subtable}{Tableau}{Tableaux}%
-      \Crefname{theorem}{Th\'eor\`eme}{Th\'eor\`emes}%
-      \Crefname{lemma}{Lemme}{Lemmes}%
-      \Crefname{corollary}{Corollaire}{Corollaires}%
-      \Crefname{proposition}{Proposition}{Propositions}%
-      \Crefname{definition}{D\'efinition}{D\'efinitions}%
-      \Crefname{result}{R\'esultat}{R\'esultats}%
-      \Crefname{example}{Exemple}{Exemples}%
-      \Crefname{remark}{Remarque}{Remarques}%
-      \Crefname{note}{Commentaire}{Commentaires}%
-      \Crefname{algorithm}{Algorithme}{Algorithmes}%
-      \Crefname{listing}{Liste}{Listes}%
-      \Crefname{line}{Ligne}{Lignes}%
-      \if@cref@capitalise%
-        \crefname{equation}{{\'E}quation}{{\'E}quations}%
-        \crefname{part}{Partie}{Parties}%
-        \crefname{chapter}{Chapitre}{Chapitres}%
-        \crefname{section}{Section}{Sections}%
-        \crefname{subsection}{Section}{Sections}%
-        \crefname{subsubsection}{Section}{Sections}%
-        \crefname{appendix}{Annexe}{Annexes}%
-        \crefname{subappendix}{Annexe}{Annexes}%
-        \crefname{subsubappendix}{Annexe}{Annexes}%
-        \crefname{subsubsubappendix}{Annexe}{Annexes}%
-        \crefname{enumi}{Point}{Points}%
-        \crefname{enumii}{Point}{Points}%
-        \crefname{enumiii}{Point}{Points}%
-        \crefname{enumiv}{Point}{Points}%
-        \crefname{enumv}{Point}{Points}%
-        \crefname{footnote}{Note}{Notes}%
-        \crefname{figure}{Figure}{Figures}%
-        \crefname{subfigure}{Figure}{Figures}%
-        \crefname{table}{Tableau}{Tableaux}%
-        \crefname{subtable}{Tableau}{Tableaux}%
-        \crefname{theorem}{Th\'eor\`eme}{Th\'eor\`emes}%
-        \crefname{lemma}{Lemme}{Lemmes}%
-        \crefname{corollary}{Corollaire}{Corollaires}%
-        \crefname{proposition}{Proposition}{Propositions}%
-        \crefname{definition}{D\'efinition}{D\'efinitions}%
-        \crefname{result}{R\'esultat}{R\'esultats}%
-        \crefname{example}{Exemple}{Exemples}%
-        \crefname{remark}{Remarque}{Remarques}%
-        \crefname{note}{Commentaire}{Commentaires}%
-        \crefname{algorithm}{Algorithme}{Algorithmes}%
-        \crefname{listing}{Liste}{Listes}%
-        \crefname{line}{Ligne}{Lignes}%
-      \else%
-        \crefname{equation}{{\'e}quation}{{\'e}quations}%
-        \crefname{part}{partie}{parties}%
-        \crefname{chapter}{chapitre}{chapitres}%
-        \crefname{section}{section}{sections}%
-        \crefname{subsection}{section}{sections}%
-        \crefname{subsubsection}{section}{sections}%
-        \crefname{appendix}{annexe}{annexes}%
-        \crefname{subappendix}{annexe}{annexes}%
-        \crefname{subsubappendix}{annexe}{annexes}%
-        \crefname{subsubsubappendix}{annexe}{annexes}%
-        \crefname{enumi}{point}{points}%
-        \crefname{enumii}{point}{points}%
-        \crefname{enumiii}{point}{points}%
-        \crefname{enumiv}{point}{points}%
-        \crefname{enumv}{point}{points}%
-        \crefname{footnote}{note}{notes}%
-        \crefname{figure}{figure}{figures}%
-        \crefname{subfigure}{figure}{figures}%
-        \crefname{table}{tableau}{tableaux}%
-        \crefname{subtable}{tableau}{tableaux}%
-        \crefname{theorem}{th\'eor\`eme}{th\'eor\`emes}%
-        \crefname{lemma}{lemme}{lemmes}%
-        \crefname{corollary}{corollaire}{corollaires}%
-        \crefname{proposition}{proposition}{propositions}%
-        \crefname{definition}{d\'efinition}{d\'efinitions}%
-        \crefname{result}{r\'esultat}{r\'esultats}%
-        \crefname{example}{exemple}{exemples}%
-        \crefname{remark}{remarque}{remarques}%
-        \crefname{note}{commentaire}{commentaires}%
-        \crefname{algorithm}{algorithme}{algorithmes}%
-        \crefname{listing}{liste}{listes}%
-        \crefname{line}{ligne}{lignes}%
-      \fi%
-    }}}
+  }}% end \DeclareOption and \AtBeginDocument
+\cref@addlanguagedefs{french}{%
+  \PackageInfo{cleveref}{loaded `french' language definitions}%
+  \renewcommand{\crefrangeconjunction}{ \`a\nobreakspace}%
+  \renewcommand\crefrangepreconjunction{}%
+  \renewcommand\crefrangepostconjunction{}%
+  \renewcommand{\crefpairconjunction}{ et\nobreakspace}%
+  \renewcommand{\crefmiddleconjunction}{, }%
+  \renewcommand{\creflastconjunction}{ et\nobreakspace}%
+  \renewcommand{\crefpairgroupconjunction}{ et\nobreakspace}%
+  \renewcommand{\crefmiddlegroupconjunction}{, }%
+  \renewcommand{\creflastgroupconjunction}{ et\nobreakspace}%
+ %
+  \Crefname{equation}{{\'E}quation}{{\'E}quations}%
+  \Crefname{figure}{Figure}{Figures}%
+  \Crefname{subfigure}{Figure}{Figures}%
+  \Crefname{table}{Tableau}{Tableaux}%
+  \Crefname{subtable}{Tableau}{Tableaux}%
+  \Crefname{page}{Page}{Pages}%
+  \Crefname{part}{Partie}{Parties}%
+  \Crefname{chapter}{Chapitre}{Chapitres}%
+  \Crefname{section}{Section}{Sections}%
+  \Crefname{subsection}{Section}{Sections}%
+  \Crefname{subsubsection}{Section}{Sections}%
+  \Crefname{appendix}{Annexe}{Annexes}%
+  \Crefname{subappendix}{Annexe}{Annexes}%
+  \Crefname{subsubappendix}{Annexe}{Annexes}%
+  \Crefname{subsubsubappendix}{Annexe}{Annexes}%
+  \Crefname{enumi}{Point}{Points}%
+  \Crefname{enumii}{Point}{Points}%
+  \Crefname{enumiii}{Point}{Points}%
+  \Crefname{enumiv}{Point}{Points}%
+  \Crefname{enumv}{Point}{Points}%
+  \Crefname{footnote}{Note}{Notes}%
+  \Crefname{theorem}{Th\'eor\`eme}{Th\'eor\`emes}%
+  \Crefname{lemma}{Lemme}{Lemmes}%
+  \Crefname{corollary}{Corollaire}{Corollaires}%
+  \Crefname{proposition}{Proposition}{Propositions}%
+  \Crefname{definition}{D\'efinition}{D\'efinitions}%
+  \Crefname{result}{R\'esultat}{R\'esultats}%
+  \Crefname{example}{Exemple}{Exemples}%
+  \Crefname{remark}{Remarque}{Remarques}%
+  \Crefname{note}{Commentaire}{Commentaires}%
+  \Crefname{algorithm}{Algorithme}{Algorithmes}%
+  \Crefname{listing}{Liste}{Listes}%
+  \Crefname{line}{Ligne}{Lignes}%
+ %
+  \if@cref@capitalise%  capitalise set
+    \crefname{equation}{{\'E}quation}{{\'E}quations}%
+    \crefname{figure}{Figure}{Figures}%
+    \crefname{subfigure}{Figure}{Figures}%
+    \crefname{table}{Tableau}{Tableaux}%
+    \crefname{subtable}{Tableau}{Tableaux}%
+    \crefname{page}{Page}{Pages}%
+    \crefname{part}{Partie}{Parties}%
+    \crefname{chapter}{Chapitre}{Chapitres}%
+    \crefname{section}{Section}{Sections}%
+    \crefname{subsection}{Section}{Sections}%
+    \crefname{subsubsection}{Section}{Sections}%
+    \crefname{appendix}{Annexe}{Annexes}%
+    \crefname{subappendix}{Annexe}{Annexes}%
+    \crefname{subsubappendix}{Annexe}{Annexes}%
+    \crefname{subsubsubappendix}{Annexe}{Annexes}%
+    \crefname{enumi}{Point}{Points}%
+    \crefname{enumii}{Point}{Points}%
+    \crefname{enumiii}{Point}{Points}%
+    \crefname{enumiv}{Point}{Points}%
+    \crefname{enumv}{Point}{Points}%
+    \crefname{footnote}{Note}{Notes}%
+    \crefname{theorem}{Th\'eor\`eme}{Th\'eor\`emes}%
+    \crefname{lemma}{Lemme}{Lemmes}%
+    \crefname{corollary}{Corollaire}{Corollaires}%
+    \crefname{proposition}{Proposition}{Propositions}%
+    \crefname{definition}{D\'efinition}{D\'efinitions}%
+    \crefname{result}{R\'esultat}{R\'esultats}%
+    \crefname{example}{Exemple}{Exemples}%
+    \crefname{remark}{Remarque}{Remarques}%
+    \crefname{note}{Commentaire}{Commentaires}%
+    \crefname{algorithm}{Algorithme}{Algorithmes}%
+    \crefname{listing}{Liste}{Listes}%
+    \crefname{line}{Ligne}{Lignes}%
+ %
+  \else%  capitalise unset
+    \crefname{equation}{{\'e}quation}{{\'e}quations}%
+    \crefname{figure}{figure}{figures}%
+    \crefname{subfigure}{figure}{figures}%
+    \crefname{table}{tableau}{tableaux}%
+    \crefname{subtable}{tableau}{tableaux}%
+    \crefname{page}{page}{pages}%
+    \crefname{part}{partie}{parties}%
+    \crefname{chapter}{chapitre}{chapitres}%
+    \crefname{section}{section}{sections}%
+    \crefname{subsection}{section}{sections}%
+    \crefname{subsubsection}{section}{sections}%
+    \crefname{appendix}{annexe}{annexes}%
+    \crefname{subappendix}{annexe}{annexes}%
+    \crefname{subsubappendix}{annexe}{annexes}%
+    \crefname{subsubsubappendix}{annexe}{annexes}%
+    \crefname{enumi}{point}{points}%
+    \crefname{enumii}{point}{points}%
+    \crefname{enumiii}{point}{points}%
+    \crefname{enumiv}{point}{points}%
+    \crefname{enumv}{point}{points}%
+    \crefname{footnote}{note}{notes}%
+    \crefname{theorem}{th\'eor\`eme}{th\'eor\`emes}%
+    \crefname{lemma}{lemme}{lemmes}%
+    \crefname{corollary}{corollaire}{corollaires}%
+    \crefname{proposition}{proposition}{propositions}%
+    \crefname{definition}{d\'efinition}{d\'efinitions}%
+    \crefname{result}{r\'esultat}{r\'esultats}%
+    \crefname{example}{exemple}{exemples}%
+    \crefname{remark}{remarque}{remarques}%
+    \crefname{note}{commentaire}{commentaires}%
+    \crefname{algorithm}{algorithme}{algorithmes}%
+    \crefname{listing}{liste}{listes}%
+    \crefname{line}{ligne}{lignes}%
+  \fi}% end \cref@loadlanguagedefs
 \DeclareOption{spanish}{%
-  \PackageInfo{cleveref}{loaded `spanish' language definitions}
   \AtBeginDocument{%
     \def\crefrangeconjunction@preamble{ a\nobreakspace}%
     \def\crefrangepreconjunction@preamble{}%
@@ -3825,15 +4564,17 @@
     \def\crefpairgroupconjunction@preamble{ y\nobreakspace}%
     \def\crefmiddlegroupconjunction@preamble{, }%
     \def\creflastgroupconjunction@preamble{ y\nobreakspace}%
+ %
     \Crefname@preamble{equation}{Ecuaci\'on}{Ecuaciones}%
+    \Crefname@preamble{figure}{Figura}{Figuras}%
+    \Crefname@preamble{table}{Cuadro}{Cuadros}%
+    \Crefname@preamble{page}{P\'agina}{P\'aginas}%
     \Crefname@preamble{part}{Parte}{Partes}%
     \Crefname@preamble{chapter}{Cap\'itulo}{Cap\'itulos}%
-    \Crefname@preamble{section}{Secci\'on}{Secciones}%
+    \Crefname@preamble{section}{Apartado}{Apartados}%
     \Crefname@preamble{appendix}{Ap\'endice}{Ap\'endices}%
     \Crefname@preamble{enumi}{Punto}{Puntos}%
     \Crefname@preamble{footnote}{Nota}{Notas}%
-    \Crefname@preamble{figure}{Figura}{Figuras}%
-    \Crefname@preamble{table}{Cuadro}{Cuadros}%
     \Crefname@preamble{theorem}{Teorema}{Teoremas}%
     \Crefname@preamble{lemma}{Lema}{Lemas}%
     \Crefname@preamble{corollary}{Corolario}{Corolarios}%
@@ -3846,16 +4587,18 @@
     \Crefname@preamble{algorithm}{Algoritmo}{Algoritmos}%
     \Crefname@preamble{listing}{Listado}{Listados}%
     \Crefname@preamble{line}{L\'inea}{L\'ineas}%
-    \if@cref@capitalise%
+ %
+    \if@cref@capitalise%  capitalise set
       \crefname@preamble{equation}{Ecuaci\'on}{Ecuaciones}%
+      \crefname@preamble{figure}{Figura}{Figuras}%
+      \crefname@preamble{table}{Cuadro}{Cuadros}%
+      \crefname@preamble{page}{P\'agina}{P\'aginas}%
       \crefname@preamble{part}{Parte}{Partes}%
       \crefname@preamble{chapter}{Cap\'itulo}{Cap\'itulos}%
-      \crefname@preamble{section}{Secci\'on}{Secciones}%
+      \crefname@preamble{section}{Apartado}{Apartados}%
       \crefname@preamble{appendix}{Ap\'endice}{Ap\'endices}%
       \crefname@preamble{enumi}{Punto}{Puntos}%
       \crefname@preamble{footnote}{Nota}{Notas}%
-      \crefname@preamble{figure}{Figura}{Figuras}%
-      \crefname@preamble{table}{Cuadro}{Cuadros}%
       \crefname@preamble{theorem}{Teorema}{Teoremas}%
       \crefname@preamble{lemma}{Lema}{Lemas}%
       \crefname@preamble{corollary}{Corolario}{Corolarios}%
@@ -3868,16 +4611,18 @@
       \crefname@preamble{algorithm}{Algoritmo}{Algoritmos}%
       \crefname@preamble{listing}{Listado}{Listados}%
       \crefname@preamble{line}{L\'inea}{L\'ineas}%
-    \else%
+ %
+    \else%  capitalise unset
       \crefname@preamble{equation}{ecuaci\'on}{ecuaciones}%
+      \crefname@preamble{figure}{figura}{figuras}%
+      \crefname@preamble{table}{cuadro}{cuadros}%
+      \crefname@preamble{page}{p\'agina}{p\'aginas}%
       \crefname@preamble{part}{parte}{partes}%
       \crefname@preamble{chapter}{cap\'itulo}{cap\'itulos}%
-      \crefname@preamble{section}{secci\'on}{secciones}%
+      \crefname@preamble{section}{apartado}{apartados}%
       \crefname@preamble{appendix}{ap\'endice}{ap\'endices}%
       \crefname@preamble{enumi}{punto}{puntos}%
       \crefname@preamble{footnote}{nota}{notas}%
-      \crefname@preamble{figure}{figura}{figuras}%
-      \crefname@preamble{table}{cuadro}{cuadros}%
       \crefname@preamble{theorem}{teorema}{teoremas}%
       \crefname@preamble{lemma}{lema}{lemas}%
       \crefname@preamble{corollary}{corolario}{corolarios}%
@@ -3892,118 +4637,124 @@
       \crefname@preamble{line}{l\'inea}{l\'ineas}%
     \fi%
     \def\cref@language{spanish}%
-    \cref@addto\extrasspanish{%
-      \renewcommand{\crefrangeconjunction}{ a\nobreakspace}%
-      \renewcommand{\crefrangepreconjunction}{}%
-      \renewcommand{\crefrangepostconjunction}{}%
-      \renewcommand{\crefpairconjunction}{ y\nobreakspace}%
-      \renewcommand{\crefmiddleconjunction}{, }%
-      \renewcommand{\creflastconjunction}{ y\nobreakspace}%
-      \renewcommand{\crefpairgroupconjunction}{ y\nobreakspace}%
-      \renewcommand{\crefmiddlegroupconjunction}{, }%
-      \renewcommand{\creflastgroupconjunction}{ y\nobreakspace}%
-      \Crefname{equation}{Ecuaci\'on}{Ecuaciones}%
-      \Crefname{part}{Parte}{Partes}%
-      \Crefname{chapter}{Cap\'itulo}{Cap\'itulos}%
-      \Crefname{section}{Secci\'on}{Secciones}%
-      \Crefname{subsection}{Secci\'on}{Secciones}%
-      \Crefname{subsubsection}{Secci\'on}{Secciones}%
-      \Crefname{appendix}{Ap\'endice}{Ap\'endices}%
-      \Crefname{subappendix}{Ap\'endice}{Ap\'endices}%
-      \Crefname{subsubappendix}{Ap\'endice}{Ap\'endices}%
-      \Crefname{subsubsubappendix}{Ap\'endice}{Ap\'endices}%
-      \Crefname{enumi}{Punto}{Puntos}%
-      \Crefname{enumii}{Punto}{Puntos}%
-      \Crefname{enumiii}{Punto}{Puntos}%
-      \Crefname{enumiv}{Punto}{Puntos}%
-      \Crefname{enumv}{Punto}{Puntos}%
-      \Crefname{footnote}{Nota}{Notas}%
-      \Crefname{figure}{Figura}{Figuras}%
-      \Crefname{subfigure}{Figura}{Figuras}%
-      \Crefname{table}{Cuadro}{Cuadros}%
-      \Crefname{subtable}{Cuadro}{Cuadros}%
-      \Crefname{theorem}{Teorema}{Teoremas}%
-      \Crefname{lemma}{Lema}{Lemas}%
-      \Crefname{corollary}{Corolario}{Corolarios}%
-      \Crefname{proposition}{Proposici\'on}{Proposiciones}%
-      \Crefname{definition}{Definici\'on}{Definiciones}%
-      \Crefname{result}{Resultado}{Resultados}%
-      \Crefname{example}{Ejemplo}{Ejemplos}%
-      \Crefname{remark}{Observaci\'on}{Observaci\'on}%
-      \Crefname{note}{Nota}{Notas}%
-      \Crefname{algorithm}{Algoritmo}{Algoritmos}%
-      \Crefname{listing}{Listado}{Listados}%
-      \Crefname{line}{L\'inea}{L\'ineas}%
-      \if@cref@capitalise%
-        \crefname{equation}{Ecuaci\'on}{Ecuaciones}%
-        \crefname{part}{Parte}{Partes}%
-        \crefname{chapter}{Cap\'itulo}{Cap\'itulos}%
-        \crefname{section}{Secci\'on}{Secciones}%
-        \crefname{subsection}{Secci\'on}{Secciones}%
-        \crefname{subsubsection}{Secci\'on}{Secciones}%
-        \crefname{appendix}{Ap\'endice}{Ap\'endices}%
-        \crefname{subappendix}{Ap\'endice}{Ap\'endices}%
-        \crefname{subsubappendix}{Ap\'endice}{Ap\'endices}%
-        \crefname{subsubsubappendix}{Ap\'endice}{Ap\'endices}%
-        \crefname{enumi}{Punto}{Puntos}%
-        \crefname{enumii}{Punto}{Puntos}%
-        \crefname{enumiii}{Punto}{Puntos}%
-        \crefname{enumiv}{Punto}{Puntos}%
-        \crefname{enumv}{Punto}{Puntos}%
-        \crefname{footnote}{Nota}{Notas}%
-        \crefname{figure}{Figura}{Figuras}%
-        \crefname{subfigure}{Figura}{Figuras}%
-        \crefname{table}{Cuadro}{Cuadros}%
-        \crefname{subtable}{Cuadro}{Cuadros}%
-        \crefname{theorem}{Teorema}{Teoremas}%
-        \crefname{lemma}{Lema}{Lemas}%
-        \crefname{corollary}{Corolario}{Corolarios}%
-        \crefname{proposition}{Proposici\'on}{Proposiciones}%
-        \crefname{definition}{Definici\'on}{Definiciones}%
-        \crefname{result}{Resultado}{Resultados}%
-        \crefname{example}{Ejemplo}{Ejemplos}%
-        \crefname{remark}{Observaci\'on}{Observaci\'ones}%
-        \crefname{note}{Nota}{Notas}%
-        \crefname{algorithm}{Algoritmo}{Algoritmos}%
-        \crefname{listing}{Listado}{Listados}%
-        \crefname{line}{L\'inea}{L\'ineas}%
-      \else%
-        \crefname{equation}{ecuaci\'on}{ecuaciones}%
-        \crefname{part}{parte}{partes}%
-        \crefname{chapter}{cap\'itulo}{cap\'itulos}%
-        \crefname{section}{secci\'on}{secciones}%
-        \crefname{subsection}{secci\'on}{secciones}%
-        \crefname{subsubsection}{secci\'on}{secciones}%
-        \crefname{appendix}{ap\'endice}{ap\'endices}%
-        \crefname{subappendix}{ap\'endice}{ap\'endices}%
-        \crefname{subsubappendix}{ap\'endice}{ap\'endices}%
-        \crefname{subsubsubappendix}{ap\'endice}{ap\'endices}%
-        \crefname{enumi}{punto}{puntos}%
-        \crefname{enumii}{punto}{puntos}%
-        \crefname{enumiii}{punto}{puntos}%
-        \crefname{enumiv}{punto}{puntos}%
-        \crefname{enumv}{punto}{puntos}%
-        \crefname{footnote}{nota}{notas}%
-        \crefname{figure}{figura}{figuras}%
-        \crefname{subfigure}{figura}{figuras}%
-        \crefname{table}{cuadro}{cuadros}%
-        \crefname{subtable}{cuadro}{cuadros}%
-        \crefname{theorem}{teorema}{teoremas}%
-        \crefname{lemma}{lema}{lemas}%
-        \crefname{corollary}{corolario}{corolarios}%
-        \crefname{proposition}{proposici\'on}{proposiciones}%
-        \crefname{definition}{definici\'on}{definiciones}%
-        \crefname{result}{resultado}{resultados}%
-        \crefname{example}{ejemplo}{ejemplos}%
-        \crefname{remark}{observaci\'on}{observaci\'ones}%
-        \crefname{note}{nota}{notas}%
-        \crefname{algorithm}{algoritmo}{algoritmos}%
-        \crefname{listing}{listado}{listados}%
-        \crefname{line}{l\'inea}{l\'ineas}%
-      \fi%
-    }}}
+  }}% end \DeclareOption and \AtBeginDocument
+\cref@addlanguagedefs{spanish}{%
+  \PackageInfo{cleveref}{loaded `spanish' language definitions}%
+  \renewcommand{\crefrangeconjunction}{ a\nobreakspace}%
+  \renewcommand{\crefrangepreconjunction}{}%
+  \renewcommand{\crefrangepostconjunction}{}%
+  \renewcommand{\crefpairconjunction}{ y\nobreakspace}%
+  \renewcommand{\crefmiddleconjunction}{, }%
+  \renewcommand{\creflastconjunction}{ y\nobreakspace}%
+  \renewcommand{\crefpairgroupconjunction}{ y\nobreakspace}%
+  \renewcommand{\crefmiddlegroupconjunction}{, }%
+  \renewcommand{\creflastgroupconjunction}{ y\nobreakspace}%
+ %
+  \Crefname{equation}{Ecuaci\'on}{Ecuaciones}%
+  \Crefname{figure}{Figura}{Figuras}%
+  \Crefname{subfigure}{Figura}{Figuras}%
+  \Crefname{table}{Cuadro}{Cuadros}%
+  \Crefname{subtable}{Cuadro}{Cuadros}%
+  \Crefname{page}{P\'agina}{P\'aginas}%
+  \Crefname{part}{Parte}{Partes}%
+  \Crefname{chapter}{Cap\'itulo}{Cap\'itulos}%
+  \Crefname{section}{Apartado}{Apartados}%
+  \Crefname{subsection}{Apartado}{Apartados}%
+  \Crefname{subsubsection}{Apartado}{Apartados}%
+  \Crefname{appendix}{Ap\'endice}{Ap\'endices}%
+  \Crefname{subappendix}{Ap\'endice}{Ap\'endices}%
+  \Crefname{subsubappendix}{Ap\'endice}{Ap\'endices}%
+  \Crefname{subsubsubappendix}{Ap\'endice}{Ap\'endices}%
+  \Crefname{enumi}{Punto}{Puntos}%
+  \Crefname{enumii}{Punto}{Puntos}%
+  \Crefname{enumiii}{Punto}{Puntos}%
+  \Crefname{enumiv}{Punto}{Puntos}%
+  \Crefname{enumv}{Punto}{Puntos}%
+  \Crefname{footnote}{Nota}{Notas}%
+  \Crefname{theorem}{Teorema}{Teoremas}%
+  \Crefname{lemma}{Lema}{Lemas}%
+  \Crefname{corollary}{Corolario}{Corolarios}%
+  \Crefname{proposition}{Proposici\'on}{Proposiciones}%
+  \Crefname{definition}{Definici\'on}{Definiciones}%
+  \Crefname{result}{Resultado}{Resultados}%
+  \Crefname{example}{Ejemplo}{Ejemplos}%
+  \Crefname{remark}{Observaci\'on}{Observaci\'on}%
+  \Crefname{note}{Nota}{Notas}%
+  \Crefname{algorithm}{Algoritmo}{Algoritmos}%
+  \Crefname{listing}{Listado}{Listados}%
+  \Crefname{line}{L\'inea}{L\'ineas}%
+ %
+  \if@cref@capitalise%  capitalise set
+    \crefname{equation}{Ecuaci\'on}{Ecuaciones}%
+    \crefname{figure}{Figura}{Figuras}%
+    \crefname{subfigure}{Figura}{Figuras}%
+    \crefname{table}{Cuadro}{Cuadros}%
+    \crefname{subtable}{Cuadro}{Cuadros}%
+    \crefname{page}{P\'agina}{P\'aginas}%
+    \crefname{part}{Parte}{Partes}%
+    \crefname{chapter}{Cap\'itulo}{Cap\'itulos}%
+    \crefname{section}{Apartado}{Apartados}%
+    \crefname{subsection}{Apartado}{Apartados}%
+    \crefname{subsubsection}{Apartado}{Apartados}%
+    \crefname{appendix}{Ap\'endice}{Ap\'endices}%
+    \crefname{subappendix}{Ap\'endice}{Ap\'endices}%
+    \crefname{subsubappendix}{Ap\'endice}{Ap\'endices}%
+    \crefname{subsubsubappendix}{Ap\'endice}{Ap\'endices}%
+    \crefname{enumi}{Punto}{Puntos}%
+    \crefname{enumii}{Punto}{Puntos}%
+    \crefname{enumiii}{Punto}{Puntos}%
+    \crefname{enumiv}{Punto}{Puntos}%
+    \crefname{enumv}{Punto}{Puntos}%
+    \crefname{footnote}{Nota}{Notas}%
+    \crefname{theorem}{Teorema}{Teoremas}%
+    \crefname{lemma}{Lema}{Lemas}%
+    \crefname{corollary}{Corolario}{Corolarios}%
+    \crefname{proposition}{Proposici\'on}{Proposiciones}%
+    \crefname{definition}{Definici\'on}{Definiciones}%
+    \crefname{result}{Resultado}{Resultados}%
+    \crefname{example}{Ejemplo}{Ejemplos}%
+    \crefname{remark}{Observaci\'on}{Observaci\'ones}%
+    \crefname{note}{Nota}{Notas}%
+    \crefname{algorithm}{Algoritmo}{Algoritmos}%
+    \crefname{listing}{Listado}{Listados}%
+    \crefname{line}{L\'inea}{L\'ineas}%
+ %
+  \else%  capitalise unset
+    \crefname{equation}{ecuaci\'on}{ecuaciones}%
+    \crefname{figure}{figura}{figuras}%
+    \crefname{subfigure}{figura}{figuras}%
+    \crefname{table}{cuadro}{cuadros}%
+    \crefname{subtable}{cuadro}{cuadros}%
+    \crefname{page}{p\'agina}{p\'aginas}%
+    \crefname{part}{parte}{partes}%
+    \crefname{chapter}{cap\'itulo}{cap\'itulos}%
+    \crefname{section}{apartado}{apartados}%
+    \crefname{subsection}{apartado}{apartados}%
+    \crefname{subsubsection}{apartado}{apartados}%
+    \crefname{appendix}{ap\'endice}{ap\'endices}%
+    \crefname{subappendix}{ap\'endice}{ap\'endices}%
+    \crefname{subsubappendix}{ap\'endice}{ap\'endices}%
+    \crefname{subsubsubappendix}{ap\'endice}{ap\'endices}%
+    \crefname{enumi}{punto}{puntos}%
+    \crefname{enumii}{punto}{puntos}%
+    \crefname{enumiii}{punto}{puntos}%
+    \crefname{enumiv}{punto}{puntos}%
+    \crefname{enumv}{punto}{puntos}%
+    \crefname{footnote}{nota}{notas}%
+    \crefname{theorem}{teorema}{teoremas}%
+    \crefname{lemma}{lema}{lemas}%
+    \crefname{corollary}{corolario}{corolarios}%
+    \crefname{proposition}{proposici\'on}{proposiciones}%
+    \crefname{definition}{definici\'on}{definiciones}%
+    \crefname{result}{resultado}{resultados}%
+    \crefname{example}{ejemplo}{ejemplos}%
+    \crefname{remark}{observaci\'on}{observaci\'ones}%
+    \crefname{note}{nota}{notas}%
+    \crefname{algorithm}{algoritmo}{algoritmos}%
+    \crefname{listing}{listado}{listados}%
+    \crefname{line}{l\'inea}{l\'ineas}%
+  \fi}% end \cref@loadlanguagedefs
 \DeclareOption{italian}{%
-  \PackageInfo{cleveref}{loaded `italian' language definitions}
   \AtBeginDocument{%
     \def\crefrangeconjunction@preamble{ a\nobreakspace}%
     \def\crefrangepreconjunction@preamble{da\nobreakspace}%
@@ -4014,15 +4765,17 @@
     \def\crefpairgroupconjunction@preamble{ e\nobreakspace}%
     \def\crefmiddlegroupconjunction@preamble{, }%
     \def\creflastgroupconjunction@preamble{ e\nobreakspace}%
+ %
     \Crefname@preamble{equation}{Equazione}{Equazioni}%
+    \Crefname@preamble{figure}{Figura}{Figure}%
+    \Crefname@preamble{table}{Tabella}{Tabelle}%
+    \Crefname@preamble{page}{Pagina}{Pagine}%
     \Crefname@preamble{part}{Parte}{Parti}%
     \Crefname@preamble{chapter}{Capitolo}{Capitoli}%
     \Crefname@preamble{section}{Sezione}{Sezioni}%
     \Crefname@preamble{appendix}{Appendice}{Appendici}%
     \Crefname@preamble{enumi}{Voce}{Voci}%
     \Crefname@preamble{footnote}{Nota}{Note}%
-    \Crefname@preamble{figure}{Figura}{Figure}%
-    \Crefname@preamble{table}{Tabella}{Tabelle}%
     \Crefname@preamble{theorem}{Teorema}{Teoremi}%
     \Crefname@preamble{lemma}{Lemma}{Lemmi}%
     \Crefname@preamble{corollary}{Corollario}{Corollari}%
@@ -4035,16 +4788,23 @@
     \Crefname@preamble{algorithm}{Algoritmo}{Algoritmi}%
     \Crefname@preamble{listing}{Elenco}{Elenchi}%
     \Crefname@preamble{line}{Linea}{Linee}%
-    \if@cref@capitalise%
-      \crefname@preamble{equation}{Eq.}{Eq.}%
+ %
+    \if@cref@capitalise%  capitalise set
+      \if@cref@abbrev%
+        \crefname@preamble{equation}{Eq.}{Eq.}%
+        \crefname@preamble{figure}{Fig.}{Fig.}%
+      \else%
+        \crefname@preamble{equation}{Equazione}{Equazioni}%
+        \crefname@preamble{figure}{Figura}{Figure}%
+      \fi%
+      \crefname@preamble{table}{Tabella}{Tabelle}%
+      \crefname@preamble{page}{Pagina}{Pagine}%
       \crefname@preamble{part}{Parte}{Parti}%
       \crefname@preamble{chapter}{Capitolo}{Capitoli}%
       \crefname@preamble{section}{Sezione}{Sezioni}%
       \crefname@preamble{appendix}{Appendice}{Appendici}%
       \crefname@preamble{enumi}{Voce}{Voci}%
       \crefname@preamble{footnote}{Nota}{Note}%
-      \crefname@preamble{figure}{Fig.}{Fig.}%
-      \crefname@preamble{table}{Tabella}{Tabelle}%
       \crefname@preamble{theorem}{Teorema}{Teoremi}%
       \crefname@preamble{lemma}{Lemma}{Lemmi}%
       \crefname@preamble{corollary}{Corollario}{Corollari}%
@@ -4057,16 +4817,23 @@
       \crefname@preamble{algorithm}{Algoritmo}{Algoritmi}%
       \crefname@preamble{listing}{Elenco}{Elenchi}%
       \crefname@preamble{line}{Linea}{Linee}%
-    \else%
-      \crefname@preamble{equation}{eq.}{eq.}%
+ %
+    \else%  capitalise unset
+      \if@cref@abbrev%
+        \crefname@preamble{equation}{eq.}{eq.}%
+        \crefname@preamble{figure}{fig.}{fig.}%
+      \else%
+        \crefname@preamble{equation}{equazione}{equazioni}%
+        \crefname@preamble{figure}{figura}{figure}%
+      \fi%
+      \crefname@preamble{table}{tabella}{tabelle}%
+      \crefname@preamble{page}{pagina}{pagine}%
       \crefname@preamble{part}{parte}{parti}%
       \crefname@preamble{chapter}{capitolo}{capitoli}%
       \crefname@preamble{section}{sezione}{sezioni}%
       \crefname@preamble{appendix}{appendice}{appendici}%
       \crefname@preamble{enumi}{voce}{voci}%
       \crefname@preamble{footnote}{nota}{note}%
-      \crefname@preamble{figure}{fig.}{fig.}%
-      \crefname@preamble{table}{tabella}{tabelle}%
       \crefname@preamble{theorem}{teorema}{teoremi}%
       \crefname@preamble{lemma}{lemma}{lemmi}%
       \crefname@preamble{corollary}{corollario}{corollari}%
@@ -4081,118 +4848,136 @@
       \crefname@preamble{line}{linea}{linee}%
     \fi%
     \def\cref@language{italian}%
-    \cref@addto\extrasitalian{%
-      \renewcommand{\crefrangeconjunction}{ a\nobreakspace}%
-      \renewcommand\crefrangepreconjunction{da\nobreakspace}%
-      \renewcommand\crefrangepostconjunction{}%
-      \renewcommand{\crefpairconjunction}{ e\nobreakspace}%
-      \renewcommand{\crefmiddleconjunction}{, }%
-      \renewcommand{\creflastconjunction}{ e\nobreakspace}%
-      \renewcommand{\crefpairgroupconjunction}{ e\nobreakspace}%
-      \renewcommand{\crefmiddlegroupconjunction}{, }%
-      \renewcommand{\creflastgroupconjunction}{ e\nobreakspace}%
-      \Crefname{equation}{Equazione}{Equazioni}%
-      \Crefname{part}{Parte}{Parti}%
-      \Crefname{chapter}{Capitolo}{Capitoli}%
-      \Crefname{section}{Sezione}{Sezioni}%
-      \Crefname{subsection}{Sezione}{Sezioni}%
-      \Crefname{subsubsection}{Sezione}{Sezioni}%
-      \Crefname{appendix}{Appendice}{Appendici}%
-      \Crefname{subappendix}{Appendice}{Appendici}%
-      \Crefname{subsubappendix}{Appendice}{Appendici}%
-      \Crefname{subsubsubappendix}{Appendice}{Appendici}%
-      \Crefname{enumi}{Voce}{Voci}%
-      \Crefname{enumii}{Voce}{Voci}%
-      \Crefname{enumiii}{Voce}{Voci}%
-      \Crefname{enumiv}{Voce}{Voci}%
-      \Crefname{enumv}{Voce}{Voci}%
-      \Crefname{footnote}{Nota}{Note}%
-      \Crefname{figure}{Figura}{Figure}%
-      \Crefname{subfigure}{Figura}{Figure}%
-      \Crefname{table}{Tabella}{Tabelle}%
-      \Crefname{subtable}{Tabella}{Tabelle}%
-      \Crefname{theorem}{Teorema}{Teoremi}%
-      \Crefname{lemma}{Lemma}{Lemmi}%
-      \Crefname{corollary}{Corollario}{Corollari}%
-      \Crefname{proposition}{Proposizione}{Proposizioni}%
-      \Crefname{definition}{Definizione}{Definizione}%
-      \Crefname{result}{Risultato}{Risultati}%
-      \Crefname{example}{esempio}{esempi}%
-      \Crefname{remark}{Osservazione}{Osservazioni}%
-      \Crefname{note}{Nota}{Note}%
-      \Crefname{algorithm}{Algoritmo}{Algoritmi}%
-      \Crefname{listing}{Elenco}{Elenchi}%
-      \Crefname{line}{Linea}{Linee}%
-      \if@cref@capitalise%
-        \crefname{equation}{Eq.}{Eq.}%
-        \crefname{part}{Parte}{Parti}%
-        \crefname{chapter}{Capitolo}{Capitoli}%
-        \crefname{section}{Sezione}{Sezioni}%
-        \crefname{subsection}{Sezione}{Sezioni}%
-        \crefname{subsubsection}{Sezione}{Sezioni}%
-        \crefname{appendix}{Appendice}{Appendici}%
-        \crefname{subappendix}{Appendice}{Appendici}%
-        \crefname{subsubappendix}{Appendice}{Appendici}%
-        \crefname{subsubsubappendix}{Appendice}{Appendici}%
-        \crefname{enumi}{Voce}{Voci}%
-        \crefname{enumii}{Voce}{Voci}%
-        \crefname{enumiii}{Voce}{Voci}%
-        \crefname{enumiv}{Voce}{Voci}%
-        \crefname{enumv}{Voce}{Voci}%
-        \crefname{footnote}{Nota}{Note}%
-        \crefname{figure}{Fig.}{Fig.}%
-        \crefname{subfigure}{Fig.}{Fig.}%
-        \crefname{table}{Tabella}{Tabelle}%
-        \crefname{subtable}{Tabella}{Tabelle}%
-        \crefname{theorem}{Teorema}{Teoremi}%
-        \crefname{lemma}{Lemma}{Lemmi}%
-        \crefname{corollary}{Corollario}{Corollari}%
-        \crefname{proposition}{Proposizione}{Proposizioni}%
-        \crefname{definition}{Definizione}{Definizione}%
-        \crefname{result}{Risultato}{Risultati}%
-        \crefname{example}{Esempio}{Esempi}%
-        \crefname{remark}{Osservazione}{Osservazioni}%
-        \crefname{note}{Nota}{Note}%
-        \crefname{algorithm}{Algoritmo}{Algoritmi}%
-        \crefname{listing}{Elenco}{Elenchi}%
-        \crefname{line}{Linea}{Linee}%
-      \else%
-        \crefname{equation}{eq.}{eq.}%
-        \crefname{part}{parte}{parti}%
-        \crefname{chapter}{capitolo}{capitoli}%
-        \crefname{section}{sezione}{sezioni}%
-        \crefname{subsection}{sezione}{sezioni}%
-        \crefname{subsubsection}{sezione}{sezioni}%
-        \crefname{appendix}{appendice}{appendici}%
-        \crefname{subappendix}{appendice}{appendici}%
-        \crefname{subsubappendix}{appendice}{appendici}%
-        \crefname{subsubsubappendix}{appendice}{appendici}%
-        \crefname{enumi}{voce}{voci}%
-        \crefname{enumii}{voce}{voci}%
-        \crefname{enumiii}{voce}{voci}%
-        \crefname{enumiv}{voce}{voci}%
-        \crefname{enumv}{voce}{voci}%
-        \crefname{footnote}{nota}{note}%
-        \crefname{figure}{fig.}{fig.}%
-        \crefname{subfigure}{fig.}{fig.}%
-        \crefname{table}{tabella}{tabelle}%
-        \crefname{subtable}{tabella}{tabelle}%
-        \crefname{theorem}{teorema}{teoremi}%
-        \crefname{lemma}{lemma}{lemmi}%
-        \crefname{corollary}{corollario}{corollari}%
-        \crefname{proposition}{proposizione}{proposizioni}%
-        \crefname{definition}{definizione}{definizione}%
-        \crefname{result}{risultato}{risultati}%
-        \crefname{example}{esempio}{esempi}%
-        \crefname{remark}{osservazione}{osservazioni}%
-        \crefname{note}{nota}{note}%
-        \crefname{algorithm}{algoritmo}{algoritmi}%
-        \crefname{listing}{elenco}{elenchi}%
-        \crefname{line}{linea}{linee}%
-      \fi%
-    }}}
+  }}% end \DeclareOption and \AtBeginDocument
+\cref@addlanguagedefs{italian}{%
+  \PackageInfo{cleveref}{loaded `italian' language definitions}%
+  \renewcommand{\crefrangeconjunction}{ a\nobreakspace}%
+  \renewcommand\crefrangepreconjunction{da\nobreakspace}%
+  \renewcommand\crefrangepostconjunction{}%
+  \renewcommand{\crefpairconjunction}{ e\nobreakspace}%
+  \renewcommand{\crefmiddleconjunction}{, }%
+  \renewcommand{\creflastconjunction}{ e\nobreakspace}%
+  \renewcommand{\crefpairgroupconjunction}{ e\nobreakspace}%
+  \renewcommand{\crefmiddlegroupconjunction}{, }%
+  \renewcommand{\creflastgroupconjunction}{ e\nobreakspace}%
+ %
+  \Crefname{equation}{Equazione}{Equazioni}%
+  \Crefname{figure}{Figura}{Figure}%
+  \Crefname{subfigure}{Figura}{Figure}%
+  \Crefname{table}{Tabella}{Tabelle}%
+  \Crefname{subtable}{Tabella}{Tabelle}%
+  \Crefname{page}{Pagina}{Pagine}%
+  \Crefname{part}{Parte}{Parti}%
+  \Crefname{chapter}{Capitolo}{Capitoli}%
+  \Crefname{section}{Sezione}{Sezioni}%
+  \Crefname{subsection}{Sezione}{Sezioni}%
+  \Crefname{subsubsection}{Sezione}{Sezioni}%
+  \Crefname{appendix}{Appendice}{Appendici}%
+  \Crefname{subappendix}{Appendice}{Appendici}%
+  \Crefname{subsubappendix}{Appendice}{Appendici}%
+  \Crefname{subsubsubappendix}{Appendice}{Appendici}%
+  \Crefname{enumi}{Voce}{Voci}%
+  \Crefname{enumii}{Voce}{Voci}%
+  \Crefname{enumiii}{Voce}{Voci}%
+  \Crefname{enumiv}{Voce}{Voci}%
+  \Crefname{enumv}{Voce}{Voci}%
+  \Crefname{footnote}{Nota}{Note}%
+  \Crefname{theorem}{Teorema}{Teoremi}%
+  \Crefname{lemma}{Lemma}{Lemmi}%
+  \Crefname{corollary}{Corollario}{Corollari}%
+  \Crefname{proposition}{Proposizione}{Proposizioni}%
+  \Crefname{definition}{Definizione}{Definizione}%
+  \Crefname{result}{Risultato}{Risultati}%
+  \Crefname{example}{esempio}{esempi}%
+  \Crefname{remark}{Osservazione}{Osservazioni}%
+  \Crefname{note}{Nota}{Note}%
+  \Crefname{algorithm}{Algoritmo}{Algoritmi}%
+  \Crefname{listing}{Elenco}{Elenchi}%
+  \Crefname{line}{Linea}{Linee}%
+ %
+  \if@cref@capitalise%  capitalise set
+    \if@cref@abbrev%
+      \crefname{equation}{Eq.}{Eq.}%
+      \crefname{figure}{Fig.}{Fig.}%
+      \crefname{subfigure}{Fig.}{Fig.}%
+    \else%
+      \crefname{equation}{Equazione}{Equazioni}%
+      \crefname{figure}{Figura}{Figure}%
+      \crefname{figure}{Figura}{Figure}%
+    \fi%
+    \crefname{table}{Tabella}{Tabelle}%
+    \crefname{page}{Pagina}{Pagine}%
+    \crefname{subtable}{Tabella}{Tabelle}%
+    \crefname{part}{Parte}{Parti}%
+    \crefname{chapter}{Capitolo}{Capitoli}%
+    \crefname{section}{Sezione}{Sezioni}%
+    \crefname{subsection}{Sezione}{Sezioni}%
+    \crefname{subsubsection}{Sezione}{Sezioni}%
+    \crefname{appendix}{Appendice}{Appendici}%
+    \crefname{subappendix}{Appendice}{Appendici}%
+    \crefname{subsubappendix}{Appendice}{Appendici}%
+    \crefname{subsubsubappendix}{Appendice}{Appendici}%
+    \crefname{enumi}{Voce}{Voci}%
+    \crefname{enumii}{Voce}{Voci}%
+    \crefname{enumiii}{Voce}{Voci}%
+    \crefname{enumiv}{Voce}{Voci}%
+    \crefname{enumv}{Voce}{Voci}%
+    \crefname{footnote}{Nota}{Note}%
+    \crefname{theorem}{Teorema}{Teoremi}%
+    \crefname{lemma}{Lemma}{Lemmi}%
+    \crefname{corollary}{Corollario}{Corollari}%
+    \crefname{proposition}{Proposizione}{Proposizioni}%
+    \crefname{definition}{Definizione}{Definizione}%
+    \crefname{result}{Risultato}{Risultati}%
+    \crefname{example}{Esempio}{Esempi}%
+    \crefname{remark}{Osservazione}{Osservazioni}%
+    \crefname{note}{Nota}{Note}%
+    \crefname{algorithm}{Algoritmo}{Algoritmi}%
+    \crefname{listing}{Elenco}{Elenchi}%
+    \crefname{line}{Linea}{Linee}%
+ %
+  \else%  capitalise unset
+    \if@cref@abbrev%
+      \crefname{equation}{eq.}{eq.}%
+      \crefname{figure}{fig.}{fig.}%
+      \crefname{subfigure}{fig.}{fig.}%
+    \else%
+      \crefname{equation}{equazione}{equazioni}%
+      \crefname{figure}{figura}{figure}%
+      \crefname{figure}{figura}{figure}%
+    \fi%
+    \crefname{table}{tabella}{tabelle}%
+    \crefname{page}{pagina}{pagine}%
+    \crefname{subtable}{tabella}{tabelle}%
+    \crefname{part}{parte}{parti}%
+    \crefname{chapter}{capitolo}{capitoli}%
+    \crefname{section}{sezione}{sezioni}%
+    \crefname{subsection}{sezione}{sezioni}%
+    \crefname{subsubsection}{sezione}{sezioni}%
+    \crefname{appendix}{appendice}{appendici}%
+    \crefname{subappendix}{appendice}{appendici}%
+    \crefname{subsubappendix}{appendice}{appendici}%
+    \crefname{subsubsubappendix}{appendice}{appendici}%
+    \crefname{enumi}{voce}{voci}%
+    \crefname{enumii}{voce}{voci}%
+    \crefname{enumiii}{voce}{voci}%
+    \crefname{enumiv}{voce}{voci}%
+    \crefname{enumv}{voce}{voci}%
+    \crefname{footnote}{nota}{note}%
+    \crefname{theorem}{teorema}{teoremi}%
+    \crefname{lemma}{lemma}{lemmi}%
+    \crefname{corollary}{corollario}{corollari}%
+    \crefname{proposition}{proposizione}{proposizioni}%
+    \crefname{definition}{definizione}{definizione}%
+    \crefname{result}{risultato}{risultati}%
+    \crefname{example}{esempio}{esempi}%
+    \crefname{remark}{osservazione}{osservazioni}%
+    \crefname{note}{nota}{note}%
+    \crefname{algorithm}{algoritmo}{algoritmi}%
+    \crefname{listing}{elenco}{elenchi}%
+    \crefname{line}{linea}{linee}%
+  \fi}% end \cref@loadlanguagedefs
 \DeclareOption{russian}{%
-  \PackageInfo{cleveref}{loaded `russian' language definitions}
   \AtBeginDocument{%
     \def\crefrangeconjunction@preamble{--}%
     \def\crefrangepreconjunction@preamble{}%
@@ -4204,12 +4989,19 @@
     \def\crefmiddlegroupconjunction@preamble{, }%
     \def\creflastgroupconjunction@preamble%
       {, \cyra\ \cyrt\cyra\cyrk\cyrzh\cyre\nobreakspace}%
-    \Crefname@preamble{equation}%
+ %
+      \Crefname@preamble{equation}%
       {\CYRF\cyro\cyrr\cyrm\cyru\cyrl\cyra}%
       {\CYRF\cyro\cyrr\cyrm\cyru\cyrl\cyrery}%
-    \Crefname@preamble{part}%
-      {\CYRCH\cyra\cyrs\cyrt\cyrsftsn}%
-      {\CYRCH\cyra\cyrs\cyrt\cyri}%
+    \Crefname@preamble{figure}%
+      {\CYRR\cyri\cyrs\cyru\cyrn\cyro\cyrk}%
+      {\CYRR\cyri\cyrs\cyru\cyrn\cyrk\cyri}%
+    \Crefname@preamble{table}%
+      {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyra}%
+      {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrery}%
+    \Crefname@preamble{enumi}%
+      {\CYRP\cyru\cyrn\cyrk\cyrt}%
+      {\CYRP\cyru\cyrn\cyrk\cyrt\cyrery}%
     \Crefname@preamble{chapter}%
       {\CYRG\cyrl\cyra\cyrv\cyra}%
       {\CYRG\cyrl\cyra\cyrv\cyrery}%
@@ -4219,18 +5011,9 @@
     \Crefname@preamble{appendix}%
       {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
       {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}%
-    \Crefname@preamble{enumi}%
-      {\CYRP\cyru\cyrn\cyrk\cyrt}%
-      {\CYRP\cyru\cyrn\cyrk\cyrt\cyrery}%
     \Crefname@preamble{footnote}%
       {\CYRS\cyrn\cyro\cyrs\cyrk\cyra}%
       {\CYRS\cyrn\cyro\cyrs\cyrk\cyri}%
-    \Crefname@preamble{figure}%
-      {\CYRR\cyri\cyrs\cyru\cyrn\cyro\cyrk}%
-      {\CYRR\cyri\cyrs\cyru\cyrn\cyrk\cyri}%
-    \Crefname@preamble{table}%
-      {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyra}%
-      {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrery}%
     \Crefname@preamble{theorem}%
       {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyra}%
       {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyrery}%
@@ -4267,13 +5050,41 @@
     \Crefname@preamble{line}%
       {\CYRS\cyrt\cyrr\cyro\cyrk\cyra}%
       {\CYRS\cyrt\cyrr\cyro\cyrk\cyri}%
-    \if@cref@capitalise%
-      \crefname@preamble{equation}%
-        {\CYRF-\cyrl.}%
-        {\CYRF-\cyrl.}%
-      \crefname@preamble{part}%
-        {\CYRCH\cyra\cyrs\cyrt\cyrsftsn}%
-        {\CYRCH\cyra\cyrs\cyrt\cyri}%
+    \Crefname@preamble{page}%
+      {\CYRS\cyrt\cyrr\cyra\cyrn\cyri\cyrc\cyra}%
+      {\CYRS\cyrt\cyrr\cyra\cyrn\cyri\cyrc\cyrery}%
+    \Crefname@preamble{part}%
+      {\CYRCH\cyra\cyrs\cyrt\cyrsftsn}%
+      {\CYRCH\cyra\cyrs\cyrt\cyri}%
+ %
+    \if@cref@capitalise%  capitalise set
+      \if@cref@abbrev%  abbrev set
+        \crefname@preamble{equation}%
+          {\CYRF-\cyrl.}%
+          {\CYRF-\cyrl.}%
+        \crefname@preamble{figure}%
+          {\CYRR\cyri\cyrs.}%
+          {\CYRR\cyri\cyrs.}%
+        \crefname@preamble{table}%
+          {\CYRT\cyra\cyrb\cyrl.}%
+          {\CYRT\cyra\cyrb\cyrl.}%
+        \crefname@preamble{enumi}%
+          {\CYRP.}%
+          {\CYRP.\cyrp.}%
+      \else%
+        \crefname@preamble{equation}%
+          {\CYRF\cyro\cyrr\cyrm\cyru\cyrl\cyra}%
+          {\CYRF\cyro\cyrr\cyrm\cyru\cyrl\cyrery}%
+        \crefname@preamble{figure}%
+          {\CYRR\cyri\cyrs\cyru\cyrn\cyro\cyrk}%
+          {\CYRR\cyri\cyrs\cyru\cyrn\cyrk\cyri}%
+        \crefname@preamble{table}%
+          {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyra}%
+          {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrery}%
+        \crefname@preamble{enumi}%
+          {\CYRP\cyru\cyrn\cyrk\cyrt}%
+          {\CYRP\cyru\cyrn\cyrk\cyrt\cyrery}%
+      \fi%
       \crefname@preamble{chapter}%
         {\CYRG\cyrl\cyra\cyrv\cyra}%
         {\CYRG\cyrl\cyra\cyrv\cyrery}%
@@ -4283,16 +5094,9 @@
       \crefname@preamble{appendix}%
         {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
         {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}%
-      \crefname@preamble{enumi}{\CYRP.}{\CYRP.\cyrp.}%
       \crefname@preamble{footnote}%
         {\CYRS\cyrn\cyro\cyrs\cyrk\cyra}%
         {\CYRS\cyrn\cyro\cyrs\cyrk\cyri}%
-      \crefname@preamble{figure}%
-        {\CYRR\cyri\cyrs.}%
-        {\CYRR\cyri\cyrs.}%
-      \crefname@preamble{table}%
-        {\CYRT\cyra\cyrb\cyrl.}%
-        {\CYRT\cyra\cyrb\cyrl.}%
       \crefname@preamble{theorem}%
         {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyra}%
         {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyrery}%
@@ -4329,349 +5133,591 @@
       \crefname@preamble{line}%
         {\CYRS\cyrt\cyrr\cyro\cyrk\cyra}%
         {\CYRS\cyrt\cyrr\cyro\cyrk\cyri}%
-    \else%
-      \crefname@preamble{equation}{\cyrf-\cyrl.}{\cyrf-\cyrl.}%
+      \crefname@preamble{page}%
+        {\CYRS\cyrt\cyrr\cyra\cyrn\cyri\cyrc\cyra}%
+        {\CYRS\cyrt\cyrr\cyra\cyrn\cyri\cyrc\cyrery}%
+      \crefname@preamble{part}%
+        {\CYRCH\cyra\cyrs\cyrt\cyrsftsn}%
+        {\CYRCH\cyra\cyrs\cyrt\cyri}%
+ %
+    \else%  capitalise unset
+      \if@cref@abbrev%  abbrev set
+        \crefname@preamble{equation}%
+          {\cyrf-\cyrl.}%
+          {\cyrf-\cyrl.}%
+        \crefname@preamble{figure}%
+          {\cyrr\cyri\cyrs.}%
+          {\cyrr\cyri\cyrs.}%
+        \crefname@preamble{table}%
+          {\cyrt\cyra\cyrb\cyrl.}%
+          {\cyrt\cyra\cyrb\cyrl.}%
+        \crefname@preamble{enumi}%
+          {\cyrp.}%
+          {\cyrp.\cyrp.}%
+        \crefname@preamble{chapter}%
+          {\cyrg\cyrl\cyra\cyrv.}%
+          {\cyrg\cyrl\cyra\cyrv.}%
+        \crefname@preamble{section}%
+          {\cyrr\cyra\cyrz\cyrd.}%
+          {\cyrr\cyra\cyrz\cyrd\cyre\cyrl.}%
+        \crefname@preamble{appendix}%
+          {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh.}%
+          {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh.}%
+        \crefname@preamble{footnote}%
+          {\cyrs\cyrn\cyro\cyrs\cyrk.}%
+          {\cyrs\cyrn\cyro\cyrs\cyrk.}%
+        \crefname@preamble{theorem}%
+          {\cyrt\cyre\cyro\cyrr\cyre\cyrm.}%
+          {\cyrt\cyre\cyro\cyrr\cyre\cyrm.}%
+        \crefname@preamble{lemma}%
+          {\cyrl\cyre\cyrm\cyrm.}%
+          {\cyrl\cyre\cyrm\cyrm.}%
+        \crefname@preamble{corollary}%
+          {\cyrv\cyrery\cyrv\cyro\cyrd}%
+          {\cyrv\cyrery\cyrv\cyro\cyrd.}%
+        \crefname@preamble{proposition}%
+          {\cyru\cyrt\cyrv\cyre\cyrr\cyrzh\cyrd.}%
+          {\cyru\cyrt\cyrv\cyre\cyrr\cyrzh\cyrd.}%
+        \crefname@preamble{definition}%
+          {\cyro\cyrp\cyrr\cyre\cyrd\cyre\cyrl\cyre\cyrn.}%
+          {\cyro\cyrp\cyrr\cyre\cyrd\cyre\cyrl\cyre\cyrn.}%
+        \crefname@preamble{result}%
+          {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt.}%
+          {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt.}%
+        \crefname@preamble{example}%
+          {\cyrp\cyrr\cyri\cyrm.}%
+          {\cyrp\cyrr\cyri\cyrm\cyre\cyrr.}%
+        \crefname@preamble{remark}%
+          {\cyrp\cyrr\cyri\cyrm\cyre\cyrch.}%
+          {\cyrp\cyrr\cyri\cyrm\cyre\cyrch.}%
+        \crefname@preamble{note}%
+          {\cyrz\cyra\cyrm\cyre\cyrt\cyrk.}%
+          {\cyrz\cyra\cyrm\cyre\cyrt\cyrk.}%
+        \crefname@preamble{algorithm}%
+          {\cyra\cyrl\cyrg.}%
+          {\cyra\cyrl\cyrg.}%
+        \crefname@preamble{listing}%
+          {\cyrl\cyri\cyrs\cyrt\cyri\cyrn.}%
+          {\cyrl\cyri\cyrs\cyrt\cyri\cyrn\cyrg.}%
+        \crefname@preamble{line}%
+          {\cyrs\cyrt\cyrr\cyrk.}%
+          {\cyrs\cyrt\cyrr\cyrk.}%
+      \else%  abbrev unset
+        \crefname@preamble{equation}%
+          {\cyrf\cyro\cyrr\cyrm\cyru\cyrl\cyra}%
+          {\cyrf\cyro\cyrr\cyrm\cyru\cyrl\cyrery}%
+        \crefname@preamble{figure}%
+          {\cyrr\cyri\cyrs\cyru\cyrn\cyro\cyrk}%
+          {\cyrr\cyri\cyrs\cyru\cyrn\cyrk\cyri}%
+        \crefname@preamble{table}%
+          {\cyrt\cyra\cyrb\cyrl\cyri\cyrc\cyra}%
+          {\cyrt\cyra\cyrb\cyrl\cyri\cyrc\cyrery}%
+        \crefname@preamble{enumi}%
+          {\cyrp\cyru\cyrn\cyrk\cyrt}%
+          {\cyrp\cyru\cyrn\cyrk\cyrt\cyrery}%
+        \crefname@preamble{chapter}%
+          {\cyrg\cyrl\cyra\cyrv\cyra}%
+          {\cyrg\cyrl\cyra\cyrv\cyrery}%
+        \crefname@preamble{section}%
+          {\cyrr\cyra\cyrz\cyrd\cyre\cyrl}%
+          {\cyrr\cyra\cyrz\cyrd\cyre\cyrl\cyrery}%
+        \crefname@preamble{appendix}%
+          {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
+          {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}%
+        \crefname@preamble{footnote}%
+          {\cyrs\cyrn\cyro\cyrs\cyrk\cyra}%
+          {\cyrs\cyrn\cyro\cyrs\cyrk\cyri}%
+        \crefname@preamble{theorem}%
+          {\cyrt\cyre\cyro\cyrr\cyre\cyrm\cyra}%
+          {\cyrt\cyre\cyro\cyrr\cyre\cyrm\cyrery}%
+        \crefname@preamble{lemma}%
+          {\cyrl\cyre\cyrm\cyrm\cyra}%
+          {\cyrl\cyre\cyrm\cyrm\cyrery}%
+        \crefname@preamble{corollary}%
+          {\cyrv\cyrery\cyrv\cyro\cyrd}%
+          {\cyrv\cyrery\cyrv\cyro\cyrd\cyrery}%
+        \crefname@preamble{proposition}%
+          {\cyru\cyrt\cyrv\cyre\cyrr\cyrzh\cyrd\cyre\cyrn\cyri\cyre}%
+          {\cyru\cyrt\cyrv\cyre\cyrr\cyrzh\cyrd\cyre\cyrn\cyri\cyrya}%
+        \crefname@preamble{definition}%
+          {\cyro\cyrp\cyrr\cyre\cyrd\cyre\cyrl\cyre\cyrn\cyri\cyre}%
+          {\cyro\cyrp\cyrr\cyre\cyrd\cyre\cyrl\cyre\cyrn\cyri\cyrya}%
+        \crefname@preamble{result}%
+          {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt}%
+          {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt\cyrery}%
+        \crefname@preamble{example}%
+          {\cyrp\cyrr\cyri\cyrm\cyre\cyrr}%
+          {\cyrp\cyrr\cyri\cyrm\cyre\cyrr\cyrery}%
+        \crefname@preamble{remark}%
+          {\cyrp\cyrr\cyri\cyrm\cyre\cyrch\cyra\cyrn\cyri\cyre}%
+          {\cyrp\cyrr\cyri\cyrm\cyre\cyrch\cyra\cyrn\cyri\cyrya}%
+        \crefname@preamble{note}%
+          {\cyrz\cyra\cyrm\cyre\cyrt\cyrk\cyra}%
+          {\cyrz\cyra\cyrm\cyre\cyrt\cyrk\cyri}%
+        \crefname@preamble{algorithm}%
+          {\cyra\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm}%
+          {\cyra\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm\cyrery}%
+        \crefname@preamble{listing}%
+          {\cyrl\cyri\cyrs\cyrt\cyri\cyrn\cyrg}%
+          {\cyrl\cyri\cyrs\cyrt\cyri\cyrn\cyrg\cyri}%
+        \crefname@preamble{line}%
+          {\cyrs\cyrt\cyrr\cyro\cyrk\cyra}%
+          {\cyrs\cyrt\cyrr\cyro\cyrk\cyri}%
+      \fi%
+      \crefname@preamble{page}%
+        {\cyrs\cyrt\cyrr\cyra\cyrn\cyri\cyrc\cyre}%
+        {\cyrs\cyrt\cyrr\cyra\cyrn\cyri\cyrc\cyra\cyrh}%
       \crefname@preamble{part}%
         {\cyrch\cyra\cyrs\cyrt\cyrsftsn}%
         {\cyrch\cyra\cyrs\cyrt\cyri}%
-      \crefname@preamble{chapter}%
-        {\cyrg\cyrl\cyra\cyrv.}%
-        {\cyrg\cyrl\cyra\cyrv.}%
-      \crefname@preamble{section}%
-        {\cyrr\cyra\cyrz\cyrd.}%
-        {\cyrr\cyra\cyrz\cyrd\cyre\cyrl.}%
-      \crefname@preamble{appendix}%
-        {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh.}%
-        {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh.}%
-      \crefname@preamble{enumi}{\cyrp.}{\cyrp.\cyrp.}%
-      \crefname@preamble{footnote}%
-        {\cyrs\cyrn\cyro\cyrs\cyrk.}%
-        {\cyrs\cyrn\cyro\cyrs\cyrk.}%
-      \crefname@preamble{figure}%
-        {\cyrr\cyri\cyrs.}%
-        {\cyrr\cyri\cyrs.}%
-      \crefname@preamble{table}%
-        {\cyrt\cyra\cyrb\cyrl.}%
-        {\cyrt\cyra\cyrb\cyrl.}%
-      \crefname@preamble{theorem}%
-        {\cyrt\cyre\cyro\cyrr\cyre\cyrm.}%
-        {\cyrt\cyre\cyro\cyrr\cyre\cyrm.}%
-      \crefname@preamble{lemma}%
-        {\cyrl\cyre\cyrm\cyrm.}%
-        {\cyrl\cyre\cyrm\cyrm.}%
-      \crefname@preamble{corollary}%
-        {\cyrv\cyrery\cyrv\cyro\cyrd}%
-        {\cyrv\cyrery\cyrv\cyro\cyrd.}%
-      \crefname@preamble{proposition}%
-        {\cyru\cyrt\cyrv\cyre\cyrr\cyrzh\cyrd.}%
-        {\cyru\cyrt\cyrv\cyre\cyrr\cyrzh\cyrd.}%
-      \crefname@preamble{definition}%
-        {\cyro\cyrp\cyrr\cyre\cyrd\cyre\cyrl\cyre\cyrn.}%
-        {\cyro\cyrp\cyrr\cyre\cyrd\cyre\cyrl\cyre\cyrn.}%
-      \crefname@preamble{result}%
-        {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt.}%
-        {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt.}%
-      \crefname@preamble{example}%
-        {\cyrp\cyrr\cyri\cyrm.}%
-        {\cyrp\cyrr\cyri\cyrm\cyre\cyrr.}%
-      \crefname@preamble{remark}%
-        {\cyrp\cyrr\cyri\cyrm\cyre\cyrch.}%
-        {\cyrp\cyrr\cyri\cyrm\cyre\cyrch.}%
-      \crefname@preamble{note}%
-        {\cyrz\cyra\cyrm\cyre\cyrt\cyrk.}%
-        {\cyrz\cyra\cyrm\cyre\cyrt\cyrk.}%
-      \crefname@preamble{algorithm}%
-        {\cyra\cyrl\cyrg.}%
-        {\cyra\cyrl\cyrg.}%
-      \crefname@preamble{listing}%
-        {\cyrl\cyri\cyrs\cyrt\cyri\cyrn.}%
-        {\cyrl\cyri\cyrs\cyrt\cyri\cyrn\cyrg.}%
-      \crefname@preamble{line}%
-        {\cyrs\cyrt\cyrr\cyrk.}%
-        {\cyrs\cyrt\cyrr\cyrk.}%
     \fi%
     \def\cref@language{russian}%
-    \cref@addto\extrasrussian{%
-      \renewcommand{\crefrangeconjunction}{--}%
-      \renewcommand\crefrangepreconjunction{}%
-      \renewcommand\crefrangepostconjunction{}%
-      \renewcommand{\crefpairconjunction}{ \cyri\nobreakspace}%
-      \renewcommand{\crefmiddleconjunction}{, }%
-      \renewcommand{\creflastconjunction}{ \cyri\nobreakspace}%
-      \renewcommand{\crefpairgroupconjunction}{ \cyri\nobreakspace}%
-      \renewcommand{\crefmiddlegroupconjunction}{, }%
-      \renewcommand{\creflastgroupconjunction}%
-        {, \cyra\ \cyrt\cyra\cyrk\cyrzh\cyre\nobreakspace}%
-      \Crefname{equation}%
+  }}% end \DeclareOption and \AtBeginDocument
+\cref@addlanguagedefs{russian}{%
+  \PackageInfo{cleveref}{loaded `russian' language definitions}%
+  \renewcommand{\crefrangeconjunction}{--}%
+  \renewcommand\crefrangepreconjunction{}%
+  \renewcommand\crefrangepostconjunction{}%
+  \renewcommand{\crefpairconjunction}{ \cyri\nobreakspace}%
+  \renewcommand{\crefmiddleconjunction}{, }%
+  \renewcommand{\creflastconjunction}{ \cyri\nobreakspace}%
+  \renewcommand{\crefpairgroupconjunction}{ \cyri\nobreakspace}%
+  \renewcommand{\crefmiddlegroupconjunction}{, }%
+  \renewcommand{\creflastgroupconjunction}%
+    {, \cyra\ \cyrt\cyra\cyrk\cyrzh\cyre\nobreakspace}%
+ %
+    \Crefname{page}%
+    {\CYRS\cyrt\cyrr\cyra\cyrn\cyri\cyrc\cyra}%
+    {\CYRS\cyrt\cyrr\cyra\cyrn\cyri\cyrc\cyrery}%
+  \Crefname{equation}%
+    {\CYRF\cyro\cyrr\cyrm\cyru\cyrl\cyra}%
+    {\CYRF\cyro\cyrr\cyrm\cyru\cyrl\cyrery}%
+  \Crefname{figure}%
+    {\CYRR\cyri\cyrs\cyru\cyrn\cyro\cyrk}%
+    {\CYRR\cyri\cyrs\cyru\cyrn\cyrk\cyri}%
+  \Crefname{subfigure}%
+    {\CYRR\cyri\cyrs\cyru\cyrn\cyro\cyrk}%
+    {\CYRR\cyri\cyrs\cyru\cyrn\cyrk\cyri}%
+  \Crefname{table}%
+    {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyra}%
+    {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrery}%
+  \Crefname{subtable}%
+    {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyra}%
+    {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrery}%
+  \Crefname{part}%
+    {\CYRCH\cyra\cyrs\cyrt\cyrsftsn}%
+    {\CYRCH\cyra\cyrs\cyrt\cyri}%
+  \Crefname{chapter}%
+    {\CYRG\cyrl\cyra\cyrv\cyra}%
+    {\CYRG\cyrl\cyra\cyrv\cyrery}%
+  \Crefname{section}%
+    {\CYRR\cyra\cyrz\cyrd\cyre\cyrl}%
+    {\CYRR\cyra\cyrz\cyrd\cyre\cyrl\cyrery}%
+  \Crefname{subsection}%
+    {\CYRR\cyra\cyrz\cyrd\cyre\cyrl}%
+    {\CYRR\cyra\cyrz\cyrd\cyre\cyrl\cyrery}%
+  \Crefname{subsubsection}%
+    {\CYRR\cyra\cyrz\cyrd\cyre\cyrl}%
+    {\CYRR\cyra\cyrz\cyrd\cyre\cyrl\cyrery}%
+  \Crefname{appendix}%
+    {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
+    {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}%
+  \Crefname{subappendix}%
+    {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
+    {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}%
+  \Crefname{subsubappendix}%
+    {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
+    {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}%
+  \Crefname{subsubsubappendix}%
+    {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
+    {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}%
+  \Crefname{enumi}%
+    {\CYRP\cyru\cyrn\cyrk\cyrt}%
+    {\CYRP\cyru\cyrn\cyrk\cyrt\cyrery}%
+  \Crefname{enumii}%
+    {\CYRP\cyru\cyrn\cyrk\cyrt}%
+    {\CYRP\cyru\cyrn\cyrk\cyrt\cyrery}%
+  \Crefname{enumiii}%
+    {\CYRP\cyru\cyrn\cyrk\cyrt}%
+    {\CYRP\cyru\cyrn\cyrk\cyrt\cyrery}%
+  \Crefname{enumiv}%
+    {\CYRP\cyru\cyrn\cyrk\cyrt}%
+    {\CYRP\cyru\cyrn\cyrk\cyrt\cyrery}%
+  \Crefname{enumv}%
+    {\CYRP\cyru\cyrn\cyrk\cyrt}%
+    {\CYRP\cyru\cyrn\cyrk\cyrt\cyrery}%
+  \Crefname{footnote}%
+    {\CYRS\cyrn\cyro\cyrs\cyrk\cyra}%
+    {\CYRS\cyrn\cyro\cyrs\cyrk\cyri}%
+  \Crefname{theorem}%
+    {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyra}%
+    {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyrery}%
+  \Crefname{lemma}%
+    {\CYRL\cyre\cyrm\cyrm\cyra}%
+    {\CYRL\cyre\cyrm\cyrm\cyrery}%
+  \Crefname{corollary}%
+    {\CYRV\cyrery\cyrv\cyro\cyrd}%
+    {\CYRV\cyrery\cyrv\cyro\cyrd\cyrery}%
+  \Crefname{proposition}%
+    {\CYRU\cyrt\cyrv\cyre\cyrr\cyrzh\cyrd\cyre\cyrn\cyri\cyre}%
+    {\CYRU\cyrt\cyrv\cyre\cyrr\cyrzh\cyrd\cyre\cyrn\cyri\cyrya}%
+  \Crefname{definition}%
+    {\CYRO\cyrp\cyrr\cyre\cyrd\cyre\cyrl\cyre\cyrn\cyri\cyre}%
+    {\CYRO\cyrp\cyrr\cyre\cyrd\cyre\cyrl\cyre\cyrn\cyri\cyrya}%
+  \Crefname{result}%
+    {\CYRR\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt}%
+    {\CYRR\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt\cyrery}%
+  \Crefname{example}%
+    {\CYRP\cyrr\cyri\cyrm\cyre\cyrr}%
+    {\CYRP\cyrr\cyri\cyrm\cyre\cyrr\cyrery}%
+  \Crefname{remark}%
+    {\CYRP\cyrr\cyri\cyrm\cyre\cyrch\cyra\cyrn\cyri\cyre}%
+    {\CYRP\cyrr\cyri\cyrm\cyre\cyrch\cyra\cyrn\cyri\cyrya}%
+  \Crefname{note}%
+    {\CYRZ\cyra\cyrm\cyre\cyrt\cyrk\cyra}%
+    {\CYRZ\cyra\cyrm\cyre\cyrt\cyrk\cyri}%
+  \Crefname{algorithm}%
+    {\CYRA\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm}%
+    {\CYRA\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm\cyrery}%
+  \Crefname{listing}%
+    {\CYRL\cyri\cyrs\cyrt\cyri\cyrn\cyrg}%
+    {\CYRL\cyri\cyrs\cyrt\cyri\cyrn\cyrg\cyri}%
+  \Crefname{line}%
+    {\CYRS\cyrt\cyrr\cyro\cyrk\cyra}%
+    {\CYRS\cyrt\cyrr\cyro\cyrk\cyri}%
+ %
+  \if@cref@capitalise%  capitalise set
+    \if@cref@abbrev%  abbrev set
+      \crefname{equation}%
+        {\CYRF-\cyrl.}%
+        {\CYRF-\cyrl.}%
+      \crefname{figure}%
+        {\CYRR\cyri\cyrs.}%
+        {\CYRR\cyri\cyrs.}%
+      \crefname{subfigure}%
+        {\CYRR\cyri\cyrs.}%
+        {\CYRR\cyri\cyrs.}%
+      \crefname{table}%
+        {\CYRT\cyra\cyrb\cyrl.}%
+        {\CYRT\cyra\cyrb\cyrl.}%
+      \crefname{subtable}%
+        {\CYRT\cyra\cyrb\cyrl.}%
+        {\CYRT\cyra\cyrb\cyrl.}%
+      \crefname{enumi}%
+        {\CYRP.}%
+        {\CYRP.\cyrp.}%
+      \crefname{enumii}%
+        {\CYRP.}%
+        {\CYRP.\cyrp.}%
+      \crefname{enumiii}%
+        {\CYRP.}%
+        {\CYRP.\cyrp.}%
+      \crefname{enumiv}%
+        {\CYRP.}%
+        {\CYRP.\cyrp.}%
+      \crefname{enumv}%
+        {\CYRP.}%
+        {\CYRP.\cyrp.}%
+    \else%  abbrev unset
+      \crefname{equation}%
         {\CYRF\cyro\cyrr\cyrm\cyru\cyrl\cyra}%
         {\CYRF\cyro\cyrr\cyrm\cyru\cyrl\cyrery}%
-      \Crefname{part}%
-        {\CYRCH\cyra\cyrs\cyrt\cyrsftsn}%
-        {\CYRCH\cyra\cyrs\cyrt\cyri}%
-      \Crefname{chapter}%
-        {\CYRG\cyrl\cyra\cyrv\cyra}%
-        {\CYRG\cyrl\cyra\cyrv\cyrery}%
-      \Crefname{section}%
-        {\CYRR\cyra\cyrz\cyrd\cyre\cyrl}%
-        {\CYRR\cyra\cyrz\cyrd\cyre\cyrl\cyrery}%
-      \Crefname{subsection}%
-        {\CYRR\cyra\cyrz\cyrd\cyre\cyrl}%
-        {\CYRR\cyra\cyrz\cyrd\cyre\cyrl\cyrery}%
-      \Crefname{subsubsection}%
-        {\CYRR\cyra\cyrz\cyrd\cyre\cyrl}%
-        {\CYRR\cyra\cyrz\cyrd\cyre\cyrl\cyrery}%
-      \Crefname{appendix}%
-        {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
-        {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}%
-      \Crefname{subappendix}%
-        {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
-        {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}
-      \Crefname{subsubappendix}%
-        {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
-        {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}
-      \Crefname{subsubsubappendix}%
-        {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
-        {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}
-      \Crefname{enumi}%
-        {\CYRP\cyru\cyrn\cyrk\cyrt}%
-        {\CYRP\cyru\cyrn\cyrk\cyrt\cyrery}%
-      \Crefname{enumii}%
-        {\CYRP\cyru\cyrn\cyrk\cyrt}%
-        {\CYRP\cyru\cyrn\cyrk\cyrt\cyrery}%
-      \Crefname{enumiii}%
-        {\CYRP\cyru\cyrn\cyrk\cyrt}%
-        {\CYRP\cyru\cyrn\cyrk\cyrt\cyrery}%
-      \Crefname{enumiv}%
-        {\CYRP\cyru\cyrn\cyrk\cyrt}%
-        {\CYRP\cyru\cyrn\cyrk\cyrt\cyrery}%
-      \Crefname{enumv}%
-        {\CYRP\cyru\cyrn\cyrk\cyrt}%
-        {\CYRP\cyru\cyrn\cyrk\cyrt\cyrery}%
-      \Crefname{footnote}%
-        {\CYRS\cyrn\cyro\cyrs\cyrk\cyra}%
-        {\CYRS\cyrn\cyro\cyrs\cyrk\cyri}%
-      \Crefname{figure}%
+      \crefname{figure}%
         {\CYRR\cyri\cyrs\cyru\cyrn\cyro\cyrk}%
         {\CYRR\cyri\cyrs\cyru\cyrn\cyrk\cyri}%
-      \Crefname{subfigure}%
+      \crefname{subfigure}%
         {\CYRR\cyri\cyrs\cyru\cyrn\cyro\cyrk}%
         {\CYRR\cyri\cyrs\cyru\cyrn\cyrk\cyri}%
-      \Crefname{table}%
+      \crefname{table}%
         {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyra}%
         {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrery}%
-      \Crefname{subtable}%
+      \crefname{subtable}%
         {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyra}%
         {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrery}%
-      \Crefname{theorem}%
-        {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyra}%
-        {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyrery}%
-      \Crefname{lemma}%
-        {\CYRL\cyre\cyrm\cyrm\cyra}%
-        {\CYRL\cyre\cyrm\cyrm\cyrery}%
-      \Crefname{corollary}%
-        {\CYRV\cyrery\cyrv\cyro\cyrd}%
-        {\CYRV\cyrery\cyrv\cyro\cyrd\cyrery}%
-      \Crefname{proposition}%
-        {\CYRU\cyrt\cyrv\cyre\cyrr\cyrzh\cyrd\cyre\cyrn\cyri\cyre}%
-        {\CYRU\cyrt\cyrv\cyre\cyrr\cyrzh\cyrd\cyre\cyrn\cyri\cyrya}%
-      \Crefname{definition}%
-        {\CYRO\cyrp\cyrr\cyre\cyrd\cyre\cyrl\cyre\cyrn\cyri\cyre}%
-        {\CYRO\cyrp\cyrr\cyre\cyrd\cyre\cyrl\cyre\cyrn\cyri\cyrya}%
-      \Crefname{result}%
-        {\CYRR\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt}%
-        {\CYRR\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt\cyrery}%
-      \Crefname{example}%
-        {\CYRP\cyrr\cyri\cyrm\cyre\cyrr}%
-        {\CYRP\cyrr\cyri\cyrm\cyre\cyrr\cyrery}%
-      \Crefname{remark}%
-        {\CYRP\cyrr\cyri\cyrm\cyre\cyrch\cyra\cyrn\cyri\cyre}%
-        {\CYRP\cyrr\cyri\cyrm\cyre\cyrch\cyra\cyrn\cyri\cyrya}%
-      \Crefname{note}%
-        {\CYRZ\cyra\cyrm\cyre\cyrt\cyrk\cyra}%
-        {\CYRZ\cyra\cyrm\cyre\cyrt\cyrk\cyri}%
-      \Crefname{algorithm}%
-        {\CYRA\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm}%
-        {\CYRA\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm\cyrery}%
-      \Crefname{listing}%
-        {\CYRL\cyri\cyrs\cyrt\cyri\cyrn\cyrg}%
-        {\CYRL\cyri\cyrs\cyrt\cyri\cyrn\cyrg\cyri}%
-      \Crefname{line}%
-        {\CYRS\cyrt\cyrr\cyro\cyrk\cyra}%
-        {\CYRS\cyrt\cyrr\cyro\cyrk\cyri}%
-      \if@cref@capitalise%
-        \crefname{equation}{\CYRF-\cyrl.}{\CYRF-\cyrl.}%
-        \crefname{part}%
-          {\CYRCH\cyra\cyrs\cyrt\cyrsftsn}%
-          {\CYRCH\cyra\cyrs\cyrt\cyri}%
-        \crefname{chapter}%
-          {\CYRG\cyrl\cyra\cyrv\cyra}%
-          {\CYRG\cyrl\cyra\cyrv\cyrery}%
-        \crefname{section}%
-          {\CYRR\cyra\cyrz\cyrd\cyre\cyrl}%
-          {\CYRR\cyra\cyrz\cyrd\cyre\cyrl\cyrery}%
-        \crefname{subsection}%
-          {\CYRR\cyra\cyrz\cyrd\cyre\cyrl}%
-          {\CYRR\cyra\cyrz\cyrd\cyre\cyrl\cyrery}%
-        \crefname{subsubsection}%
-          {\CYRR\cyra\cyrz\cyrd\cyre\cyrl}%
-          {\CYRR\cyra\cyrz\cyrd\cyre\cyrl\cyrery}%
-        \crefname{appendix}%
-          {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
-          {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}%
-        \crefname{subappendix}%
-          {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
-          {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}%
-        \crefname{subsubappendix}%
-          {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
-          {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}%
-        \crefname{subsubsubappendix}%
-          {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
-          {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}%
-        \crefname{enumi}{\CYRP.}{\CYRP.\cyrp.}%
-        \crefname{enumii}{\CYRP.}{\CYRP.\cyrp.}%
-        \crefname{enumiii}{\CYRP.}{\CYRP.\cyrp.}%
-        \crefname{enumiv}{\CYRP.}{\CYRP.\cyrp.}%
-        \crefname{enumv}{\CYRP.}{\CYRP.\cyrp.}%
-        \crefname{footnote}%
-          {\CYRS\cyrn\cyro\cyrs\cyrk\cyra}%
-          {\CYRS\cyrn\cyro\cyrs\cyrk\cyri}%
-        \crefname{figure}%
-          {\CYRR\cyri\cyrs.}%
-          {\CYRR\cyri\cyrs.}%
-        \crefname{subfigure}%
-          {\CYRR\cyri\cyrs.}%
-          {\CYRR\cyri\cyrs.}%
-        \crefname{table}%
-          {\CYRT\cyra\cyrb\cyrl.}%
-          {\CYRT\cyra\cyrb\cyrl.}%
-        \crefname{subtable}%
-          {\CYRT\cyra\cyrb\cyrl.}%
-          {\CYRT\cyra\cyrb\cyrl.}%
-        \crefname{theorem}%
-          {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyra}%
-          {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyrery}%
-        \crefname{lemma}%
-          {\CYRL\cyre\cyrm\cyrm\cyra}%
-          {\CYRL\cyre\cyrm\cyrm\cyrery}%
-        \crefname{corollary}%
-          {\CYRV\cyrery\cyrv\cyro\cyrd}%
-          {\CYRV\cyrery\cyrv\cyro\cyrd\cyrery}%
-        \crefname{proposition}%
-          {\CYRU\cyrt\cyrv\cyre\cyrr\cyrzh\cyrd\cyre\cyrn\cyri\cyre}%
-          {\CYRU\cyrt\cyrv\cyre\cyrr\cyrzh\cyrd\cyre\cyrn\cyri\cyrya}%
-        \crefname{definition}%
-          {\CYRO\cyrp\cyrr\cyre\cyrd\cyre\cyrl\cyre\cyrn\cyri\cyre}%
-          {\CYRO\cyrp\cyrr\cyre\cyrd\cyre\cyrl\cyre\cyrn\cyri\cyrya}%
-        \crefname{result}%
-          {\CYRR\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt}%
-          {\CYRR\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt\cyrery}%
-        \crefname{example}%
-          {\CYRP\cyrr\cyri\cyrm\cyre\cyrr}%
-          {\CYRP\cyrr\cyri\cyrm\cyre\cyrr\cyrery}%
-        \crefname{remark}%
-          {\CYRP\cyrr\cyri\cyrm\cyre\cyrch\cyra\cyrn\cyri\cyre}%
-          {\CYRP\cyrr\cyri\cyrm\cyre\cyrch\cyra\cyrn\cyri\cyrya}%
-        \crefname{note}%
-          {\CYRZ\cyra\cyrm\cyre\cyrt\cyrk\cyra}%
-          {\CYRZ\cyra\cyrm\cyre\cyrt\cyrk\cyri}%
-        \crefname{algorithm}%
-          {\CYRA\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm}%
-          {\CYRA\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm\cyrery}%
-        \crefname{listing}%
-          {\CYRL\cyri\cyrs\cyrt\cyri\cyrn\cyrg}%
-          {\CYRL\cyri\cyrs\cyrt\cyri\cyrn\cyrg\cyri}%
-        \crefname{line}%
-          {\CYRS\cyrt\cyrr\cyro\cyrk\cyra}%
-          {\CYRS\cyrt\cyrr\cyro\cyrk\cyri}%
-      \else%
-        \crefname{equation}{\cyrf-\cyrl.}{\cyrf-\cyrl.}%
-        \crefname{part}%
-          {\cyrch\cyra\cyrs\cyrt\cyrsftsn}%
-          {\cyrch\cyra\cyrs\cyrt\cyri}%
-        \crefname{chapter}%
-          {\cyrg\cyrl\cyra\cyrv.}%
-          {\cyrg\cyrl\cyra\cyrv.}%
-        \crefname{section}%
-          {\cyrr\cyra\cyrz\cyrd.}%
-          {\cyrr\cyra\cyrz\cyrd\cyre\cyrl.}%
-        \crefname{subsection}%
-          {\cyrr\cyra\cyrz\cyrd.}%
-          {\cyrr\cyra\cyrz\cyrd\cyre\cyrl.}%
-        \crefname{subsubsection}%
-          {\cyrr\cyra\cyrz\cyrd.}%
-          {\cyrr\cyra\cyrz\cyrd\cyre\cyrl.}%
-        \crefname{appendix}%
-          {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh.}%
-          {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh.}%
-        \crefname{subappendix}%
-          {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh.}%
-          {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh.}%
-        \crefname{subsubappendix}%
-          {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh.}%
-          {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh.}%
-        \crefname{subsubsubappendix}%
-          {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh.}%
-          {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh.}%
-        \crefname{enumi}{\cyrp.}{\cyrp.\cyrp.}%
-        \crefname{enumii}{\cyrp.}{\cyrp.\cyrp.}%
-        \crefname{enumiii}{\cyrp.}{\cyrp.\cyrp.}%
-        \crefname{enumiv}{\cyrp.}{\cyrp.\cyrp.}%
-        \crefname{enumv}{\cyrp.}{\cyrp.\cyrp.}%
-        \crefname{footnote}%
-          {\cyrs\cyrn\cyro\cyrs\cyrk.}%
-          {\cyrs\cyrn\cyro\cyrs\cyrk.}%
-        \crefname{figure}%
-          {\cyrr\cyri\cyrs.}%
-          {\cyrr\cyri\cyrs.}%
-        \crefname{subfigure}%
-          {\cyrr\cyri\cyrs.}%
-          {\cyrr\cyri\cyrs.}%
-        \crefname{table}%
-          {\cyrt\cyra\cyrb\cyrl.}%
-          {\cyrt\cyra\cyrb\cyrl.}%
-        \crefname{subtable}%
-          {\cyrt\cyra\cyrb\cyrl.}%
-          {\cyrt\cyra\cyrb\cyrl.}%
-        \crefname{theorem}%
-          {\cyrt\cyre\cyro\cyrr\cyre\cyrm.}%
-          {\cyrt\cyre\cyro\cyrr\cyre\cyrm.}%
-        \crefname{lemma}%
-          {\cyrl\cyre\cyrm\cyrm.}%
-          {\cyrl\cyre\cyrm\cyrm.}%
-        \crefname{corollary}%
-          {\cyrv\cyrery\cyrv\cyro\cyrd}%
-          {\cyrv\cyrery\cyrv\cyro\cyrd.}%
-        \crefname{proposition}%
-          {\cyru\cyrt\cyrv\cyre\cyrr\cyrzh\cyrd.}%
-          {\cyru\cyrt\cyrv\cyre\cyrr\cyrzh\cyrd.}%
-        \crefname{definition}%
-          {\cyro\cyrp\cyrr\cyre\cyrd\cyre\cyrl\cyre\cyrn.}%
-          {\cyro\cyrp\cyrr\cyre\cyrd\cyre\cyrl\cyre\cyrn.}%
-        \crefname{result}%
-          {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt.}%
-          {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt.}%
-        \crefname{example}%
-          {\cyrp\cyrr\cyri\cyrm.}%
-          {\cyrp\cyrr\cyri\cyrm\cyre\cyrr.}%
-        \crefname{remark}%
-          {\cyrp\cyrr\cyri\cyrm\cyre\cyrch.}%
-          {\cyrp\cyrr\cyri\cyrm\cyre\cyrch.}%
-        \crefname{note}%
-          {\cyrz\cyra\cyrm\cyre\cyrt\cyrk.}%
-          {\cyrz\cyra\cyrm\cyre\cyrt\cyrk.}%
-        \crefname{algorithm}%
-          {\cyra\cyrl\cyrg.}%
-          {\cyra\cyrl\cyrg.}%
-        \crefname{listing}%
-          {\cyrl\cyri\cyrs\cyrt\cyri\cyrn.}%
-          {\cyrl\cyri\cyrs\cyrt\cyri\cyrn\cyrg.}%
-        \crefname{line}%
-          {\cyrs\cyrt\cyrr\cyrk.}%
-          {\cyrs\cyrt\cyrr\cyrk.}%
-      \fi%
-    }}}
+      \crefname{enumi}%
+        {\CYRP\cyru\cyrn\cyrk\cyrt}%
+        {\CYRP\cyru\cyrn\cyrk\cyrt\cyrery}%
+      \crefname{enumii}%
+        {\CYRP\cyru\cyrn\cyrk\cyrt}%
+        {\CYRP\cyru\cyrn\cyrk\cyrt\cyrery}%
+      \crefname{enumiii}%
+        {\CYRP\cyru\cyrn\cyrk\cyrt}%
+        {\CYRP\cyru\cyrn\cyrk\cyrt\cyrery}%
+      \crefname{enumiv}%
+        {\CYRP\cyru\cyrn\cyrk\cyrt}%
+        {\CYRP\cyru\cyrn\cyrk\cyrt\cyrery}%
+      \crefname{enumv}%
+        {\CYRP\cyru\cyrn\cyrk\cyrt}%
+        {\CYRP\cyru\cyrn\cyrk\cyrt\cyrery}%
+    \fi%
+    \crefname{page}%
+      {\CYRS\cyrt\cyrr\cyra\cyrn\cyri\cyrc\cyra}%
+      {\CYRS\cyrt\cyrr\cyra\cyrn\cyri\cyrc\cyrery}%
+    \crefname{part}%
+      {\CYRCH\cyra\cyrs\cyrt\cyrsftsn}%
+      {\CYRCH\cyra\cyrs\cyrt\cyri}%
+    \crefname{chapter}%
+      {\CYRG\cyrl\cyra\cyrv\cyra}%
+      {\CYRG\cyrl\cyra\cyrv\cyrery}%
+    \crefname{section}%
+      {\CYRR\cyra\cyrz\cyrd\cyre\cyrl}%
+      {\CYRR\cyra\cyrz\cyrd\cyre\cyrl\cyrery}%
+    \crefname{subsection}%
+      {\CYRR\cyra\cyrz\cyrd\cyre\cyrl}%
+      {\CYRR\cyra\cyrz\cyrd\cyre\cyrl\cyrery}%
+    \crefname{subsubsection}%
+      {\CYRR\cyra\cyrz\cyrd\cyre\cyrl}%
+      {\CYRR\cyra\cyrz\cyrd\cyre\cyrl\cyrery}%
+    \crefname{appendix}%
+      {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
+      {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}%
+    \crefname{subappendix}%
+      {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
+      {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}%
+    \crefname{subsubappendix}%
+      {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
+      {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}%
+    \crefname{subsubsubappendix}%
+      {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
+      {\CYRP\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}%
+    \crefname{footnote}%
+      {\CYRS\cyrn\cyro\cyrs\cyrk\cyra}%
+      {\CYRS\cyrn\cyro\cyrs\cyrk\cyri}%
+    \crefname{theorem}%
+      {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyra}%
+      {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyrery}%
+    \crefname{lemma}%
+      {\CYRL\cyre\cyrm\cyrm\cyra}%
+      {\CYRL\cyre\cyrm\cyrm\cyrery}%
+    \crefname{corollary}%
+      {\CYRV\cyrery\cyrv\cyro\cyrd}%
+      {\CYRV\cyrery\cyrv\cyro\cyrd\cyrery}%
+    \crefname{proposition}%
+      {\CYRU\cyrt\cyrv\cyre\cyrr\cyrzh\cyrd\cyre\cyrn\cyri\cyre}%
+      {\CYRU\cyrt\cyrv\cyre\cyrr\cyrzh\cyrd\cyre\cyrn\cyri\cyrya}%
+    \crefname{definition}%
+      {\CYRO\cyrp\cyrr\cyre\cyrd\cyre\cyrl\cyre\cyrn\cyri\cyre}%
+      {\CYRO\cyrp\cyrr\cyre\cyrd\cyre\cyrl\cyre\cyrn\cyri\cyrya}%
+    \crefname{result}%
+      {\CYRR\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt}%
+      {\CYRR\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt\cyrery}%
+    \crefname{example}%
+      {\CYRP\cyrr\cyri\cyrm\cyre\cyrr}%
+      {\CYRP\cyrr\cyri\cyrm\cyre\cyrr\cyrery}%
+    \crefname{remark}%
+      {\CYRP\cyrr\cyri\cyrm\cyre\cyrch\cyra\cyrn\cyri\cyre}%
+      {\CYRP\cyrr\cyri\cyrm\cyre\cyrch\cyra\cyrn\cyri\cyrya}%
+    \crefname{note}%
+      {\CYRZ\cyra\cyrm\cyre\cyrt\cyrk\cyra}%
+      {\CYRZ\cyra\cyrm\cyre\cyrt\cyrk\cyri}%
+    \crefname{algorithm}%
+      {\CYRA\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm}%
+      {\CYRA\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm\cyrery}%
+    \crefname{listing}%
+      {\CYRL\cyri\cyrs\cyrt\cyri\cyrn\cyrg}%
+      {\CYRL\cyri\cyrs\cyrt\cyri\cyrn\cyrg\cyri}%
+    \crefname{line}%
+      {\CYRS\cyrt\cyrr\cyro\cyrk\cyra}%
+      {\CYRS\cyrt\cyrr\cyro\cyrk\cyri}%
+ %
+  \else%  capitalise unset
+    \if@cref@abbrev%  abbrev set
+      \crefname{equation}%
+        {\cyrf-\cyrl.}%
+        {\cyrf-\cyrl.}%
+      \crefname{chapter}%
+        {\cyrg\cyrl\cyra\cyrv.}%
+        {\cyrg\cyrl\cyra\cyrv.}%
+      \crefname{section}%
+        {\cyrr\cyra\cyrz\cyrd.}%
+        {\cyrr\cyra\cyrz\cyrd\cyre\cyrl.}%
+      \crefname{subsection}%
+        {\cyrr\cyra\cyrz\cyrd.}%
+        {\cyrr\cyra\cyrz\cyrd\cyre\cyrl.}%
+      \crefname{subsubsection}%
+        {\cyrr\cyra\cyrz\cyrd.}%
+        {\cyrr\cyra\cyrz\cyrd\cyre\cyrl.}%
+      \crefname{appendix}%
+        {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh.}%
+        {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh.}%
+      \crefname{subappendix}%
+        {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh.}%
+        {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh.}%
+      \crefname{subsubappendix}%
+        {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh.}%
+        {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh.}%
+      \crefname{subsubsubappendix}%
+        {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh.}%
+        {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh.}%
+      \crefname{enumi}%
+        {\cyrp.}%
+        {\cyrp.\cyrp.}%
+      \crefname{enumii}%
+        {\cyrp.}%
+        {\cyrp.\cyrp.}%
+      \crefname{enumiii}%
+        {\cyrp.}%
+        {\cyrp.\cyrp.}%
+      \crefname{enumiv}%
+        {\cyrp.}%
+        {\cyrp.\cyrp.}%
+      \crefname{enumv}%
+        {\cyrp.}%
+        {\cyrp.\cyrp.}%
+      \crefname{footnote}%
+        {\cyrs\cyrn\cyro\cyrs\cyrk.}%
+        {\cyrs\cyrn\cyro\cyrs\cyrk.}%
+      \crefname{figure}%
+        {\cyrr\cyri\cyrs.}%
+        {\cyrr\cyri\cyrs.}%
+      \crefname{subfigure}%
+        {\cyrr\cyri\cyrs.}%
+        {\cyrr\cyri\cyrs.}%
+      \crefname{table}%
+        {\cyrt\cyra\cyrb\cyrl.}%
+        {\cyrt\cyra\cyrb\cyrl.}%
+      \crefname{subtable}%
+        {\cyrt\cyra\cyrb\cyrl.}%
+        {\cyrt\cyra\cyrb\cyrl.}%
+      \crefname{theorem}%
+        {\cyrt\cyre\cyro\cyrr\cyre\cyrm.}%
+        {\cyrt\cyre\cyro\cyrr\cyre\cyrm.}%
+      \crefname{lemma}%
+        {\cyrl\cyre\cyrm\cyrm.}%
+        {\cyrl\cyre\cyrm\cyrm.}%
+      \crefname{corollary}%
+        {\cyrv\cyrery\cyrv\cyro\cyrd}%
+        {\cyrv\cyrery\cyrv\cyro\cyrd.}%
+      \crefname{proposition}%
+        {\cyru\cyrt\cyrv\cyre\cyrr\cyrzh\cyrd.}%
+        {\cyru\cyrt\cyrv\cyre\cyrr\cyrzh\cyrd.}%
+      \crefname{definition}%
+        {\cyro\cyrp\cyrr\cyre\cyrd\cyre\cyrl\cyre\cyrn.}%
+        {\cyro\cyrp\cyrr\cyre\cyrd\cyre\cyrl\cyre\cyrn.}%
+      \crefname{result}%
+        {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt.}%
+        {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt.}%
+      \crefname{example}%
+        {\cyrp\cyrr\cyri\cyrm.}%
+        {\cyrp\cyrr\cyri\cyrm\cyre\cyrr.}%
+      \crefname{remark}%
+        {\cyrp\cyrr\cyri\cyrm\cyre\cyrch.}%
+        {\cyrp\cyrr\cyri\cyrm\cyre\cyrch.}%
+      \crefname{note}%
+        {\cyrz\cyra\cyrm\cyre\cyrt\cyrk.}%
+        {\cyrz\cyra\cyrm\cyre\cyrt\cyrk.}%
+      \crefname{algorithm}%
+        {\cyra\cyrl\cyrg.}%
+        {\cyra\cyrl\cyrg.}%
+      \crefname{listing}%
+        {\cyrl\cyri\cyrs\cyrt\cyri\cyrn.}%
+        {\cyrl\cyri\cyrs\cyrt\cyri\cyrn\cyrg.}%
+      \crefname{line}%
+        {\cyrs\cyrt\cyrr\cyrk.}%
+        {\cyrs\cyrt\cyrr\cyrk.}%
+    \else%  abbrev unset
+      \crefname{equation}%
+        {\cyrf\cyro\cyrr\cyrm\cyru\cyrl\cyra}%
+        {\cyrf\cyro\cyrr\cyrm\cyru\cyrl\cyrery}%
+      \crefname{figure}%
+        {\cyrr\cyri\cyrs\cyru\cyrn\cyro\cyrk}%
+        {\cyrr\cyri\cyrs\cyru\cyrn\cyrk\cyri}%
+      \crefname{subfigure}%
+        {\cyrr\cyri\cyrs\cyru\cyrn\cyro\cyrk}%
+        {\cyrr\cyri\cyrs\cyru\cyrn\cyrk\cyri}%
+      \crefname{table}%
+        {\cyrt\cyra\cyrb\cyrl\cyri\cyrc\cyra}%
+        {\cyrt\cyra\cyrb\cyrl\cyri\cyrc\cyrery}%
+      \crefname{subtable}%
+        {\cyrt\cyra\cyrb\cyrl\cyri\cyrc\cyra}%
+        {\cyrt\cyra\cyrb\cyrl\cyri\cyrc\cyrery}%
+      \crefname{enumi}%
+        {\cyrp\cyru\cyrn\cyrk\cyrt}%
+        {\cyrp\cyru\cyrn\cyrk\cyrt\cyrery}%
+      \crefname{enumii}%
+        {\cyrp\cyru\cyrn\cyrk\cyrt}%
+        {\cyrp\cyru\cyrn\cyrk\cyrt\cyrery}%
+      \crefname{enumiii}%
+        {\cyrp\cyru\cyrn\cyrk\cyrt}%
+        {\cyrp\cyru\cyrn\cyrk\cyrt\cyrery}%
+      \crefname{enumiv}%
+        {\cyrp\cyru\cyrn\cyrk\cyrt}%
+        {\cyrp\cyru\cyrn\cyrk\cyrt\cyrery}%
+      \crefname{enumv}%
+        {\cyrp\cyru\cyrn\cyrk\cyrt}%
+        {\cyrp\cyru\cyrn\cyrk\cyrt\cyrery}%
+      \crefname{chapter}%
+        {\cyrg\cyrl\cyra\cyrv\cyra}%
+        {\cyrg\cyrl\cyra\cyrv\cyrery}%
+      \crefname{section}%
+        {\cyrr\cyra\cyrz\cyrd\cyre\cyrl}%
+        {\cyrr\cyra\cyrz\cyrd\cyre\cyrl\cyrery}%
+      \crefname{subsection}%
+        {\cyrr\cyra\cyrz\cyrd\cyre\cyrl}%
+        {\cyrr\cyra\cyrz\cyrd\cyre\cyrl\cyrery}%
+      \crefname{subsubsection}%
+        {\cyrr\cyra\cyrz\cyrd\cyre\cyrl}%
+        {\cyrr\cyra\cyrz\cyrd\cyre\cyrl\cyrery}%
+      \crefname{appendix}%
+        {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
+        {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}%
+      \crefname{subappendix}%
+        {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
+        {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}%
+      \crefname{subsubappendix}%
+        {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
+        {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}%
+      \crefname{subsubsubappendix}%
+        {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyre}%
+        {\cyrp\cyrr\cyri\cyrl\cyro\cyrzh\cyre\cyrn\cyri\cyrya}%
+      \crefname{footnote}%
+        {\cyrs\cyrn\cyro\cyrs\cyrk\cyra}%
+        {\cyrs\cyrn\cyro\cyrs\cyrk\cyri}%
+      \crefname{theorem}%
+        {\cyrt\cyre\cyro\cyrr\cyre\cyrm\cyra}%
+        {\cyrt\cyre\cyro\cyrr\cyre\cyrm\cyrery}%
+      \crefname{lemma}%
+        {\cyrl\cyre\cyrm\cyrm\cyra}%
+        {\cyrl\cyre\cyrm\cyrm\cyrery}%
+      \crefname{corollary}%
+        {\cyrv\cyrery\cyrv\cyro\cyrd}%
+        {\cyrv\cyrery\cyrv\cyro\cyrd\cyrery}%
+      \crefname{proposition}%
+        {\cyru\cyrt\cyrv\cyre\cyrr\cyrzh\cyrd\cyre\cyrn\cyri\cyre}%
+        {\cyru\cyrt\cyrv\cyre\cyrr\cyrzh\cyrd\cyre\cyrn\cyri\cyrya}%
+      \crefname{definition}%
+        {\cyro\cyrp\cyrr\cyre\cyrd\cyre\cyrl\cyre\cyrn\cyri\cyre}%
+        {\cyro\cyrp\cyrr\cyre\cyrd\cyre\cyrl\cyre\cyrn\cyri\cyrya}%
+      \crefname{result}%
+        {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt}%
+        {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt\cyrery}%
+      \crefname{example}%
+        {\cyrp\cyrr\cyri\cyrm\cyre\cyrr}%
+        {\cyrp\cyrr\cyri\cyrm\cyre\cyrr\cyrery}%
+      \crefname{remark}%
+        {\cyrp\cyrr\cyri\cyrm\cyre\cyrch\cyra\cyrn\cyri\cyre}%
+        {\cyrp\cyrr\cyri\cyrm\cyre\cyrch\cyra\cyrn\cyri\cyrya}%
+      \crefname{note}%
+        {\cyrz\cyra\cyrm\cyre\cyrt\cyrk\cyra}%
+        {\cyrz\cyra\cyrm\cyre\cyrt\cyrk\cyri}%
+      \crefname{algorithm}%
+        {\cyra\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm}%
+        {\cyra\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm\cyrery}%
+      \crefname{listing}%
+        {\cyrl\cyri\cyrs\cyrt\cyri\cyrn\cyrg}%
+        {\cyrl\cyri\cyrs\cyrt\cyri\cyrn\cyrg\cyri}%
+      \crefname{line}%
+        {\cyrs\cyrt\cyrr\cyro\cyrk\cyra}%
+        {\cyrs\cyrt\cyrr\cyro\cyrk\cyri}%
+    \fi%
+    \crefname{page}%
+      {\cyrs\cyrt\cyrr\cyra\cyrn\cyri\cyrc\cyre}%
+      {\cyrs\cyrt\cyrr\cyra\cyrn\cyri\cyrc\cyra\cyrh}%
+    \crefname{part}%
+      {\cyrch\cyra\cyrs\cyrt\cyrsftsn}%
+      {\cyrch\cyra\cyrs\cyrt\cyri}%
+  \fi}% end \cref@loadlanguagedefs
 \DeclareOption{ukrainian}{%
-  \PackageInfo{cleveref}{loaded `ukrainian' language definitions}
   \AtBeginDocument{%
     \def\crefrangeconjunction@preamble{--}%
     \def\crefrangepreconjunction@preamble{}%
@@ -4683,12 +5729,19 @@
     \def\crefmiddlegroupconjunction@preamble{, }%
     \def\creflastgroupconjunction@preamble%
       {, \cyra\ \cyrt\cyra\cyrk\cyro\cyrzh\nobreakspace}%
+ %
     \Crefname@preamble{equation}%
       {\CYRF\cyro\cyrr\cyrm\cyru\cyrl\cyra}%
       {\CYRF\cyro\cyrr\cyrm\cyru\cyrl\cyri}%
-    \Crefname@preamble{part}%
-      {\CYRCH\cyra\cyrs\cyrt\cyri\cyrn\cyra}%
-      {\CYRCH\cyra\cyrs\cyrt\cyri\cyrn\cyri}%
+    \Crefname@preamble{figure}%
+      {\CYRR\cyri\cyrs\cyru\cyrn\cyro\cyrk}%
+      {\CYRR\cyri\cyrs\cyru\cyrn\cyrk\cyri}%
+    \Crefname@preamble{table}%
+      {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrya}%
+      {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrii}%
+    \Crefname@preamble{enumi}%
+      {\CYRP\cyru\cyrn\cyrk\cyrt}%
+      {\CYRP\cyru\cyrn\cyrk\cyrt\cyri}%
     \Crefname@preamble{chapter}%
       {\CYRG\cyrl\cyra\cyrv\cyra}%
       {\CYRG\cyrl\cyra\cyrv\cyri}%
@@ -4698,18 +5751,9 @@
     \Crefname@preamble{appendix}%
       {\CYRD\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
       {\CYRD\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
-    \Crefname@preamble{enumi}%
-      {\CYRP\cyru\cyrn\cyrk\cyrt}%
-      {\CYRP\cyru\cyrn\cyrk\cyrt\cyri}%
     \Crefname@preamble{footnote}%
       {\CYRV\cyri\cyrn\cyro\cyrs\cyrk\cyra}%
       {\CYRV\cyri\cyrn\cyro\cyrs\cyrk\cyri}%
-    \Crefname@preamble{figure}%
-      {\CYRR\cyri\cyrs\cyru\cyrn\cyro\cyrk}%
-      {\CYRR\cyri\cyrs\cyru\cyrn\cyrk\cyri}%
-    \Crefname@preamble{table}%
-      {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrya}%
-      {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrii}%
     \Crefname@preamble{theorem}%
       {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyra}%
       {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyri}%
@@ -4746,11 +5790,41 @@
     \Crefname@preamble{line}%
       {\CYRS\cyrt\cyrr\cyro\cyrk\cyra}%
       {\CYRS\cyrt\cyrr\cyro\cyrk\cyri}%
-    \if@cref@capitalise%
-      \crefname@preamble{equation}{\CYRF-\cyrl.}{\CYRF-\cyrl.}%
-      \crefname@preamble{part}%
-        {\CYRCH\cyra\cyrs\cyrt\cyri\cyrn\cyra}%
-        {\CYRCH\cyra\cyrs\cyrt\cyri\cyrn\cyri}%
+    \Crefname@preamble{page}%
+      {\CYRS\cyrt\cyro\cyrr\cyri\cyrn\cyrk\cyra}%
+      {\CYRS\cyrt\cyro\cyrr\cyrii\cyrn\cyrk\cyri}%
+    \Crefname@preamble{part}%
+      {\CYRCH\cyra\cyrs\cyrt\cyri\cyrn\cyra}%
+      {\CYRCH\cyra\cyrs\cyrt\cyri\cyrn\cyri}%
+ %
+    \if@cref@capitalise%  capitalise set
+      \if@cref@abbrev%  abbrev set
+        \crefname@preamble{equation}%
+          {\CYRF-\cyrl.}%
+          {\CYRF-\cyrl.}%
+        \crefname@preamble{figure}%
+          {\CYRR\cyri\cyrs.}%
+          {\CYRR\cyri\cyrs.}%
+        \crefname@preamble{table}%
+          {\CYRT\cyra\cyrb\cyrl.}%
+          {\CYRT\cyra\cyrb\cyrl.}%
+        \crefname@preamble{enumi}%
+          {\CYRP.}%
+          {\CYRP.\cyrp.}%
+      \else%
+        \crefname@preamble{equation}%
+          {\CYRF\cyro\cyrr\cyrm\cyru\cyrl\cyra}%
+          {\CYRF\cyro\cyrr\cyrm\cyru\cyrl\cyri}%
+        \crefname@preamble{figure}%
+          {\CYRR\cyri\cyrs\cyru\cyrn\cyro\cyrk}%
+          {\CYRR\cyri\cyrs\cyru\cyrn\cyrk\cyri}%
+        \crefname@preamble{table}%
+          {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrya}%
+          {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrii}%
+        \crefname@preamble{enumi}%
+          {\CYRP\cyru\cyrn\cyrk\cyrt}%
+          {\CYRP\cyru\cyrn\cyrk\cyrt\cyri}%
+      \fi%
       \crefname@preamble{chapter}%
         {\CYRG\cyrl\cyra\cyrv\cyra}%
         {\CYRG\cyrl\cyra\cyrv\cyri}%
@@ -4760,16 +5834,9 @@
       \crefname@preamble{appendix}%
         {\CYRD\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
         {\CYRD\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
-      \crefname@preamble{enumi}{\CYRP.}{\CYRP.\cyrp.}%
       \crefname@preamble{footnote}%
         {\CYRV\cyri\cyrn\cyro\cyrs\cyrk\cyra}%
         {\CYRV\cyri\cyrn\cyro\cyrs\cyrk\cyri}%
-      \crefname@preamble{figure}%
-        {\CYRR\cyri\cyrs.}%
-        {\CYRR\cyri\cyrs.}%
-      \crefname@preamble{table}%
-        {\CYRT\cyra\cyrb\cyrl.}%
-        {\CYRT\cyra\cyrb\cyrl.}%
       \crefname@preamble{theorem}%
         {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyra}%
         {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyri}%
@@ -4806,347 +5873,592 @@
       \crefname@preamble{line}%
         {\CYRS\cyrt\cyrr\cyro\cyrk\cyra}%
         {\CYRS\cyrt\cyrr\cyro\cyrk\cyri}%
-    \else%
-      \crefname@preamble{equation}{\cyrf-\cyrl.}{\cyrf-\cyrl.}%
+      \crefname@preamble{page}%
+        {\CYRS\cyrt\cyro\cyrr\cyri\cyrn\cyrk\cyra}%
+        {\CYRS\cyrt\cyro\cyrr\cyrii\cyrn\cyrk\cyri}%
+      \crefname@preamble{part}%
+        {\CYRCH\cyra\cyrs\cyrt\cyri\cyrn\cyra}%
+        {\CYRCH\cyra\cyrs\cyrt\cyri\cyrn\cyri}%
+ %
+    \else%  capitalise unset
+      \if@cref@abbrev%  abbrev set
+        \crefname@preamble{equation}%
+          {\cyrf-\cyrl.}%
+          {\cyrf-\cyrl.}%
+        \crefname@preamble{figure}%
+          {\cyrr\cyri\cyrs.}%
+          {\cyrr\cyri\cyrs.}%
+        \crefname@preamble{table}%
+          {\cyrt\cyra\cyrb\cyrl.}%
+          {\cyrt\cyra\cyrb\cyrl.}%
+        \crefname@preamble{enumi}%
+          {\cyrp.}%
+          {\cyrp.\cyrp.}%
+        \crefname@preamble{chapter}%
+          {\cyrg\cyrl\cyra\cyrv.}%
+          {\cyrg\cyrl\cyra\cyrv.}%
+        \crefname@preamble{section}%
+          {\cyrr\cyro\cyrz\cyrd.}%
+          {\cyrr\cyro\cyrz\cyrd\cyrii\cyrl.}%
+        \crefname@preamble{appendix}%
+          {\cyrd\cyro\cyrd\cyra\cyrt.}%
+          {\cyrd\cyro\cyrd\cyra\cyrt\cyrk.}%
+        \crefname@preamble{footnote}%
+          {\cyrv\cyri\cyrn\cyro\cyrs\cyrk.}%
+          {\cyrv\cyri\cyrn\cyro\cyrs\cyrk.}%
+        \crefname@preamble{theorem}%
+          {\cyrt\cyre\cyro\cyrr\cyre\cyrm.}%
+          {\cyrt\cyre\cyro\cyrr\cyre\cyrm.}%
+        \crefname@preamble{lemma}%
+          {\cyrl\cyre\cyrm\cyrm.}%
+          {\cyrl\cyre\cyrm\cyrm.}%
+        \crefname@preamble{corollary}%
+          {\cyrv\cyri\cyrs\cyrn\cyro\cyrv.}%
+          {\cyrv\cyri\cyrs\cyrn\cyro\cyrv\cyrk.}%
+        \crefname@preamble{proposition}%
+          {\cyrt\cyrv\cyre\cyrr\cyrd\cyrzh\cyre\cyrn\cyrn.}%
+          {\cyrt\cyrv\cyre\cyrr\cyrd\cyrzh\cyre\cyrn\cyrn.}%
+        \crefname@preamble{definition}%
+          {\cyrv\cyri\cyrz\cyrn\cyra\cyrch\cyre\cyrn\cyrn.}%
+          {\cyrv\cyri\cyrz\cyrn\cyra\cyrch\cyre\cyrn\cyrn.}%
+        \crefname@preamble{result}%
+          {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt.}%
+          {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt.}%
+        \crefname@preamble{example}%
+          {\cyrp\cyrr\cyri\cyrk\cyrl.}%
+          {\cyrp\cyrr\cyri\cyrk\cyrl\cyra\cyrd.}%
+        \crefname@preamble{remark}%
+          {\cyrp\cyrr\cyri\cyrm\cyrii\cyrt.}%
+          {\cyrp\cyrr\cyri\cyrm\cyrii\cyrt.}%
+        \crefname@preamble{note}%
+          {\cyrz\cyra\cyrm\cyrii\cyrt.}%
+          {\cyrz\cyra\cyrm\cyrii\cyrt.}%
+        \crefname@preamble{algorithm}%
+          {\cyra\cyrl\cyrg.}%
+          {\cyra\cyrl\cyrg.}%
+        \crefname@preamble{listing}%
+          {\cyrl\cyrii\cyrs\cyrt\cyri\cyrn.}%
+          {\cyrl\cyrii\cyrs\cyrt\cyri\cyrn\cyrg.}%
+        \crefname@preamble{line}%
+          {\cyrs\cyrt\cyrr\cyrk.}%
+          {\cyrs\cyrt\cyrr\cyrk.}%
+      \else%  abbrev unset
+        \crefname@preamble{equation}%
+          {\cyrf\cyro\cyrr\cyrm\cyru\cyrl\cyra}%
+          {\cyrf\cyro\cyrr\cyrm\cyru\cyrl\cyri}%
+        \crefname@preamble{figure}%
+          {\cyrr\cyri\cyrs\cyru\cyrn\cyro\cyrk}%
+          {\cyrr\cyri\cyrs\cyru\cyrn\cyrk\cyri}%
+        \crefname@preamble{table}%
+          {\cyrt\cyra\cyrb\cyrl\cyri\cyrc\cyrya}%
+          {\cyrt\cyra\cyrb\cyrl\cyri\cyrc\cyrii}%
+        \crefname@preamble{enumi}%
+          {\cyrp\cyru\cyrn\cyrk\cyrt}%
+          {\cyrp\cyru\cyrn\cyrk\cyrt\cyri}%
+        \crefname@preamble{chapter}%
+          {\cyrg\cyrl\cyra\cyrv\cyra}%
+          {\cyrg\cyrl\cyra\cyrv\cyri}%
+        \crefname@preamble{section}%
+          {\cyrr\cyro\cyrz\cyrd\cyrii\cyrl}%
+          {\cyrr\cyro\cyrz\cyrd\cyrii\cyrl\cyri}%
+        \crefname@preamble{appendix}%
+          {\cyrd\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
+          {\cyrd\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
+        \crefname@preamble{footnote}%
+          {\cyrv\cyri\cyrn\cyro\cyrs\cyrk\cyra}%
+          {\cyrv\cyri\cyrn\cyro\cyrs\cyrk\cyri}%
+        \crefname@preamble{theorem}%
+          {\cyrt\cyre\cyro\cyrr\cyre\cyrm\cyra}%
+          {\cyrt\cyre\cyro\cyrr\cyre\cyrm\cyri}%
+        \crefname@preamble{lemma}%
+          {\cyrl\cyre\cyrm\cyrm\cyra}%
+          {\cyrl\cyre\cyrm\cyrm\cyri}%
+        \crefname@preamble{corollary}%
+          {\cyrv\cyri\cyrs\cyrn\cyro\cyrv\cyro\cyrk}%
+          {\cyrv\cyri\cyrs\cyrn\cyro\cyrv\cyrk\cyri}%
+        \crefname@preamble{proposition}%
+          {\cyrt\cyrv\cyre\cyrr\cyrd\cyrzh\cyre\cyrn\cyrn\cyrya}%
+          {\cyrt\cyrv\cyre\cyrr\cyrd\cyrzh\cyre\cyrn\cyrn\cyrya}%
+        \crefname@preamble{definition}%
+          {\cyrv\cyri\cyrz\cyrn\cyra\cyrch\cyre\cyrn\cyrn\cyrya}%
+          {\cyrv\cyri\cyrz\cyrn\cyra\cyrch\cyre\cyrn\cyrn\cyrya}%
+        \crefname@preamble{result}%
+          {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt}%
+          {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt\cyri}%
+        \crefname@preamble{example}%
+          {\cyrp\cyrr\cyri\cyrk\cyrl\cyra\cyrd}%
+          {\cyrp\cyrr\cyri\cyrk\cyrl\cyra\cyrd\cyri}%
+        \crefname@preamble{remark}%
+          {\cyrp\cyrr\cyri\cyrm\cyrii\cyrt\cyrk\cyra}%
+          {\cyrp\cyrr\cyri\cyrm\cyrii\cyrt\cyrk\cyri}%
+        \crefname@preamble{note}%
+          {\cyrz\cyra\cyrm\cyrii\cyrt\cyrk\cyra}%
+          {\cyrz\cyra\cyrm\cyrii\cyrt\cyrk\cyri}%
+        \crefname@preamble{algorithm}%
+          {\cyra\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm}%
+          {\cyra\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm\cyri}%
+        \crefname@preamble{listing}%
+          {\cyrl\cyrii\cyrs\cyrt\cyri\cyrn\cyrg}%
+          {\cyrl\cyrii\cyrs\cyrt\cyri\cyrn\cyrg\cyri}%
+        \crefname@preamble{line}%
+          {\cyrs\cyrt\cyrr\cyro\cyrk\cyra}%
+          {\cyrs\cyrt\cyrr\cyro\cyrk\cyri}%
+      \fi%
+      \crefname@preamble{page}%
+        {\cyrs\cyrt\cyro\cyrr\cyri\cyrn\cyrc\cyrii}%
+        {\cyrs\cyrt\cyro\cyrr\cyrii\cyrn\cyrk\cyra\cyrh}%
       \crefname@preamble{part}%
         {\cyrch\cyra\cyrs\cyrt\cyri\cyrn\cyra}%
         {\cyrch\cyra\cyrs\cyrt\cyri\cyrn\cyri}%
-      \crefname@preamble{chapter}%
-        {\cyrg\cyrl\cyra\cyrv.}%
-        {\cyrg\cyrl\cyra\cyrv.}%
-      \crefname@preamble{section}%
-        {\cyrr\cyro\cyrz\cyrd.}%
-        {\cyrr\cyro\cyrz\cyrd\cyrii\cyrl.}%
-      \crefname@preamble{appendix}%
-        {\cyrd\cyro\cyrd\cyra\cyrt.}%
-        {\cyrd\cyro\cyrd\cyra\cyrt\cyrk.}%
-      \crefname@preamble{enumi}{\cyrp.}{\cyrp.\cyrp.}%
-      \crefname@preamble{footnote}%
-        {\cyrv\cyri\cyrn\cyro\cyrs\cyrk.}%
-        {\cyrv\cyri\cyrn\cyro\cyrs\cyrk.}%
-      \crefname@preamble{figure}%
-        {\cyrr\cyri\cyrs.}%
-        {\cyrr\cyri\cyrs.}%
-      \crefname@preamble{table}%
-        {\cyrt\cyra\cyrb\cyrl.}%
-        {\cyrt\cyra\cyrb\cyrl.}%
-      \crefname@preamble{theorem}%
-        {\cyrt\cyre\cyro\cyrr\cyre\cyrm.}%
-        {\cyrt\cyre\cyro\cyrr\cyre\cyrm.}%
-      \crefname@preamble{lemma}%
-        {\cyrl\cyre\cyrm\cyrm.}%
-        {\cyrl\cyre\cyrm\cyrm.}%
-      \crefname@preamble{corollary}%
-        {\cyrv\cyri\cyrs\cyrn\cyro\cyrv.}%
-        {\cyrv\cyri\cyrs\cyrn\cyro\cyrv\cyrk.}%
-      \crefname@preamble{proposition}%
-        {\cyrt\cyrv\cyre\cyrr\cyrd\cyrzh\cyre\cyrn\cyrn.}%
-        {\cyrt\cyrv\cyre\cyrr\cyrd\cyrzh\cyre\cyrn\cyrn.}%
-      \crefname@preamble{definition}%
-        {\cyrv\cyri\cyrz\cyrn\cyra\cyrch\cyre\cyrn\cyrn.}%
-        {\cyrv\cyri\cyrz\cyrn\cyra\cyrch\cyre\cyrn\cyrn.}%
-      \crefname@preamble{result}%
-        {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt.}%
-        {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt.}%
-      \crefname@preamble{example}%
-        {\cyrp\cyrr\cyri\cyrk\cyrl.}%
-        {\cyrp\cyrr\cyri\cyrk\cyrl\cyra\cyrd.}%
-      \crefname@preamble{remark}%
-        {\cyrp\cyrr\cyri\cyrm\cyrii\cyrt.}%
-        {\cyrp\cyrr\cyri\cyrm\cyrii\cyrt.}%
-      \crefname@preamble{note}%
-        {\cyrz\cyra\cyrm\cyrii\cyrt.}%
-        {\cyrz\cyra\cyrm\cyrii\cyrt.}%
-      \crefname@preamble{algorithm}%
-        {\cyra\cyrl\cyrg.}%
-        {\cyra\cyrl\cyrg.}%
-      \crefname@preamble{listing}%
-        {\cyrl\cyrii\cyrs\cyrt\cyri\cyrn.}%
-        {\cyrl\cyrii\cyrs\cyrt\cyri\cyrn\cyrg.}%
-      \crefname@preamble{line}%
-        {\cyrs\cyrt\cyrr\cyrk.}%
-        {\cyrs\cyrt\cyrr\cyrk.}%
     \fi%
     \def\cref@language{ukrainian}%
-    \cref@addto\extrasukrainian{%
-      \renewcommand{\crefrangeconjunction}{--}%
-      \renewcommand\crefrangepreconjunction{}%
-      \renewcommand\crefrangepostconjunction{}%
-      \renewcommand{\crefpairconjunction}{ \cyrii\nobreakspace}%
-      \renewcommand{\crefmiddleconjunction}{, }%
-      \renewcommand{\creflastconjunction}{ \cyrii\nobreakspace}%
-      \renewcommand{\crefpairgroupconjunction}{ \cyrt\cyra\nobreakspace}%
-      \renewcommand{\crefmiddlegroupconjunction}{, }%
-      \renewcommand{\creflastgroupconjunction}%
-        {, \cyra\ \cyrt\cyra\cyrk\cyro\cyrzh\nobreakspace}%
-      \Crefname{equation}%
+  }}% end \DeclareOption and \AtBeginDocument
+\cref@addlanguagedefs{ukrainian}{%
+  \PackageInfo{cleveref}{loaded `ukrainian' language definitions}%
+  \renewcommand{\crefrangeconjunction}{--}%
+  \renewcommand\crefrangepreconjunction{}%
+  \renewcommand\crefrangepostconjunction{}%
+  \renewcommand{\crefpairconjunction}{ \cyrii\nobreakspace}%
+  \renewcommand{\crefmiddleconjunction}{, }%
+  \renewcommand{\creflastconjunction}{ \cyrii\nobreakspace}%
+  \renewcommand{\crefpairgroupconjunction}%
+    { \cyrt\cyra\nobreakspace}%
+  \renewcommand{\crefmiddlegroupconjunction}{, }%
+  \renewcommand{\creflastgroupconjunction}%
+    {, \cyra\ \cyrt\cyra\cyrk\cyro\cyrzh\nobreakspace}%
+ %
+    \Crefname{equation}%
+    {\CYRF\cyro\cyrr\cyrm\cyru\cyrl\cyra}%
+    {\CYRF\cyro\cyrr\cyrm\cyru\cyrl\cyri}%
+  \Crefname{figure}%
+    {\CYRR\cyri\cyrs\cyru\cyrn\cyro\cyrk}%
+    {\CYRR\cyri\cyrs\cyru\cyrn\cyrk\cyri}%
+  \Crefname{subfigure}%
+    {\CYRR\cyri\cyrs\cyru\cyrn\cyro\cyrk}%
+    {\CYRR\cyri\cyrs\cyru\cyrn\cyrk\cyri}%
+  \Crefname{table}%
+    {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrya}%
+    {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrii}%
+  \Crefname{subtable}%
+    {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrya}%
+    {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrii}%
+  \Crefname{enumi}%
+    {\CYRP\cyru\cyrn\cyrk\cyrt}%
+    {\CYRP\cyru\cyrn\cyrk\cyrt\cyri}%
+  \Crefname{enumii}%
+    {\CYRP\cyru\cyrn\cyrk\cyrt}%
+    {\CYRP\cyru\cyrn\cyrk\cyrt\cyri}%
+  \Crefname{enumiii}%
+    {\CYRP\cyru\cyrn\cyrk\cyrt}%
+    {\CYRP\cyru\cyrn\cyrk\cyrt\cyri}%
+  \Crefname{enumiv}%
+    {\CYRP\cyru\cyrn\cyrk\cyrt}%
+    {\CYRP\cyru\cyrn\cyrk\cyrt\cyri}%
+  \Crefname{enumv}%
+    {\CYRP\cyru\cyrn\cyrk\cyrt}%
+    {\CYRP\cyru\cyrn\cyrk\cyrt\cyri}%
+  \Crefname{chapter}%
+    {\CYRG\cyrl\cyra\cyrv\cyra}%
+    {\CYRG\cyrl\cyra\cyrv\cyri}%
+  \Crefname{section}%
+    {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl}%
+    {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl\cyri}%
+  \Crefname{subsection}%
+    {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl}%
+    {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl\cyri}%
+  \Crefname{subsubsection}%
+    {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl}%
+    {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl\cyri}%
+  \Crefname{appendix}%
+    {\CYRD\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
+    {\CYRD\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
+  \Crefname{subappendix}%
+    {\CYRD\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
+    {\CYRD\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
+  \Crefname{subsubappendix}%
+    {\CYRD\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
+    {\CYRD\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
+  \Crefname{subsubsubappendix}%
+    {\CYRD\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
+    {\CYRD\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
+  \Crefname{footnote}%
+    {\CYRV\cyri\cyrn\cyro\cyrs\cyrk\cyra}%
+    {\CYRV\cyri\cyrn\cyro\cyrs\cyrk\cyri}%
+  \Crefname{theorem}%
+    {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyra}%
+    {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyri}%
+  \Crefname{lemma}%
+    {\CYRL\cyre\cyrm\cyrm\cyra}%
+    {\CYRL\cyre\cyrm\cyrm\cyri}%
+  \Crefname{corollary}%
+    {\CYRV\cyri\cyrs\cyrn\cyro\cyrv\cyro\cyrk}%
+    {\CYRV\cyri\cyrs\cyrn\cyro\cyrv\cyrk\cyri}%
+  \Crefname{proposition}%
+    {\CYRT\cyrv\cyre\cyrr\cyrd\cyrzh\cyre\cyrn\cyrn\cyrya}%
+    {\CYRT\cyrv\cyre\cyrr\cyrd\cyrzh\cyre\cyrn\cyrn\cyrya}%
+  \Crefname{definition}%
+    {\CYRV\cyri\cyrz\cyrn\cyra\cyrch\cyre\cyrn\cyrn\cyrya}%
+    {\CYRV\cyri\cyrz\cyrn\cyra\cyrch\cyre\cyrn\cyrn\cyrya}%
+  \Crefname{result}%
+    {\CYRR\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt}%
+    {\CYRR\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt\cyri}%
+  \Crefname{example}%
+    {\CYRP\cyrr\cyri\cyrk\cyrl\cyra\cyrd}%
+    {\CYRP\cyrr\cyri\cyrk\cyrl\cyra\cyrd\cyri}%
+  \Crefname{remark}%
+    {\CYRP\cyrr\cyri\cyrm\cyrii\cyrt\cyrk\cyra}%
+    {\CYRP\cyrr\cyri\cyrm\cyrii\cyrt\cyrk\cyri}%
+  \Crefname{note}%
+    {\CYRZ\cyra\cyrm\cyrii\cyrt\cyrk\cyra}%
+    {\CYRZ\cyra\cyrm\cyrii\cyrt\cyrk\cyri}%
+  \Crefname{algorithm}%
+    {\CYRA\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm}%
+    {\CYRA\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm\cyri}%
+  \Crefname{listing}%
+    {\CYRL\cyrii\cyrs\cyrt\cyri\cyrn\cyrg}%
+    {\CYRL\cyrii\cyrs\cyrt\cyri\cyrn\cyrg\cyri}%
+  \Crefname{line}%
+    {\CYRS\cyrt\cyrr\cyro\cyrk\cyra}%
+    {\CYRS\cyrt\cyrr\cyro\cyrk\cyri}%
+  \Crefname{page}%
+    {\CYRS\cyrt\cyro\cyrr\cyri\cyrn\cyrk\cyra}%
+    {\CYRS\cyrt\cyro\cyrr\cyrii\cyrn\cyrk\cyri}%
+  \Crefname{part}%
+    {\CYRCH\cyra\cyrs\cyrt\cyri\cyrn\cyra}%
+    {\CYRCH\cyra\cyrs\cyrt\cyri\cyrn\cyri}%
+ %
+  \if@cref@capitalise%  capitalise set
+    \if@cref@abbrev%  abbrev set
+      \crefname{equation}%
+        {\CYRF-\cyrl.}%
+        {\CYRF-\cyrl.}%
+      \crefname{figure}%
+        {\CYRR\cyri\cyrs.}%
+        {\CYRR\cyri\cyrs.}%
+      \crefname{subfigure}%
+        {\CYRR\cyri\cyrs.}%
+        {\CYRR\cyri\cyrs.}%
+      \crefname{table}%
+        {\CYRT\cyra\cyrb\cyrl.}%
+        {\CYRT\cyra\cyrb\cyrl.}%
+      \crefname{subtable}%
+        {\CYRT\cyra\cyrb\cyrl.}%
+        {\CYRT\cyra\cyrb\cyrl.}%
+      \crefname{enumi}%
+        {\CYRP.}%
+        {\CYRP.\cyrp.}%
+      \crefname{enumii}%
+        {\CYRP.}%
+        {\CYRP.\cyrp.}%
+      \crefname{enumiii}%
+        {\CYRP.}%
+        {\CYRP.\cyrp.}%
+      \crefname{enumiv}%
+        {\CYRP.}%
+        {\CYRP.\cyrp.}%
+      \crefname{enumv}%
+        {\CYRP.}%
+        {\CYRP.\cyrp.}%
+    \else%  abbrev unset
+      \crefname{equation}%
         {\CYRF\cyro\cyrr\cyrm\cyru\cyrl\cyra}%
         {\CYRF\cyro\cyrr\cyrm\cyru\cyrl\cyri}%
-      \Crefname{part}%
-        {\CYRCH\cyra\cyrs\cyrt\cyri\cyrn\cyra}%
-        {\CYRCH\cyra\cyrs\cyrt\cyri\cyrn\cyri}%
-      \Crefname{chapter}%
-        {\CYRG\cyrl\cyra\cyrv\cyra}%
-        {\CYRG\cyrl\cyra\cyrv\cyri}%
-      \Crefname{section}%
-        {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl}%
-        {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl\cyri}%
-      \Crefname{subsection}%
-        {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl}%
-        {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl\cyri}%
-      \Crefname{subsubsection}%
-        {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl}%
-        {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl\cyri}%
-      \Crefname{appendix}%
-        {\CYRD\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
-        {\CYRD\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
-      \Crefname{subappendix}%
-        {\CYRD\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
-        {\CYRD\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
-      \Crefname{subsubappendix}%
-        {\CYRD\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
-        {\CYRD\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
-      \Crefname{subsubsubappendix}%
-        {\CYRD\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
-        {\CYRD\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
-      \Crefname{enumi}%
-        {\CYRP\cyru\cyrn\cyrk\cyrt}%
-        {\CYRP\cyru\cyrn\cyrk\cyrt\cyri}%
-      \Crefname{enumii}%
-        {\CYRP\cyru\cyrn\cyrk\cyrt}%
-        {\CYRP\cyru\cyrn\cyrk\cyrt\cyri}%
-      \Crefname{enumiii}%
-        {\CYRP\cyru\cyrn\cyrk\cyrt}%
-        {\CYRP\cyru\cyrn\cyrk\cyrt\cyri}%
-      \Crefname{enumiv}%
-        {\CYRP\cyru\cyrn\cyrk\cyrt}%
-        {\CYRP\cyru\cyrn\cyrk\cyrt\cyri}%
-      \Crefname{enumv}%
-        {\CYRP\cyru\cyrn\cyrk\cyrt}%
-        {\CYRP\cyru\cyrn\cyrk\cyrt\cyri}%
-      \Crefname{footnote}%
-        {\CYRV\cyri\cyrn\cyro\cyrs\cyrk\cyra}%
-        {\CYRV\cyri\cyrn\cyro\cyrs\cyrk\cyri}%
-      \Crefname{figure}%
+      \crefname{figure}%
         {\CYRR\cyri\cyrs\cyru\cyrn\cyro\cyrk}%
         {\CYRR\cyri\cyrs\cyru\cyrn\cyrk\cyri}%
-      \Crefname{subfigure}%
+      \crefname{subfigure}%
         {\CYRR\cyri\cyrs\cyru\cyrn\cyro\cyrk}%
         {\CYRR\cyri\cyrs\cyru\cyrn\cyrk\cyri}%
-      \Crefname{table}%
+      \crefname{table}%
         {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrya}%
         {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrii}%
-      \Crefname{subtable}%
+      \crefname{subtable}%
         {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrya}%
         {\CYRT\cyra\cyrb\cyrl\cyri\cyrc\cyrii}%
-      \Crefname{theorem}%
-        {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyra}%
-        {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyri}%
-      \Crefname{lemma}%
-        {\CYRL\cyre\cyrm\cyrm\cyra}%
-        {\CYRL\cyre\cyrm\cyrm\cyri}%
-      \Crefname{corollary}%
-        {\CYRV\cyri\cyrs\cyrn\cyro\cyrv\cyro\cyrk}%
-        {\CYRV\cyri\cyrs\cyrn\cyro\cyrv\cyrk\cyri}%
-      \Crefname{proposition}%
-        {\CYRT\cyrv\cyre\cyrr\cyrd\cyrzh\cyre\cyrn\cyrn\cyrya}%
-        {\CYRT\cyrv\cyre\cyrr\cyrd\cyrzh\cyre\cyrn\cyrn\cyrya}%
-      \Crefname{definition}%
-        {\CYRV\cyri\cyrz\cyrn\cyra\cyrch\cyre\cyrn\cyrn\cyrya}%
-        {\CYRV\cyri\cyrz\cyrn\cyra\cyrch\cyre\cyrn\cyrn\cyrya}%
-      \Crefname{result}%
-        {\CYRR\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt}%
-        {\CYRR\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt\cyri}%
-      \Crefname{example}%
-        {\CYRP\cyrr\cyri\cyrk\cyrl\cyra\cyrd}%
-        {\CYRP\cyrr\cyri\cyrk\cyrl\cyra\cyrd\cyri}%
-      \Crefname{remark}%
-        {\CYRP\cyrr\cyri\cyrm\cyrii\cyrt\cyrk\cyra}%
-        {\CYRP\cyrr\cyri\cyrm\cyrii\cyrt\cyrk\cyri}%
-      \Crefname{note}%
-        {\CYRZ\cyra\cyrm\cyrii\cyrt\cyrk\cyra}%
-        {\CYRZ\cyra\cyrm\cyrii\cyrt\cyrk\cyri}%
-      \Crefname{algorithm}%
-        {\CYRA\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm}%
-        {\CYRA\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm\cyri}%
-      \Crefname{listing}%
-        {\CYRL\cyrii\cyrs\cyrt\cyri\cyrn\cyrg}%
-        {\CYRL\cyrii\cyrs\cyrt\cyri\cyrn\cyrg\cyri}%
-      \Crefname{line}%
-        {\CYRS\cyrt\cyrr\cyro\cyrk\cyra}%
-        {\CYRS\cyrt\cyrr\cyro\cyrk\cyri}%
-      \if@cref@capitalise%
-        \crefname{equation}{\CYRF-\cyrl.}{\CYRF-\cyrl.}%
-        \crefname{part}%
-          {\CYRCH\cyra\cyrs\cyrt\cyri\cyrn\cyra}%
-          {\CYRCH\cyra\cyrs\cyrt\cyri\cyrn\cyri}%
-        \crefname{chapter}%
-          {\CYRG\cyrl\cyra\cyrv\cyra}%
-          {\CYRG\cyrl\cyra\cyrv\cyri}%
-        \crefname{section}%
-          {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl}%
-          {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl\cyri}%
-        \crefname{subsection}%
-          {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl}%
-          {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl\cyri}%
-        \crefname{subsubsection}%
-          {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl}%
-          {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl\cyri}%
-        \crefname{appendix}%
-          {\CYRD\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
-          {\CYRD\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
-        \crefname{subappendix}%
-          {\CYRD\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
-          {\CYRD\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
-        \crefname{subsubappendix}%
-          {\CYRD\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
-          {\CYRD\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
-        \crefname{subsubsubappendix}%
-          {\CYRD\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
-          {\CYRD\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
-        \crefname{enumi}{\CYRP.}{\CYRP.\cyrp.}%
-        \crefname{enumii}{\CYRP.}{\CYRP.\cyrp.}%
-        \crefname{enumiii}{\CYRP.}{\CYRP.\cyrp.}%
-        \crefname{enumiv}{\CYRP.}{\CYRP.\cyrp.}%
-        \crefname{enumv}{\CYRP.}{\CYRP.\cyrp.}%
-        \crefname{footnote}%
-          {\CYRV\cyri\cyrn\cyro\cyrs\cyrk\cyra}%
-          {\CYRV\cyri\cyrn\cyro\cyrs\cyrk\cyri}%
-        \crefname{figure}%
-          {\CYRR\cyri\cyrs.}%
-          {\CYRR\cyri\cyrs.}%
-        \crefname{subfigure}%
-          {\CYRR\cyri\cyrs.}%
-          {\CYRR\cyri\cyrs.}%
-        \crefname{table}%
-          {\CYRT\cyra\cyrb\cyrl.}%
-          {\CYRT\cyra\cyrb\cyrl.}%
-        \crefname{subtable}%
-          {\CYRT\cyra\cyrb\cyrl.}%
-          {\CYRT\cyra\cyrb\cyrl.}%
-        \crefname{theorem}%
-          {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyra}%
-          {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyri}%
-        \crefname{lemma}%
-          {\CYRL\cyre\cyrm\cyrm\cyra}%
-          {\CYRL\cyre\cyrm\cyrm\cyri}%
-        \crefname{corollary}%
-          {\CYRV\cyri\cyrs\cyrn\cyro\cyrv\cyro\cyrk}%
-          {\CYRV\cyri\cyrs\cyrn\cyro\cyrv\cyrk\cyri}%
-        \crefname{proposition}%
-          {\CYRT\cyrv\cyre\cyrr\cyrd\cyrzh\cyre\cyrn\cyrn\cyrya}%
-          {\CYRT\cyrv\cyre\cyrr\cyrd\cyrzh\cyre\cyrn\cyrn\cyrya}%
-        \crefname{definition}%
-          {\CYRV\cyri\cyrz\cyrn\cyra\cyrch\cyre\cyrn\cyrn\cyrya}%
-          {\CYRV\cyri\cyrz\cyrn\cyra\cyrch\cyre\cyrn\cyrn\cyrya}%
-        \crefname{result}%
-          {\CYRR\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt}%
-          {\CYRR\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt\cyri}%
-        \crefname{example}%
-          {\CYRP\cyrr\cyri\cyrk\cyrl\cyra\cyrd}%
-          {\CYRP\cyrr\cyri\cyrk\cyrl\cyra\cyrd\cyri}%
-        \crefname{remark}%
-          {\CYRP\cyrr\cyri\cyrm\cyrii\cyrt\cyrk\cyra}%
-          {\CYRP\cyrr\cyri\cyrm\cyrii\cyrt\cyrk\cyri}%
-        \crefname{note}%
-          {\CYRZ\cyra\cyrm\cyrii\cyrt\cyrk\cyra}%
-          {\CYRZ\cyra\cyrm\cyrii\cyrt\cyrk\cyri}%
-        \crefname{algorithm}%
-          {\CYRA\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm}%
-          {\CYRA\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm\cyri}%
-        \crefname{listing}%
-          {\CYRL\cyrii\cyrs\cyrt\cyri\cyrn\cyrg}%
-          {\CYRL\cyrii\cyrs\cyrt\cyri\cyrn\cyrg\cyri}%
-        \crefname{line}%
-          {\CYRS\cyrt\cyrr\cyro\cyrk\cyra}%
-          {\CYRS\cyrt\cyrr\cyro\cyrk\cyri}%
-      \else%
-        \crefname{equation}{\cyrf-\cyrl.}{\cyrf-\cyrl.}%
-        \crefname{part}%
-          {\cyrch\cyra\cyrs\cyrt\cyri\cyrn\cyra}%
-          {\cyrch\cyra\cyrs\cyrt\cyri\cyrn\cyri}%
-        \crefname{chapter}%
-          {\cyrg\cyrl\cyra\cyrv.}%
-          {\cyrg\cyrl\cyra\cyrv.}%
-        \crefname{section}%
-          {\cyrr\cyro\cyrz\cyrd.}%
-          {\cyrr\cyro\cyrz\cyrd\cyrii\cyrl.}%
-        \crefname{subsection}%
-          {\cyrr\cyro\cyrz\cyrd.}%
-          {\cyrr\cyro\cyrz\cyrd\cyrii\cyrl.}%
-        \crefname{subsubsection}%
-          {\cyrr\cyro\cyrz\cyrd.}%
-          {\cyrr\cyro\cyrz\cyrd\cyrii\cyrl.}%
-        \crefname{appendix}%
-          {\cyrd\cyro\cyrd\cyra\cyrt.}%
-          {\cyrd\cyro\cyrd\cyra\cyrt\cyrk.}%
-        \crefname{subappendix}%
-          {\cyrd\cyro\cyrd\cyra\cyrt.}%
-          {\cyrd\cyro\cyrd\cyra\cyrt\cyrk.}%
-        \crefname{subsubappendix}%
-          {\cyrd\cyro\cyrd\cyra\cyrt.}%
-          {\cyrd\cyro\cyrd\cyra\cyrt\cyrk.}%
-        \crefname{subsubsubappendix}%
-          {\cyrd\cyro\cyrd\cyra\cyrt.}%
-          {\cyrd\cyro\cyrd\cyra\cyrt\cyrk.}%
-        \crefname{enumi}{\cyrp.}{\cyrp.\cyrp.}%
-        \crefname{enumii}{\cyrp.}{\cyrp.\cyrp.}%
-        \crefname{enumiii}{\cyrp.}{\cyrp.\cyrp.}%
-        \crefname{enumiv}{\cyrp.}{\cyrp.\cyrp.}%
-        \crefname{enumv}{\cyrp.}{\cyrp.\cyrp.}%
-        \crefname{footnote}%
-          {\cyrv\cyri\cyrn\cyro\cyrs\cyrk.}%
-          {\cyrv\cyri\cyrn\cyro\cyrs\cyrk.}%
-        \crefname{figure}%
-          {\cyrr\cyri\cyrs.}%
-          {\cyrr\cyri\cyrs.}%
-        \crefname{subfigure}%
-          {\cyrr\cyri\cyrs.}%
-          {\cyrr\cyri\cyrs.}%
-        \crefname{table}%
-          {\cyrt\cyra\cyrb\cyrl.}%
-          {\cyrt\cyra\cyrb\cyrl.}%
-        \crefname{subtable}%
-          {\cyrt\cyra\cyrb\cyrl.}%
-          {\cyrt\cyra\cyrb\cyrl.}%
-        \crefname{theorem}%
-          {\cyrt\cyre\cyro\cyrr\cyre\cyrm.}%
-          {\cyrt\cyre\cyro\cyrr\cyre\cyrm.}%
-        \crefname{lemma}{\cyrl\cyre\cyrm\cyrm.}{\cyrl\cyre\cyrm\cyrm.}%
-        \crefname{corollary}%
-          {\cyrv\cyri\cyrs\cyrn\cyro\cyrv.}%
-          {\cyrv\cyri\cyrs\cyrn\cyro\cyrv\cyrk.}%
-        \crefname{proposition}%
-          {\cyrt\cyrv\cyre\cyrr\cyrd\cyrzh\cyre\cyrn\cyrn.}%
-          {\cyrt\cyrv\cyre\cyrr\cyrd\cyrzh\cyre\cyrn\cyrn.}%
-        \crefname{definition}%
-          {\cyrv\cyri\cyrz\cyrn\cyra\cyrch\cyre\cyrn\cyrn.}%
-          {\cyrv\cyri\cyrz\cyrn\cyra\cyrch\cyre\cyrn\cyrn.}%
-        \crefname{result}%
-          {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt.}%
-          {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt.}%
-        \crefname{example}%
-          {\cyrp\cyrr\cyri\cyrk\cyrl.}%
-          {\cyrp\cyrr\cyri\cyrk\cyrl\cyra\cyrd.}%
-        \crefname{remark}%
-          {\cyrp\cyrr\cyri\cyrm\cyrii\cyrt.}%
-          {\cyrp\cyrr\cyri\cyrm\cyrii\cyrt.}%
-        \crefname{note}%
-          {\cyrz\cyra\cyrm\cyrii\cyrt.}%
-          {\cyrz\cyra\cyrm\cyrii\cyrt.}%
-        \crefname{algorithm}%
-          {\cyra\cyrl\cyrg.}%
-          {\cyra\cyrl\cyrg.}%
-        \crefname{listing}%
-          {\cyrl\cyrii\cyrs\cyrt\cyri\cyrn.}%
-          {\cyrl\cyrii\cyrs\cyrt\cyri\cyrn\cyrg.}%
-        \crefname{line}%
-          {\cyrs\cyrt\cyrr\cyrk.}%
-          {\cyrs\cyrt\cyrr\cyrk.}%
-      \fi%
-    }}}
+      \crefname{enumi}%
+        {\CYRP\cyru\cyrn\cyrk\cyrt}%
+        {\CYRP\cyru\cyrn\cyrk\cyrt\cyri}%
+      \crefname{enumii}%
+        {\CYRP\cyru\cyrn\cyrk\cyrt}%
+        {\CYRP\cyru\cyrn\cyrk\cyrt\cyri}%
+      \crefname{enumiii}%
+        {\CYRP\cyru\cyrn\cyrk\cyrt}%
+        {\CYRP\cyru\cyrn\cyrk\cyrt\cyri}%
+      \crefname{enumiv}%
+        {\CYRP\cyru\cyrn\cyrk\cyrt}%
+        {\CYRP\cyru\cyrn\cyrk\cyrt\cyri}%
+      \crefname{enumv}%
+        {\CYRP\cyru\cyrn\cyrk\cyrt}%
+        {\CYRP\cyru\cyrn\cyrk\cyrt\cyri}%
+    \fi%
+    \crefname{chapter}%
+      {\CYRG\cyrl\cyra\cyrv\cyra}%
+      {\CYRG\cyrl\cyra\cyrv\cyri}%
+    \crefname{section}%
+      {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl}%
+      {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl\cyri}%
+    \crefname{subsection}%
+      {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl}%
+      {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl\cyri}%
+    \crefname{subsubsection}%
+      {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl}%
+      {\CYRR\cyro\cyrz\cyrd\cyrii\cyrl\cyri}%
+    \crefname{appendix}%
+      {\CYRD\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
+      {\CYRD\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
+    \crefname{subappendix}%
+      {\CYRD\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
+      {\CYRD\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
+    \crefname{subsubappendix}%
+      {\CYRD\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
+      {\CYRD\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
+    \crefname{subsubsubappendix}%
+      {\CYRD\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
+      {\CYRD\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
+    \crefname{footnote}%
+      {\CYRV\cyri\cyrn\cyro\cyrs\cyrk\cyra}%
+      {\CYRV\cyri\cyrn\cyro\cyrs\cyrk\cyri}%
+    \crefname{theorem}%
+      {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyra}%
+      {\CYRT\cyre\cyro\cyrr\cyre\cyrm\cyri}%
+    \crefname{lemma}%
+      {\CYRL\cyre\cyrm\cyrm\cyra}%
+      {\CYRL\cyre\cyrm\cyrm\cyri}%
+    \crefname{corollary}%
+      {\CYRV\cyri\cyrs\cyrn\cyro\cyrv\cyro\cyrk}%
+      {\CYRV\cyri\cyrs\cyrn\cyro\cyrv\cyrk\cyri}%
+    \crefname{proposition}%
+      {\CYRT\cyrv\cyre\cyrr\cyrd\cyrzh\cyre\cyrn\cyrn\cyrya}%
+      {\CYRT\cyrv\cyre\cyrr\cyrd\cyrzh\cyre\cyrn\cyrn\cyrya}%
+    \crefname{definition}%
+      {\CYRV\cyri\cyrz\cyrn\cyra\cyrch\cyre\cyrn\cyrn\cyrya}%
+      {\CYRV\cyri\cyrz\cyrn\cyra\cyrch\cyre\cyrn\cyrn\cyrya}%
+    \crefname{result}%
+      {\CYRR\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt}%
+      {\CYRR\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt\cyri}%
+    \crefname{example}%
+      {\CYRP\cyrr\cyri\cyrk\cyrl\cyra\cyrd}%
+      {\CYRP\cyrr\cyri\cyrk\cyrl\cyra\cyrd\cyri}%
+    \crefname{remark}%
+      {\CYRP\cyrr\cyri\cyrm\cyrii\cyrt\cyrk\cyra}%
+      {\CYRP\cyrr\cyri\cyrm\cyrii\cyrt\cyrk\cyri}%
+    \crefname{note}%
+      {\CYRZ\cyra\cyrm\cyrii\cyrt\cyrk\cyra}%
+      {\CYRZ\cyra\cyrm\cyrii\cyrt\cyrk\cyri}%
+    \crefname{algorithm}%
+      {\CYRA\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm}%
+      {\CYRA\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm\cyri}%
+    \crefname{listing}%
+      {\CYRL\cyrii\cyrs\cyrt\cyri\cyrn\cyrg}%
+      {\CYRL\cyrii\cyrs\cyrt\cyri\cyrn\cyrg\cyri}%
+    \crefname{line}%
+      {\CYRS\cyrt\cyrr\cyro\cyrk\cyra}%
+      {\CYRS\cyrt\cyrr\cyro\cyrk\cyri}%
+    \crefname{page}%
+      {\CYRS\cyrt\cyro\cyrr\cyri\cyrn\cyrk\cyra}%
+      {\CYRS\cyrt\cyro\cyrr\cyrii\cyrn\cyrk\cyri}%
+    \crefname{part}%
+      {\CYRCH\cyra\cyrs\cyrt\cyri\cyrn\cyra}%
+      {\CYRCH\cyra\cyrs\cyrt\cyri\cyrn\cyri}%
+ %
+  \else%  capitalise unset
+    \if@cref@abbrev%  abbrev set
+      \crefname{equation}%
+        {\cyrf-\cyrl.}%
+        {\cyrf-\cyrl.}%
+      \crefname{chapter}%
+        {\cyrg\cyrl\cyra\cyrv.}%
+        {\cyrg\cyrl\cyra\cyrv.}%
+      \crefname{section}%
+        {\cyrr\cyro\cyrz\cyrd.}%
+        {\cyrr\cyro\cyrz\cyrd\cyrii\cyrl.}%
+      \crefname{subsection}%
+        {\cyrr\cyro\cyrz\cyrd.}%
+        {\cyrr\cyro\cyrz\cyrd\cyrii\cyrl.}%
+      \crefname{subsubsection}%
+        {\cyrr\cyro\cyrz\cyrd.}%
+        {\cyrr\cyro\cyrz\cyrd\cyrii\cyrl.}%
+      \crefname{appendix}%
+        {\cyrd\cyro\cyrd\cyra\cyrt.}%
+        {\cyrd\cyro\cyrd\cyra\cyrt\cyrk.}%
+      \crefname{subappendix}%
+        {\cyrd\cyro\cyrd\cyra\cyrt.}%
+        {\cyrd\cyro\cyrd\cyra\cyrt\cyrk.}%
+      \crefname{subsubappendix}%
+        {\cyrd\cyro\cyrd\cyra\cyrt.}%
+        {\cyrd\cyro\cyrd\cyra\cyrt\cyrk.}%
+      \crefname{subsubsubappendix}%
+        {\cyrd\cyro\cyrd\cyra\cyrt.}%
+        {\cyrd\cyro\cyrd\cyra\cyrt\cyrk.}%
+      \crefname{enumi}%
+        {\cyrp.}%
+        {\cyrp.\cyrp.}%
+      \crefname{enumii}%
+        {\cyrp.}%
+        {\cyrp.\cyrp.}%
+      \crefname{enumiii}%
+        {\cyrp.}%
+        {\cyrp.\cyrp.}%
+      \crefname{enumiv}%
+        {\cyrp.}%
+        {\cyrp.\cyrp.}%
+      \crefname{enumv}%
+        {\cyrp.}%
+        {\cyrp.\cyrp.}%
+      \crefname{footnote}%
+        {\cyrv\cyri\cyrn\cyro\cyrs\cyrk.}%
+        {\cyrv\cyri\cyrn\cyro\cyrs\cyrk.}%
+      \crefname{figure}%
+        {\cyrr\cyri\cyrs.}%
+        {\cyrr\cyri\cyrs.}%
+      \crefname{subfigure}%
+        {\cyrr\cyri\cyrs.}%
+        {\cyrr\cyri\cyrs.}%
+      \crefname{table}%
+        {\cyrt\cyra\cyrb\cyrl.}%
+        {\cyrt\cyra\cyrb\cyrl.}%
+      \crefname{subtable}%
+        {\cyrt\cyra\cyrb\cyrl.}%
+        {\cyrt\cyra\cyrb\cyrl.}%
+      \crefname{theorem}%
+        {\cyrt\cyre\cyro\cyrr\cyre\cyrm.}%
+        {\cyrt\cyre\cyro\cyrr\cyre\cyrm.}%
+      \crefname{lemma}%
+        {\cyrl\cyre\cyrm\cyrm.}%
+        {\cyrl\cyre\cyrm\cyrm.}%
+      \crefname{corollary}%
+        {\cyrv\cyri\cyrs\cyrn\cyro\cyrv.}%
+        {\cyrv\cyri\cyrs\cyrn\cyro\cyrv\cyrk.}%
+      \crefname{proposition}%
+        {\cyrt\cyrv\cyre\cyrr\cyrd\cyrzh\cyre\cyrn\cyrn.}%
+        {\cyrt\cyrv\cyre\cyrr\cyrd\cyrzh\cyre\cyrn\cyrn.}%
+      \crefname{definition}%
+        {\cyrv\cyri\cyrz\cyrn\cyra\cyrch\cyre\cyrn\cyrn.}%
+        {\cyrv\cyri\cyrz\cyrn\cyra\cyrch\cyre\cyrn\cyrn.}%
+      \crefname{result}%
+        {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt.}%
+        {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt.}%
+      \crefname{example}%
+        {\cyrp\cyrr\cyri\cyrk\cyrl.}%
+        {\cyrp\cyrr\cyri\cyrk\cyrl\cyra\cyrd.}%
+      \crefname{remark}%
+        {\cyrp\cyrr\cyri\cyrm\cyrii\cyrt.}%
+        {\cyrp\cyrr\cyri\cyrm\cyrii\cyrt.}%
+      \crefname{note}%
+        {\cyrz\cyra\cyrm\cyrii\cyrt.}%
+        {\cyrz\cyra\cyrm\cyrii\cyrt.}%
+      \crefname{algorithm}%
+        {\cyra\cyrl\cyrg.}%
+        {\cyra\cyrl\cyrg.}%
+      \crefname{listing}%
+        {\cyrl\cyrii\cyrs\cyrt\cyri\cyrn.}%
+        {\cyrl\cyrii\cyrs\cyrt\cyri\cyrn\cyrg.}%
+      \crefname{line}%
+        {\cyrs\cyrt\cyrr\cyrk.}%
+        {\cyrs\cyrt\cyrr\cyrk.}%
+    \else%  abbrev unset
+      \crefname{equation}%
+        {\cyrf\cyro\cyrr\cyrm\cyru\cyrl\cyra}%
+        {\cyrf\cyro\cyrr\cyrm\cyru\cyrl\cyri}%
+      \crefname{figure}%
+        {\cyrr\cyri\cyrs\cyru\cyrn\cyro\cyrk}%
+        {\cyrr\cyri\cyrs\cyru\cyrn\cyrk\cyri}%
+      \crefname{subfigure}%
+        {\cyrr\cyri\cyrs\cyru\cyrn\cyro\cyrk}%
+        {\cyrr\cyri\cyrs\cyru\cyrn\cyrk\cyri}%
+      \crefname{table}%
+        {\cyrt\cyra\cyrb\cyrl\cyri\cyrc\cyrya}%
+        {\cyrt\cyra\cyrb\cyrl\cyri\cyrc\cyrii}%
+      \crefname{subtable}%
+        {\cyrt\cyra\cyrb\cyrl\cyri\cyrc\cyrya}%
+        {\cyrt\cyra\cyrb\cyrl\cyri\cyrc\cyrii}%
+      \crefname{enumi}%
+        {\cyrp\cyru\cyrn\cyrk\cyrt}%
+        {\cyrp\cyru\cyrn\cyrk\cyrt\cyri}%
+      \crefname{enumii}%
+        {\cyrp\cyru\cyrn\cyrk\cyrt}%
+        {\cyrp\cyru\cyrn\cyrk\cyrt\cyri}%
+      \crefname{enumiii}%
+        {\cyrp\cyru\cyrn\cyrk\cyrt}%
+        {\cyrp\cyru\cyrn\cyrk\cyrt\cyri}%
+      \crefname{enumiv}%
+        {\cyrp\cyru\cyrn\cyrk\cyrt}%
+        {\cyrp\cyru\cyrn\cyrk\cyrt\cyri}%
+      \crefname{enumv}%
+        {\cyrp\cyru\cyrn\cyrk\cyrt}%
+        {\cyrp\cyru\cyrn\cyrk\cyrt\cyri}%
+      \crefname{chapter}%
+        {\cyrg\cyrl\cyra\cyrv\cyra}%
+        {\cyrg\cyrl\cyra\cyrv\cyri}%
+      \crefname{section}%
+        {\cyrr\cyro\cyrz\cyrd\cyrii\cyrl}%
+        {\cyrr\cyro\cyrz\cyrd\cyrii\cyrl\cyri}%
+      \crefname{subsection}%
+        {\cyrr\cyro\cyrz\cyrd\cyrii\cyrl}%
+        {\cyrr\cyro\cyrz\cyrd\cyrii\cyrl\cyri}%
+      \crefname{subsubsection}%
+        {\cyrr\cyro\cyrz\cyrd\cyrii\cyrl}%
+        {\cyrr\cyro\cyrz\cyrd\cyrii\cyrl\cyri}%
+      \crefname{appendix}%
+        {\cyrd\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
+        {\cyrd\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
+      \crefname{subappendix}%
+        {\cyrd\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
+        {\cyrd\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
+      \crefname{subsubappendix}%
+        {\cyrd\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
+        {\cyrd\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
+      \crefname{subsubsubappendix}%
+        {\cyrd\cyro\cyrd\cyra\cyrt\cyro\cyrk}%
+        {\cyrd\cyro\cyrd\cyra\cyrt\cyrk\cyri}%
+      \crefname{footnote}%
+        {\cyrv\cyri\cyrn\cyro\cyrs\cyrk\cyra}%
+        {\cyrv\cyri\cyrn\cyro\cyrs\cyrk\cyri}%
+      \crefname{theorem}%
+        {\cyrt\cyre\cyro\cyrr\cyre\cyrm\cyra}%
+        {\cyrt\cyre\cyro\cyrr\cyre\cyrm\cyri}%
+      \crefname{lemma}%
+        {\cyrl\cyre\cyrm\cyrm\cyra}%
+        {\cyrl\cyre\cyrm\cyrm\cyri}%
+      \crefname{corollary}%
+        {\cyrv\cyri\cyrs\cyrn\cyro\cyrv\cyro\cyrk}%
+        {\cyrv\cyri\cyrs\cyrn\cyro\cyrv\cyrk\cyri}%
+      \crefname{proposition}%
+        {\cyrt\cyrv\cyre\cyrr\cyrd\cyrzh\cyre\cyrn\cyrn\cyrya}%
+        {\cyrt\cyrv\cyre\cyrr\cyrd\cyrzh\cyre\cyrn\cyrn\cyrya}%
+      \crefname{definition}%
+        {\cyrv\cyri\cyrz\cyrn\cyra\cyrch\cyre\cyrn\cyrn\cyrya}%
+        {\cyrv\cyri\cyrz\cyrn\cyra\cyrch\cyre\cyrn\cyrn\cyrya}%
+      \crefname{result}%
+        {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt}%
+        {\cyrr\cyre\cyrz\cyru\cyrl\cyrsftsn\cyrt\cyra\cyrt\cyri}%
+      \crefname{example}%
+        {\cyrp\cyrr\cyri\cyrk\cyrl\cyra\cyrd}%
+        {\cyrp\cyrr\cyri\cyrk\cyrl\cyra\cyrd\cyri}%
+      \crefname{remark}%
+        {\cyrp\cyrr\cyri\cyrm\cyrii\cyrt\cyrk\cyra}%
+        {\cyrp\cyrr\cyri\cyrm\cyrii\cyrt\cyrk\cyri}%
+      \crefname{note}%
+        {\cyrz\cyra\cyrm\cyrii\cyrt\cyrk\cyra}%
+        {\cyrz\cyra\cyrm\cyrii\cyrt\cyrk\cyri}%
+      \crefname{algorithm}%
+        {\cyra\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm}%
+        {\cyra\cyrl\cyrg\cyro\cyrr\cyri\cyrt\cyrm\cyri}%
+      \crefname{listing}%
+        {\cyrl\cyrii\cyrs\cyrt\cyri\cyrn\cyrg}%
+        {\cyrl\cyrii\cyrs\cyrt\cyri\cyrn\cyrg\cyri}%
+      \crefname{line}%
+        {\cyrs\cyrt\cyrr\cyro\cyrk\cyra}%
+        {\cyrs\cyrt\cyrr\cyro\cyrk\cyri}%
+    \fi%
+    \crefname{page}%
+      {\cyrs\cyrt\cyro\cyrr\cyri\cyrn\cyrc\cyrii}%
+      {\cyrs\cyrt\cyro\cyrr\cyrii\cyrn\cyrk\cyra\cyrh}%
+    \crefname{part}%
+      {\cyrch\cyra\cyrs\cyrt\cyri\cyrn\cyra}%
+      {\cyrch\cyra\cyrs\cyrt\cyri\cyrn\cyri}%
+  \fi}% end \cref@loadlanguagedefs
 \DeclareOption{norsk}{%
-  \PackageInfo{cleveref}{loaded norsk language definitions}
   \AtBeginDocument{%
     \def\crefrangeconjunction@preamble{ til\nobreakspace}%
     \def\crefrangepreconjunction@preamble{}%
@@ -5157,15 +6469,17 @@
     \def\crefpairgroupconjunction@preamble{ og\nobreakspace}%
     \def\crefmiddlegroupconjunction@preamble{, }%
     \def\creflastgroupconjunction@preamble{ og\nobreakspace}%
+ %
     \Crefname@preamble{equation}{Likning}{Likningene}%
+    \Crefname@preamble{figure}{Figur}{Figurene}%
+    \Crefname@preamble{table}{Tabell}{Tabellene}%
+    \Crefname@preamble{page}{Side}{Siden}%
     \Crefname@preamble{part}{Del}{Delene}%
     \Crefname@preamble{chapter}{Kapittel}{Kapitlene}%
     \Crefname@preamble{section}{Avsnitt}{Avsnittene}%
     \Crefname@preamble{appendix}{Tillegg}{Tilleggene}%
     \Crefname@preamble{enumi}{Punkt}{Punktene}%
     \Crefname@preamble{footnote}{Fotnote}{Fotnotene}%
-    \Crefname@preamble{figure}{Figur}{Figurene}%
-    \Crefname@preamble{table}{Tabell}{Tabellene}%
     \Crefname@preamble{theorem}{Teorem}{Teoremene}%
     \Crefname@preamble{lemma}{Lemma}{Lemma}%
     \Crefname@preamble{corollary}{Korollar}{Korollarene}%
@@ -5178,16 +6492,18 @@
     \Crefname@preamble{algorithm}{Algoritme}{Algoritmene}%
     \Crefname@preamble{listing}{Opplisting}{Opplistingene}%
     \Crefname@preamble{line}{Linje}{Linjene}%
+ %
     \if@cref@capitalise%
+      \crefname@preamble{page}{Side}{Siden}%
       \crefname@preamble{equation}{Likning}{Likningene}%
+      \crefname@preamble{figure}{Figur}{Figurene}%
+      \crefname@preamble{table}{Tabell}{Tabellene}%
       \crefname@preamble{part}{Del}{Delene}%
       \crefname@preamble{chapter}{Kapittel}{Kapitlene}%
       \crefname@preamble{section}{Avsnitt}{Avsnittene}%
       \crefname@preamble{appendix}{Tillegg}{Tilleggene}%
       \crefname@preamble{enumi}{Punkt}{Punktene}%
       \crefname@preamble{footnote}{Fotnote}{Fotnotene}%
-      \crefname@preamble{figure}{Figur}{Figurene}%
-      \crefname@preamble{table}{Tabell}{Tabellene}%
       \crefname@preamble{theorem}{Teorem}{Teoremene}%
       \crefname@preamble{lemma}{Lemma}{Lemma}%
       \crefname@preamble{corollary}{Korollar}{Korollarene}%
@@ -5200,16 +6516,18 @@
       \crefname@preamble{algorithm}{Algoritme}{Algoritmene}%
       \crefname@preamble{listing}{Opplisting}{Opplistingene}%
       \crefname@preamble{line}{Linje}{Linjene}%
+ %
     \else%
       \crefname@preamble{equation}{likning}{likningene}%
+      \crefname@preamble{figure}{figur}{figurene}%
+      \crefname@preamble{table}{tabell}{tabeller}%
+      \crefname@preamble{page}{side}{siden}%
       \crefname@preamble{part}{del}{delene}%
       \crefname@preamble{chapter}{kapittel}{kapitlene}%
       \crefname@preamble{section}{avsnitt}{avsnittene}%
       \crefname@preamble{appendix}{tillegg}{tilleggene}%
       \crefname@preamble{enumi}{punkt}{punktene}%
       \crefname@preamble{footnote}{fotnote}{fotnotene}%
-      \crefname@preamble{figure}{figur}{figurene}%
-      \crefname@preamble{table}{tabell}{tabeller}%
       \crefname@preamble{theorem}{teorem}{teoremene}%
       \crefname@preamble{lemma}{lemma}{lemma}%
       \crefname@preamble{corollary}{korollar}{korollarene}%
@@ -5224,118 +6542,124 @@
       \crefname@preamble{line}{linje}{linjene}%
     \fi%
     \def\cref@language{norsk}%
-    \cref@addto\extrasnorsk{%
-      \renewcommand{\crefrangeconjunction}{ til\nobreakspace}%
-      \renewcommand\crefrangepreconjunction{}%
-      \renewcommand\crefrangepostconjunction{}%
-      \renewcommand{\crefpairconjunction}{ og\nobreakspace}%
-      \renewcommand{\crefmiddleconjunction}{, }%
-      \renewcommand{\creflastconjunction}{ og\nobreakspace}%
-      \renewcommand{\crefpairgroupconjunction}{ og\nobreakspace}%
-      \renewcommand{\crefmiddlegroupconjunction}{, }%
-      \renewcommand{\creflastgroupconjunction}{ og\nobreakspace}%
-      \Crefname{equation}{Likning}{Likningene}%
-      \Crefname{part}{Del}{Delene}%
-      \Crefname{chapter}{Kapittel}{Kapitlene}%
-      \Crefname{section}{Avsnitt}{Avsnittene}%
-      \Crefname{subsection}{Avsnitt}{Avsnittene}%
-      \Crefname{subsubsection}{Avsnitt}{Avsnittene}%
-      \Crefname{appendix}{Tillegg}{Tilleggene}%
-      \Crefname{subappendix}{Tillegg}{Tilleggene}%
-      \Crefname{subsubappendix}{Tillegg}{Tilleggene}%
-      \Crefname{subsubsubappendix}{Tillegg}{Tilleggene}%
-      \Crefname{enumi}{Punkt}{Punktene}%
-      \Crefname{enumii}{Punkt}{Punktene}%
-      \Crefname{enumiii}{Punkt}{Punktene}%
-      \Crefname{enumiv}{Punkt}{Punktene}%
-      \Crefname{enumv}{Punkt}{Punktene}%
-      \Crefname{footnote}{Fotnote}{Fotnotene}%
-      \Crefname{figure}{Figur}{Figurene}%
-      \Crefname{subfigure}{Figur}{Figurene}%
-      \Crefname{table}{Tabell}{Tabellene}%
-      \Crefname{subtable}{Tabell}{Tabellene}%
-      \Crefname{theorem}{Teorem}{Teoremene}%
-      \Crefname{lemma}{Lemma}{Lemma}%
-      \Crefname{corollary}{Korollar}{Korollarene}%
-      \Crefname{proposition}{P\aa stand}{P\aa standene}%
-      \Crefname{definition}{Definisjon}{Definisjonene}%
-      \Crefname{result}{Resultat}{Resultatene}%
-      \Crefname{example}{Eksempel}{Eksemplene}%
-      \Crefname{remark}{Bemerkning}{Bemerkningene}%
-      \Crefname{note}{Note}{Notene}%
-      \Crefname{algorithm}{Algoritme}{Algoritmene}%
-      \Crefname{listing}{Opplisting}{Opplistingene}%
-      \Crefname{line}{Linje}{Linjene}%
-      \if@cref@capitalise%
-        \crefname{equation}{Likning}{Likningene}%
-        \crefname{part}{Del}{Delene}%
-        \crefname{chapter}{Kapittel}{Kapitlene}%
-        \crefname{section}{Avsnitt}{Avsnittene}%
-        \crefname{subsection}{Avsnitt}{Avsnittene}%
-        \crefname{subsubsection}{Avsnitt}{Avsnittene}%
-        \crefname{appendix}{Tillegg}{Tilleggene}%
-        \crefname{subappendix}{Tillegg}{Tilleggene}%
-        \crefname{subsubappendix}{Tillegg}{Tilleggene}%
-        \crefname{subsubsubappendix}{Tillegg}{Tilleggene}%
-        \crefname{enumi}{Punkt}{Punktene}%
-        \crefname{enumii}{Punkt}{Punktene}%
-        \crefname{enumiii}{Punkt}{Punktene}%
-        \crefname{enumiv}{Punkt}{Punktene}%
-        \crefname{enumv}{Punkt}{Punktene}%
-        \crefname{footnote}{Fotnote}{Fotnotene}%
-        \crefname{figure}{Figur}{Figurene}%
-        \crefname{subfigure}{Figur}{Figurene}%
-        \crefname{table}{Tabell}{Tabellene}%
-        \crefname{subtable}{Tabell}{Tabellene}%
-        \crefname{theorem}{Teorem}{Teoremene}%
-        \crefname{lemma}{Lemma}{Lemma}%
-        \crefname{corollary}{Korollar}{Korollarene}%
-        \crefname{proposition}{P\aa stand}{P\aa standene}%
-        \crefname{definition}{Definisjon}{Definisjonene}%
-        \crefname{result}{Resultat}{Resultatene}%
-        \crefname{example}{Eksempel}{Eksemplene}%
-        \crefname{remark}{Bemerkning}{Bemerkningene}%
-        \crefname{note}{Note}{Notene}%
-        \crefname{algorithm}{Algoritme}{Algoritmene}%
-        \crefname{listing}{Opplisting}{Opplistingene}%
-        \crefname{line}{Linje}{Linjene}%
-      \else%
-        \crefname{equation}{likning}{likningene}%
-        \crefname{part}{del}{delene}%
-        \crefname{chapter}{kapittel}{kapitlene}%
-        \crefname{section}{avsnitt}{avsnittene}%
-        \crefname{subsection}{avsnitt}{avsnittene}%
-        \crefname{subsubsection}{avsnitt}{avsnittene}%
-        \crefname{appendix}{tillegg}{tilleggene}%
-        \crefname{subappendix}{tillegg}{tilleggene}%
-        \crefname{subsubappendix}{tillegg}{tilleggene}%
-        \crefname{subsubsubappendix}{tillegg}{tilleggene}%
-        \crefname{enumi}{punkt}{punktene}%
-        \crefname{enumii}{punkt}{punktene}%
-        \crefname{enumiii}{punkt}{punktene}%
-        \crefname{enumiv}{punkt}{punktene}%
-        \crefname{enumv}{punkt}{punktene}%
-        \crefname{footnote}{fotnote}{fotnotene}%
-        \crefname{figure}{figur}{figurene}%
-        \crefname{subfigure}{figur}{figurene}%
-        \crefname{table}{tabell}{tabellene}%
-        \crefname{subtable}{tabell}{tabellene}%
-        \crefname{theorem}{teorem}{teoremene}%
-        \crefname{lemma}{lemma}{lemma}%
-        \crefname{corollary}{korollar}{korollarene}%
-        \crefname{proposition}{p\aa stand}{p\aa standene}%
-        \crefname{definition}{definisjon}{definisjonene}%
-        \crefname{result}{resultat}{resultatene}%
-        \crefname{example}{eksempel}{eksemplene}%
-        \crefname{remark}{bemerkning}{bemerkningene}%
-        \crefname{note}{note}{notene}%
-        \crefname{algorithm}{algoritme}{algoritmene}%
-        \crefname{listing}{opplisting}{opplistingene}%
-        \crefname{line}{linje}{linjene}%
-      \fi%
-    }}}
+  }}% end \DeclareOption and \AtBeginDocument
+\cref@addlanguagedefs{norsk}{%
+  \PackageInfo{cleveref}{loaded `norsk' language definitions}%
+  \renewcommand{\crefrangeconjunction}{ til\nobreakspace}%
+  \renewcommand\crefrangepreconjunction{}%
+  \renewcommand\crefrangepostconjunction{}%
+  \renewcommand{\crefpairconjunction}{ og\nobreakspace}%
+  \renewcommand{\crefmiddleconjunction}{, }%
+  \renewcommand{\creflastconjunction}{ og\nobreakspace}%
+  \renewcommand{\crefpairgroupconjunction}{ og\nobreakspace}%
+  \renewcommand{\crefmiddlegroupconjunction}{, }%
+  \renewcommand{\creflastgroupconjunction}{ og\nobreakspace}%
+ %
+  \Crefname{equation}{Likning}{Likningene}%
+  \Crefname{figure}{Figur}{Figurene}%
+  \Crefname{subfigure}{Figur}{Figurene}%
+  \Crefname{table}{Tabell}{Tabellene}%
+  \Crefname{subtable}{Tabell}{Tabellene}%
+  \Crefname{page}{Side}{Siden}%
+  \Crefname{part}{Del}{Delene}%
+  \Crefname{chapter}{Kapittel}{Kapitlene}%
+  \Crefname{section}{Avsnitt}{Avsnittene}%
+  \Crefname{subsection}{Avsnitt}{Avsnittene}%
+  \Crefname{subsubsection}{Avsnitt}{Avsnittene}%
+  \Crefname{appendix}{Tillegg}{Tilleggene}%
+  \Crefname{subappendix}{Tillegg}{Tilleggene}%
+  \Crefname{subsubappendix}{Tillegg}{Tilleggene}%
+  \Crefname{subsubsubappendix}{Tillegg}{Tilleggene}%
+  \Crefname{enumi}{Punkt}{Punktene}%
+  \Crefname{enumii}{Punkt}{Punktene}%
+  \Crefname{enumiii}{Punkt}{Punktene}%
+  \Crefname{enumiv}{Punkt}{Punktene}%
+  \Crefname{enumv}{Punkt}{Punktene}%
+  \Crefname{footnote}{Fotnote}{Fotnotene}%
+  \Crefname{theorem}{Teorem}{Teoremene}%
+  \Crefname{lemma}{Lemma}{Lemma}%
+  \Crefname{corollary}{Korollar}{Korollarene}%
+  \Crefname{proposition}{P\aa stand}{P\aa standene}%
+  \Crefname{definition}{Definisjon}{Definisjonene}%
+  \Crefname{result}{Resultat}{Resultatene}%
+  \Crefname{example}{Eksempel}{Eksemplene}%
+  \Crefname{remark}{Bemerkning}{Bemerkningene}%
+  \Crefname{note}{Note}{Notene}%
+  \Crefname{algorithm}{Algoritme}{Algoritmene}%
+  \Crefname{listing}{Opplisting}{Opplistingene}%
+  \Crefname{line}{Linje}{Linjene}%
+ %
+  \if@cref@capitalise%
+    \crefname{equation}{Likning}{Likningene}%
+    \crefname{figure}{Figur}{Figurene}%
+    \crefname{subfigure}{Figur}{Figurene}%
+    \crefname{table}{Tabell}{Tabellene}%
+    \crefname{subtable}{Tabell}{Tabellene}%
+    \crefname{page}{Side}{Siden}%
+    \crefname{part}{Del}{Delene}%
+    \crefname{chapter}{Kapittel}{Kapitlene}%
+    \crefname{section}{Avsnitt}{Avsnittene}%
+    \crefname{subsection}{Avsnitt}{Avsnittene}%
+    \crefname{subsubsection}{Avsnitt}{Avsnittene}%
+    \crefname{appendix}{Tillegg}{Tilleggene}%
+    \crefname{subappendix}{Tillegg}{Tilleggene}%
+    \crefname{subsubappendix}{Tillegg}{Tilleggene}%
+    \crefname{subsubsubappendix}{Tillegg}{Tilleggene}%
+    \crefname{enumi}{Punkt}{Punktene}%
+    \crefname{enumii}{Punkt}{Punktene}%
+    \crefname{enumiii}{Punkt}{Punktene}%
+    \crefname{enumiv}{Punkt}{Punktene}%
+    \crefname{enumv}{Punkt}{Punktene}%
+    \crefname{footnote}{Fotnote}{Fotnotene}%
+    \crefname{theorem}{Teorem}{Teoremene}%
+    \crefname{lemma}{Lemma}{Lemma}%
+    \crefname{corollary}{Korollar}{Korollarene}%
+    \crefname{proposition}{P\aa stand}{P\aa standene}%
+    \crefname{definition}{Definisjon}{Definisjonene}%
+    \crefname{result}{Resultat}{Resultatene}%
+    \crefname{example}{Eksempel}{Eksemplene}%
+    \crefname{remark}{Bemerkning}{Bemerkningene}%
+    \crefname{note}{Note}{Notene}%
+    \crefname{algorithm}{Algoritme}{Algoritmene}%
+    \crefname{listing}{Opplisting}{Opplistingene}%
+    \crefname{line}{Linje}{Linjene}%
+ %
+  \else%
+    \crefname{equation}{likning}{likningene}%
+    \crefname{figure}{figur}{figurene}%
+    \crefname{subfigure}{figur}{figurene}%
+    \crefname{table}{tabell}{tabellene}%
+    \crefname{subtable}{tabell}{tabellene}%
+    \crefname{page}{side}{siden}%
+    \crefname{part}{del}{delene}%
+    \crefname{chapter}{kapittel}{kapitlene}%
+    \crefname{section}{avsnitt}{avsnittene}%
+    \crefname{subsection}{avsnitt}{avsnittene}%
+    \crefname{subsubsection}{avsnitt}{avsnittene}%
+    \crefname{appendix}{tillegg}{tilleggene}%
+    \crefname{subappendix}{tillegg}{tilleggene}%
+    \crefname{subsubappendix}{tillegg}{tilleggene}%
+    \crefname{subsubsubappendix}{tillegg}{tilleggene}%
+    \crefname{enumi}{punkt}{punktene}%
+    \crefname{enumii}{punkt}{punktene}%
+    \crefname{enumiii}{punkt}{punktene}%
+    \crefname{enumiv}{punkt}{punktene}%
+    \crefname{enumv}{punkt}{punktene}%
+    \crefname{footnote}{fotnote}{fotnotene}%
+    \crefname{theorem}{teorem}{teoremene}%
+    \crefname{lemma}{lemma}{lemma}%
+    \crefname{corollary}{korollar}{korollarene}%
+    \crefname{proposition}{p\aa stand}{p\aa standene}%
+    \crefname{definition}{definisjon}{definisjonene}%
+    \crefname{result}{resultat}{resultatene}%
+    \crefname{example}{eksempel}{eksemplene}%
+    \crefname{remark}{bemerkning}{bemerkningene}%
+    \crefname{note}{note}{notene}%
+    \crefname{algorithm}{algoritme}{algoritmene}%
+    \crefname{listing}{opplisting}{opplistingene}%
+    \crefname{line}{linje}{linjene}%
+  \fi}% end \cref@loadlanguagedefs
 \DeclareOption{danish}{%
-  \PackageInfo{cleveref}{loaded danish language definitions}
   \AtBeginDocument{%
     \def\crefrangeconjunction@preamble{ til\nobreakspace}%
     \def\crefrangepreconjunction@preamble{}%
@@ -5346,15 +6670,17 @@
     \def\crefpairgroupconjunction@preamble{ og\nobreakspace}%
     \def\crefmiddlegroupconjunction@preamble{, }%
     \def\creflastgroupconjunction@preamble{ og\nobreakspace}%
+ %
     \Crefname@preamble{equation}{Ligning}{Ligninger}%
+    \Crefname@preamble{figure}{Figur}{Figurer}%
+    \Crefname@preamble{table}{Tabel}{Tabeller}%
+    \Crefname@preamble{page}{Side}{Sider}%
     \Crefname@preamble{part}{Del}{Dele}%
     \Crefname@preamble{chapter}{Kapitel}{Kapitler}%
     \Crefname@preamble{section}{Afsnit}{Afsnit}%
     \Crefname@preamble{appendix}{Appendiks}{Appendiks}%
     \Crefname@preamble{enumi}{Punkt}{Punkter}%
     \Crefname@preamble{footnote}{Fodnote}{Fodnoter}%
-    \Crefname@preamble{figure}{Figur}{Figurer}%
-    \Crefname@preamble{table}{Tabel}{Tabeller}%
     \Crefname@preamble{theorem}{Teorem}{Teoremer}%
     \Crefname@preamble{lemma}{Lemma}{Lemma}%
     \Crefname@preamble{corollary}{F\o lgeslutning}{F\o lgeslutninger}%
@@ -5366,16 +6692,18 @@
     \Crefname@preamble{note}{Note}{Noter}%
     \Crefname@preamble{algorithm}{Algoritme}{Algoritmer}%
     \Crefname@preamble{line}{Linje}{Linjer}%
+ %
     \if@cref@capitalise%
       \crefname@preamble{equation}{Ligning}{Ligninger}%
+      \crefname@preamble{figure}{Figur}{Figurer}%
+      \crefname@preamble{table}{Tabel}{Tabeller}%
+      \crefname@preamble{page}{Side}{Sider}%
       \crefname@preamble{part}{Del}{Dele}%
       \crefname@preamble{chapter}{Kapitel}{Kapitler}%
       \crefname@preamble{section}{Afsnit}{Afsnit}%
       \crefname@preamble{appendix}{Appendiks}{Appendiks}%
       \crefname@preamble{enumi}{Punkt}{Punkter}%
       \crefname@preamble{footnote}{Fodnote}{Fodnoter}%
-      \crefname@preamble{figure}{Figur}{Figurer}%
-      \crefname@preamble{table}{Tabel}{Tabeller}%
       \crefname@preamble{theorem}{Teorem}{Teoremer}%
       \crefname@preamble{lemma}{Lemma}{Lemma}%
       \crefname@preamble{corollary}{F\o lgeslutning}{F\o lgeslutninger}%
@@ -5387,16 +6715,18 @@
       \crefname@preamble{note}{Note}{Noter}%
       \crefname@preamble{algorithm}{Algoritme}{Algoritmer}%
       \crefname@preamble{line}{Linje}{Linjer}%
+ %
     \else%
       \crefname@preamble{equation}{ligning}{ligninger}%
+      \crefname@preamble{figure}{figur}{figurer}%
+      \crefname@preamble{table}{tabel}{tabeller}%
+      \crefname@preamble{page}{side}{sider}%
       \crefname@preamble{part}{del}{dele}%
       \crefname@preamble{chapter}{kapitel}{kapitler}%
       \crefname@preamble{section}{afsnit}{afsnit}%
       \crefname@preamble{appendix}{appendiks}{appendiks}%
       \crefname@preamble{enumi}{punkt}{punkter}%
       \crefname@preamble{footnote}{fodnote}{fodnoter}%
-      \crefname@preamble{figure}{figur}{figurer}%
-      \crefname@preamble{table}{tabel}{tabeller}%
       \crefname@preamble{theorem}{teorem}{teoremer}%
       \crefname@preamble{lemma}{lemma}{lemma}%
       \crefname@preamble{corollary}{f\o lgeslutning}{f\o lgeslutninger}%
@@ -5410,80 +6740,724 @@
       \crefname@preamble{line}{linje}{linjer}%
     \fi%
     \def\cref@language{danish}%
-    \cref@addto\extrasdanish{%
-    \renewcommand{\crefrangeconjunction@preamble}{ til\nobreakspace}%
-    \renewcommand\crefrangepreconjunction@preamble{}%
-    \renewcommand\crefrangepostconjunction@preamble{}%
-    \renewcommand{\crefpairconjunction@preamble}{ og\nobreakspace}%
-    \renewcommand{\crefmiddleconjunction@preamble}{, }%
-    \renewcommand{\creflastconjunction@preamble}{ og\nobreakspace}%
-    \renewcommand{\crefpairgroupconjunction@preamble}{ og\nobreakspace}%
-    \renewcommand{\crefmiddlegroupconjunction@preamble}{, }%
-    \renewcommand{\creflastgroupconjunction@preamble}{ og\nobreakspace}%
-    \Crefname@preamble{equation}{Ligning}{Ligninger}%
-    \Crefname@preamble{part}{Del}{Dele}%
-    \Crefname@preamble{chapter}{Kapitel}{Kapitler}%
-    \Crefname@preamble{section}{Afsnit}{Afsnit}%
-    \Crefname@preamble{appendix}{Appendiks}{Appendiks}%
-    \Crefname@preamble{enumi}{Punkt}{Punkter}%
-    \Crefname@preamble{footnote}{Fodnote}{Fodnoter}%
-    \Crefname@preamble{figure}{Figur}{Figurer}%
-    \Crefname@preamble{table}{Tabel}{Tabeller}%
-    \Crefname@preamble{theorem}{Teorem}{Teoremer}%
-    \Crefname@preamble{lemma}{Lemma}{Lemma}%
-    \Crefname@preamble{corollary}{F\o lgeslutning}{F\o lgeslutninger}%
-    \Crefname@preamble{proposition}{Udsagn}{Udsagn}%
-    \Crefname@preamble{definition}{Definition}{Definitioner}%
-    \Crefname@preamble{result}{Resultat}{Resultater}%
-    \Crefname@preamble{example}{Eksempel}{Eksempler}%
-    \Crefname@preamble{remark}{Bem\ae rkning}{Bem\ae rkninger}%
-    \Crefname@preamble{note}{Note}{Noter}%
-    \Crefname@preamble{algorithm}{Algoritme}{Algoritmer}%
-    \Crefname@preamble{line}{Linje}{Linjer}%
+  }}% end \DeclareOption and \AtBeginDocument
+\cref@addlanguagedefs{danish}{%
+  \PackageInfo{cleveref}{loaded `danish' language definitions}%
+  \renewcommand{\crefrangeconjunction@preamble}{ til\nobreakspace}%
+  \renewcommand\crefrangepreconjunction@preamble{}%
+  \renewcommand\crefrangepostconjunction@preamble{}%
+  \renewcommand{\crefpairconjunction@preamble}{ og\nobreakspace}%
+  \renewcommand{\crefmiddleconjunction@preamble}{, }%
+  \renewcommand{\creflastconjunction@preamble}{ og\nobreakspace}%
+  \renewcommand{\crefpairgroupconjunction@preamble}{ og\nobreakspace}%
+  \renewcommand{\crefmiddlegroupconjunction@preamble}{, }%
+  \renewcommand{\creflastgroupconjunction@preamble}{ og\nobreakspace}%
+ %
+  \Crefname{equation}{Ligning}{Ligninger}%
+  \Crefname{figure}{Figur}{Figurer}%
+  \Crefname{subfigure}{Figur}{Figurer}%
+  \Crefname{table}{Tabel}{Tabeller}%
+  \Crefname{subtable}{Tabel}{Tabeller}%
+  \Crefname{page}{Side}{Sider}%
+  \Crefname{part}{Del}{Dele}%
+  \Crefname{chapter}{Kapitel}{Kapitler}%
+  \Crefname{section}{Afsnit}{Afsnit}%
+  \Crefname{subsection}{Afsnit}{Afsnit}%
+  \Crefname{subsubsection}{Afsnit}{Afsnit}%
+  \Crefname{appendix}{Appendiks}{Appendiks}%
+  \Crefname{subappendix}{Appendiks}{Appendiks}%
+  \Crefname{subsubappendix}{Appendiks}{Appendiks}%
+  \Crefname{subsubsubappendix}{Appendiks}{Appendiks}%
+  \Crefname{enumi}{Punkt}{Punkter}%
+  \Crefname{enumii}{Punkt}{Punkter}%
+  \Crefname{enumiii}{Punkt}{Punkter}%
+  \Crefname{enumiv}{Punkt}{Punkter}%
+  \Crefname{enumv}{Punkt}{Punkter}%
+  \Crefname{footnote}{Fodnote}{Fodnoter}%
+  \Crefname{theorem}{Teorem}{Teoremer}%
+  \Crefname{lemma}{Lemma}{Lemma}%
+  \Crefname{corollary}{F\o lgeslutning}{F\o lgeslutninger}%
+  \Crefname{proposition}{Udsagn}{Udsagn}%
+  \Crefname{definition}{Definition}{Definitioner}%
+  \Crefname{result}{Resultat}{Resultater}%
+  \Crefname{example}{Eksempel}{Eksempler}%
+  \Crefname{remark}{Bem\ae rkning}{Bem\ae rkninger}%
+  \Crefname{note}{Note}{Noter}%
+  \Crefname{algorithm}{Algoritme}{Algoritmer}%
+  \Crefname{line}{Linje}{Linjer}%
+ %
+  \if@cref@capitalise%
+    \crefname{equation}{Ligning}{Ligninger}%
+    \crefname{figure}{Figur}{Figurer}%
+    \crefname{subfigure}{Figur}{Figurer}%
+    \crefname{table}{Tabel}{Tabeller}%
+    \crefname{subtable}{Tabel}{Tabeller}%
+    \crefname{page}{Side}{Sider}%
+    \crefname{part}{Del}{Dele}%
+    \crefname{chapter}{Kapitel}{Kapitler}%
+    \crefname{section}{Afsnit}{Afsnit}%
+    \crefname{subsection}{Afsnit}{Afsnit}%
+    \crefname{subsubsection}{Afsnit}{Afsnit}%
+    \crefname{appendix}{Appendiks}{Appendiks}%
+    \crefname{subappendix}{Appendiks}{Appendiks}%
+    \crefname{subsubappendix}{Appendiks}{Appendiks}%
+    \crefname{subsubsubappendix}{Appendiks}{Appendiks}%
+    \crefname{enumi}{Punkt}{Punkter}%
+    \crefname{enumii}{Punkt}{Punkter}%
+    \crefname{enumiii}{Punkt}{Punkter}%
+    \crefname{enumiv}{Punkt}{Punkter}%
+    \crefname{enumv}{Punkt}{Punkter}%
+    \crefname{footnote}{Fodnote}{Fodnoter}%
+    \crefname{theorem}{Teorem}{Teoremer}%
+    \crefname{lemma}{Lemma}{Lemma}%
+    \crefname{corollary}{F\o lgeslutning}{F\o lgeslutninger}%
+    \crefname{proposition}{Udsagn}{Udsagn}%
+    \crefname{definition}{Definition}{Definitioner}%
+    \crefname{result}{Resultat}{Resultater}%
+    \crefname{example}{Eksempel}{Eksempler}%
+    \crefname{remark}{Bem\ae rkning}{Bem\ae rkninger}%
+    \crefname{note}{Note}{Noter}%
+    \crefname{algorithm}{Algoritme}{Algoritmer}%
+    \crefname{line}{Linje}{Linjer}%
+ %
+  \else%
+    \crefname{equation}{ligning}{ligninger}%
+    \crefname{figure}{figur}{figurer}%
+    \crefname{subfigure}{figur}{figurer}%
+    \crefname{table}{tabel}{tabeller}%
+    \crefname{subtable}{tabel}{tabeller}%
+    \crefname{page}{side}{sider}%
+    \crefname{part}{del}{dele}%
+    \crefname{chapter}{kapitel}{kapitler}%
+    \crefname{section}{afsnit}{afsnit}%
+    \crefname{subsection}{afsnit}{afsnit}%
+    \crefname{subsubsection}{afsnit}{afsnit}%
+    \crefname{appendix}{appendiks}{appendiks}%
+    \crefname{subappendix}{appendiks}{appendiks}%
+    \crefname{subsubappendix}{appendiks}{appendiks}%
+    \crefname{subsubsubappendix}{appendiks}{appendiks}%
+    \crefname{enumi}{punkt}{punkter}%
+    \crefname{enumii}{punkt}{punkter}%
+    \crefname{enumiii}{punkt}{punkter}%
+    \crefname{enumiv}{punkt}{punkter}%
+    \crefname{enumv}{punkt}{punkter}%
+    \crefname{footnote}{fodnote}{fodnoter}%
+    \crefname{theorem}{teorem}{teoremer}%
+    \crefname{lemma}{lemma}{lemma}%
+    \crefname{corollary}{f\o lgeslutning}{f\o lgeslutninger}%
+    \crefname{proposition}{udsagn}{udsagn}%
+    \crefname{definition}{definition}{definitioner}%
+    \crefname{result}{resultat}{resultater}%
+    \crefname{example}{eksempel}{eksempler}%
+    \crefname{remark}{bem\ae rkning}{bem\ae rkninger}%
+    \crefname{note}{note}{noter}%
+    \crefname{algorithm}{algoritme}{algoritmer}%
+    \crefname{line}{linje}{linjer}%
+  \fi}% end \cref@loadlanguagedefs
+\DeclareOption{esperanto}{%
+  \AtBeginDocument{%
+    \def\crefrangeconjunction@preamble{ \^gis\nobreakspace}%
+    \def\crefrangepreconjunction@preamble{}%
+    \def\crefrangepostconjunction@preamble{}%
+    \def\crefpairconjunction@preamble{ kaj\nobreakspace}%
+    \def\crefmiddleconjunction@preamble{, }%
+    \def\creflastconjunction@preamble{ kaj\nobreakspace}%
+    \def\crefpairgroupconjunction@preamble{ kaj\nobreakspace}%
+    \def\crefmiddlegroupconjunction@preamble{, }%
+    \def\creflastgroupconjunction@preamble{ kaj\nobreakspace}%
+    \Crefname@preamble{equation}{Ekvacio}{Ekvacioj}%
+    \Crefname@preamble{part}{Parto}{Partoj}%
+    \Crefname@preamble{chapter}{\^Capitro}{\^Capitroj}%
+    \Crefname@preamble{section}{Sekcio}{Sekcioj}%
+    \Crefname@preamble{appendix}{Aldono}{Aldonoj}%
+    \Crefname@preamble{enumi}{Punkto}{Punktoj}%
+    \Crefname@preamble{footnote}{Piednoto}{Piednotoj}%
+    \Crefname@preamble{figure}{Figuro}{Figuroj}%
+    \Crefname@preamble{table}{Tabelo}{Tabeloj}%
+    \Crefname@preamble{theorem}{Teoremo}{Teoremoj}%
+    \Crefname@preamble{lemma}{Lemo}{Lemoj}%
+    \Crefname@preamble{corollary}{Korolario}{Korolarioj}%
+    \Crefname@preamble{proposition}{Propozicio}{Propozicioj}%
+    \Crefname@preamble{definition}{Defino}{Definoj}%
+    \Crefname@preamble{result}{Rezulto}{Rezultoj}%
+    \Crefname@preamble{example}{Ekzemplo}{Ekzemploj}%
+    \Crefname@preamble{remark}{Rimarko}{Rimarkoj}%
+    \Crefname@preamble{note}{Noto}{Notoj}%
+    \Crefname@preamble{algorithm}{Algoritmo}{Algoritmoj}%
+    \Crefname@preamble{listing}{Listado}{Listadoj}%
+    \Crefname@preamble{line}{Linio}{Linioj}%
     \if@cref@capitalise%
-      \crefname@preamble{equation}{Ligning}{Ligninger}%
-      \crefname@preamble{part}{Del}{Dele}%
-      \crefname@preamble{chapter}{Kapitel}{Kapitler}%
-      \crefname@preamble{section}{Afsnit}{Afsnit}%
-      \crefname@preamble{appendix}{Appendiks}{Appendiks}%
-      \crefname@preamble{enumi}{Punkt}{Punkter}%
-      \crefname@preamble{footnote}{Fodnote}{Fodnoter}%
-      \crefname@preamble{figure}{Figur}{Figurer}%
-      \crefname@preamble{table}{Tabel}{Tabeller}%
-      \crefname@preamble{theorem}{Teorem}{Teoremer}%
-      \crefname@preamble{lemma}{Lemma}{Lemma}%
-      \crefname@preamble{corollary}{F\o lgeslutning}{F\o lgeslutninger}%
-      \crefname@preamble{proposition}{Udsagn}{Udsagn}%
-      \crefname@preamble{definition}{Definition}{Definitioner}%
-      \crefname@preamble{result}{Resultat}{Resultater}%
-      \crefname@preamble{example}{Eksempel}{Eksempler}%
-      \crefname@preamble{remark}{Bem\ae rkning}{Bem\ae rkninger}%
-      \crefname@preamble{note}{Note}{Noter}%
-      \crefname@preamble{algorithm}{Algoritme}{Algoritmer}%
-      \crefname@preamble{line}{Linje}{Linjer}%
+      \crefname@preamble{equation}{Ekvacio}{Ekvacioj}%
+      \crefname@preamble{part}{Parto}{Partoj}%
+      \crefname@preamble{chapter}{\^Capitro}{\^Capitroj}%
+      \crefname@preamble{section}{Sekcio}{Sekcioj}%
+      \crefname@preamble{appendix}{Aldono}{Aldonoj}%
+      \crefname@preamble{enumi}{Punkto}{Punktoj}%
+      \crefname@preamble{footnote}{Piednoto}{Piednotoj}%
+      \crefname@preamble{figure}{Figuro}{Figuroj}%
+      \crefname@preamble{table}{Tabelo}{Tabeloj}%
+      \crefname@preamble{theorem}{Teoremo}{Teoremoj}%
+      \crefname@preamble{lemma}{Lemo}{Lemoj}%
+      \crefname@preamble{corollary}{Korolario}{Korolarioj}%
+      \crefname@preamble{proposition}{Propozicio}{Propozicioj}%
+      \crefname@preamble{definition}{Defino}{Definoj}%
+      \crefname@preamble{result}{Rezulto}{Rezultoj}%
+      \crefname@preamble{example}{Ekzemplo}{Ekzemploj}%
+      \crefname@preamble{remark}{Rimarko}{Rimarkoj}%
+      \crefname@preamble{note}{Noto}{Notoj}%
+      \crefname@preamble{algorithm}{Algoritmo}{Algoritmoj}%
+      \crefname@preamble{listing}{Listado}{Listadoj}%
+      \crefname@preamble{line}{Linio}{Linioj}%
     \else%
-      \crefname@preamble{equation}{ligning}{ligninger}%
-      \crefname@preamble{part}{del}{dele}%
-      \crefname@preamble{chapter}{kapitel}{kapitler}%
-      \crefname@preamble{section}{afsnit}{afsnit}%
-      \crefname@preamble{appendix}{appendiks}{appendiks}%
-      \crefname@preamble{enumi}{punkt}{punkter}%
-      \crefname@preamble{footnote}{fodnote}{fodnoter}%
-      \crefname@preamble{figure}{figur}{figurer}%
-      \crefname@preamble{table}{tabel}{tabeller}%
-      \crefname@preamble{theorem}{teorem}{teoremer}%
-      \crefname@preamble{lemma}{lemma}{lemma}%
-      \crefname@preamble{corollary}{f\o lgeslutning}{f\o lgeslutninger}%
-      \crefname@preamble{proposition}{udsagn}{udsagn}%
-      \crefname@preamble{definition}{definition}{definitioner}%
-      \crefname@preamble{result}{resultat}{resultater}%
-      \crefname@preamble{example}{eksempel}{eksempler}%
-      \crefname@preamble{remark}{bem\ae rkning}{bem\ae rkninger}%
-      \crefname@preamble{note}{note}{noter}%
-      \crefname@preamble{algorithm}{algoritme}{algoritmer}%
-      \crefname@preamble{line}{linje}{linjer}%
+      \crefname@preamble{equation}{ekvacio}{ekvacioj}%
+      \crefname@preamble{part}{parto}{partoj}%
+      \crefname@preamble{chapter}{\^capitro}{\^capitroj}%
+      \crefname@preamble{section}{sekcio}{sekcioj}%
+      \crefname@preamble{appendix}{aldono}{aldonoj}%
+      \crefname@preamble{enumi}{punkto}{punktoj}%
+      \crefname@preamble{footnote}{piednoto}{piednotoj}%
+      \crefname@preamble{figure}{figuro}{figuroj}%
+      \crefname@preamble{table}{tabelo}{tabeloj}%
+      \crefname@preamble{theorem}{teoremo}{teoremoj}%
+      \crefname@preamble{lemma}{lemo}{lemoj}%
+      \crefname@preamble{corollary}{korolario}{korolarioj}%
+      \crefname@preamble{proposition}{propozicio}{propozicioj}%
+      \crefname@preamble{definition}{defino}{definoj}%
+      \crefname@preamble{result}{rezulto}{rezultoj}%
+      \crefname@preamble{example}{ekzemplo}{ekzemploj}%
+      \crefname@preamble{remark}{rimarko}{rimarkoj}%
+      \crefname@preamble{note}{noto}{notoj}%
+      \crefname@preamble{algorithm}{algoritmo}{algoritmoj}%
+      \crefname@preamble{listing}{listado}{listadoj}%
+      \crefname@preamble{line}{linio}{linioj}%
+    \fi%
+    \def\cref@language{esperanto}%
+  }}% end \DeclareOption and \AtBeginDocument
+\cref@addlanguagedefs{esperanto}{%
+  \PackageInfo{cleveref}{loaded `esperanto' language definitions}%
+  \renewcommand{\crefrangeconjunction}{ \^gis\nobreakspace}%
+  \renewcommand{\crefrangepreconjunction}{}%
+  \renewcommand{\crefrangepostconjunction}{}%
+  \renewcommand{\crefpairconjunction}{ kaj\nobreakspace}%
+  \renewcommand{\crefmiddleconjunction}{, }%
+  \renewcommand{\creflastconjunction}{ kaj\nobreakspace}%
+  \renewcommand{\crefpairgroupconjunction}{ kaj\nobreakspace}%
+  \renewcommand{\crefmiddlegroupconjunction}{, }%
+  \renewcommand{\creflastgroupconjunction}{ kaj\nobreakspace}%
+  \Crefname{equation}{Ekvacio}{Ekvacioj}%
+  \Crefname{part}{Parto}{Partoj}%
+  \Crefname{chapter}{\^Capitro}{\^Capitroj}%
+  \Crefname{section}{Sekcio}{Sekcioj}%
+  \Crefname{appendix}{Aldono}{Aldonoj}%
+  \Crefname{enumi}{Punkto}{Punktoj}%
+  \Crefname{footnote}{Piednoto}{Piednotoj}%
+  \Crefname{figure}{Figuro}{Figuroj}%
+  \Crefname{table}{Tabelo}{Tabeloj}%
+  \Crefname{theorem}{Teoremo}{Teoremoj}%
+  \Crefname{lemma}{Lemo}{Lemoj}%
+  \Crefname{corollary}{Korolario}{Korolarioj}%
+  \Crefname{proposition}{Propozicio}{Propozicioj}%
+  \Crefname{definition}{Defino}{Definoj}%
+  \Crefname{result}{Rezulto}{Rezultoj}%
+  \Crefname{example}{Ekzemplo}{Ekzemploj}%
+  \Crefname{remark}{Rimarko}{Rimarkoj}%
+  \Crefname{note}{Noto}{Notoj}%
+  \Crefname{algorithm}{Algoritmo}{Algoritmoj}%
+  \Crefname{listing}{Listado}{Listadoj}%
+  \Crefname{line}{Linio}{Linioj}%
+  \if@cref@capitalise%
+    \crefname{equation}{Ekvacio}{Ekvacioj}%
+    \crefname{part}{Parto}{Partoj}%
+    \crefname{chapter}{\^Capitro}{\^Capitroj}%
+    \crefname{section}{Sekcio}{Sekcioj}%
+    \crefname{appendix}{Aldono}{Aldonoj}%
+    \crefname{enumi}{Punkto}{Punktoj}%
+    \crefname{footnote}{Piednoto}{Piednotoj}%
+    \crefname{figure}{Figuro}{Figuroj}%
+    \crefname{table}{Tabelo}{Tabeloj}%
+    \crefname{theorem}{Teoremo}{Teoremoj}%
+    \crefname{lemma}{Lemo}{Lemoj}%
+    \crefname{corollary}{Korolario}{Korolarioj}%
+    \crefname{proposition}{Propozicio}{Propozicioj}%
+    \crefname{definition}{Defino}{Definoj}%
+    \crefname{result}{Rezulto}{Rezultoj}%
+    \crefname{example}{Ekzemplo}{Ekzemploj}%
+    \crefname{remark}{Rimarko}{Rimarkoj}%
+    \crefname{note}{Noto}{Notoj}%
+    \crefname{algorithm}{Algoritmo}{Algoritmoj}%
+    \crefname{listing}{Listado}{Listadoj}%
+    \crefname{line}{Linio}{Linioj}%
+  \else%
+    \crefname{equation}{ekvacio}{ekvacioj}%
+    \crefname{part}{parto}{partoj}%
+    \crefname{chapter}{\^capitro}{\^capitroj}%
+    \crefname{section}{sekcio}{sekcioj}%
+    \crefname{appendix}{aldono}{aldonoj}%
+    \crefname{enumi}{punkto}{punktoj}%
+    \crefname{footnote}{piednoto}{piednotoj}%
+    \crefname{figure}{figuro}{figuroj}%
+    \crefname{table}{tabelo}{tabeloj}%
+    \crefname{theorem}{teoremo}{teoremoj}%
+    \crefname{lemma}{lemo}{lemoj}%
+    \crefname{corollary}{korolario}{korolarioj}%
+    \crefname{proposition}{propozicio}{propozicioj}%
+    \crefname{definition}{defino}{definoj}%
+    \crefname{result}{rezulto}{rezultoj}%
+    \crefname{example}{ekzemplo}{ekzemploj}%
+    \crefname{remark}{rimarko}{rimarkoj}%
+    \crefname{note}{noto}{notoj}%
+    \crefname{algorithm}{algoritmo}{algoritmoj}%
+    \crefname{listing}{listado}{listadoj}%
+    \crefname{line}{linio}{linioj}%
+  \fi}% end \cref@loadlanguagedefs
+\DeclareOption{swedish}{%
+  \AtBeginDocument{%
+    \def\crefrangeconjunction@preamble{ till\nobreakspace}%
+    \def\crefrangepreconjunction@preamble{}%
+    \def\crefrangepostconjunction@preamble{}%
+    \def\crefpairconjunction@preamble{ och\nobreakspace}%
+    \def\crefmiddleconjunction@preamble{, }%
+    \def\creflastconjunction@preamble{ och\nobreakspace}%
+    \def\crefpairgroupconjunction@preamble{ och\nobreakspace}%
+    \def\crefmiddlegroupconjunction@preamble{, }%
+    \def\creflastgroupconjunction@preamble{, och\nobreakspace}%
+ %
+    \Crefname@preamble{equation}{Ekvation}{Ekvation}%
+    \Crefname@preamble{figure}{Figur}{Figur}%
+    \Crefname@preamble{table}{Tabell}{Tabell}%
+    \Crefname@preamble{page}{Sida}{Sida}%
+    \Crefname@preamble{part}{Del}{Del}%
+    \Crefname@preamble{chapter}{Kapitel}{Kapitel}%
+    \Crefname@preamble{section}{Avsnitt}{Avsnitt}%
+    \Crefname@preamble{appendix}{Appendix}{Appendix}%
+    \Crefname@preamble{enumi}{Punkt}{Punkt}%
+    \Crefname@preamble{footnote}{Fotnot}{Fotnot}%
+    \Crefname@preamble{theorem}{Sats}{Sats}%
+    \Crefname@preamble{lemma}{Lemma}{Lemmas}%
+    \Crefname@preamble{corollary}{F\"oljdsats}{F\"oljdsats}%
+    \Crefname@preamble{proposition}{Proposition}{Proposition}%
+    \Crefname@preamble{definition}{Definition}{Definition}%
+    \Crefname@preamble{result}{Resultat}{Resultat}%
+    \Crefname@preamble{example}{Exempel}{Exempel}%
+    \Crefname@preamble{remark}{Anm\"arkning}{Anm\"arkning}%
+    \Crefname@preamble{note}{Notering}{Notering}%
+    \Crefname@preamble{algorithm}{Algoritm}{Algoritm}%
+    \Crefname@preamble{listing}{Kodlistning}{Kodlistning}%
+    \Crefname@preamble{line}{Rad}{Rad}%
+ %
+    \if@cref@capitalise%  capitalise set
+      \if@cref@abbrev%
+        \crefname@preamble{equation}{Ekv.}{Ekv.}%
+        \crefname@preamble{figure}{Fig.}{Fig.}%
+      \else%
+        \crefname@preamble{equation}{Ekvation}{Ekvation}%
+        \crefname@preamble{figure}{Figur}{Figur}%
       \fi%
-    }}}
+      \crefname@preamble{page}{Sida}{Sida}%
+      \crefname@preamble{table}{Tabell}{Tabell}%
+      \crefname@preamble{part}{Del}{Del}%
+      \crefname@preamble{chapter}{Kapitel}{Kapitel}%
+      \crefname@preamble{section}{Avsnitt}{Avsnitt}%
+      \crefname@preamble{appendix}{Appendix}{Appendix}%
+      \crefname@preamble{enumi}{Punkt}{Punkt}%
+      \crefname@preamble{footnote}{Fotnot}{Fotnot}%
+      \crefname@preamble{theorem}{Sats}{Sats}%
+      \crefname@preamble{lemma}{Lemma}{Lemmas}%
+      \crefname@preamble{corollary}{F\"oljdsats}{F\"oljdsats}%
+      \crefname@preamble{proposition}{Proposition}{Proposition}%
+      \crefname@preamble{definition}{Definition}{Definition}%
+      \crefname@preamble{result}{Resultat}{Resultat}%
+      \crefname@preamble{example}{Exempel}{Exempel}%
+      \crefname@preamble{remark}{Anm\"arkning}{Anm\"arkning}%
+      \crefname@preamble{note}{Notering}{Notering}%
+      \crefname@preamble{algorithm}{Algoritm}{Algoritm}%
+      \crefname@preamble{listing}{Kodlistning}{Kodlistning}%
+      \crefname@preamble{line}{Rad}{Rad}%
+ %
+    \else%  capitalise unset
+      \if@cref@abbrev%
+        \crefname@preamble{equation}{ekv.}{ekv.}%
+        \crefname@preamble{figure}{fig.}{fig.}%
+        \crefname@preamble{page}{s.}{ss.}%
+      \else%
+        \crefname@preamble{equation}{ekvation}{ekvation}%
+        \crefname@preamble{figure}{figur}{figur}%
+        \crefname@preamble{page}{sida}{sida}%
+      \fi%
+      \crefname@preamble{table}{tabell}{tabell}%
+      \crefname@preamble{part}{del}{del}%
+      \crefname@preamble{chapter}{kapitel}{kapitel}%
+      \crefname@preamble{section}{avsnitt}{avsnitt}%
+      \crefname@preamble{appendix}{appendix}{appendix}%
+      \crefname@preamble{enumi}{punkt}{punkt}%
+      \crefname@preamble{footnote}{fotnot}{fotnot}%
+      \crefname@preamble{theorem}{sats}{sats}%
+      \crefname@preamble{lemma}{lemma}{lemmas}%
+      \crefname@preamble{corollary}{f\"oljdsats}{f\"oljdsats}%
+      \crefname@preamble{proposition}{proposition}{proposition}%
+      \crefname@preamble{definition}{definition}{definition}%
+      \crefname@preamble{result}{resultat}{resultat}%
+      \crefname@preamble{example}{exempel}{exempel}%
+      \crefname@preamble{remark}{anm\"arkning}{anm\"arkning}%
+      \crefname@preamble{note}{notering}{notering}%
+      \crefname@preamble{algorithm}{algoritm}{algoritm}%
+      \crefname@preamble{listing}{kodlistning}{kodlistning}%
+      \crefname@preamble{line}{rad}{rad}%
+    \fi%
+    \def\cref@language{swedish}%
+  }}% end \AtBeginDocument and \DeclareOption
+\cref@addlanguagedefs{swedish}{%
+  \PackageInfo{cleveref}{loaded `swedish' language definitions}%
+  \renewcommand{\crefrangeconjunction}{ till\nobreakspace}%
+  \renewcommand\crefrangepreconjunction{}%
+  \renewcommand\crefrangepostconjunction{}%
+  \renewcommand{\crefpairconjunction}{ och\nobreakspace}%
+  \renewcommand{\crefmiddleconjunction}{, }%
+  \renewcommand{\creflastconjunction}{ och\nobreakspace}%
+  \renewcommand{\crefpairgroupconjunction}{ and\nobreakspace}%
+  \renewcommand{\crefmiddlegroupconjunction}{, }%
+  \renewcommand{\creflastgroupconjunction}{, and\nobreakspace}%
+ %
+  \Crefname{equation}{Ekvation}{Ekvation}%
+  \Crefname{figure}{Figur}{Figur}%
+  \Crefname{subfigure}{Figur}{Figur}%
+  \Crefname{table}{Tabell}{Tabell}%
+  \Crefname{subtable}{Tabell}{Tabell}%
+  \Crefname{page}{Sida}{Sida}%
+  \Crefname{part}{Del}{Del}%
+  \Crefname{chapter}{Kapitel}{Kapitel}%
+  \Crefname{section}{Avsnitt}{Avsnitt}%
+  \Crefname{subsection}{Avsnitt}{Avsnitt}%
+  \Crefname{subsubsection}{Avsnitt}{Avsnitt}%
+  \Crefname{appendix}{Appendix}{Appendix}%
+  \Crefname{subappendix}{Appendix}{Appendix}%
+  \Crefname{subsubappendix}{Appendix}{Appendix}%
+  \Crefname{subsubsubappendix}{Appendix}{Appendix}%
+  \Crefname{enumi}{Punkt}{Punkt}%
+  \Crefname{enumii}{Punkt}{Punkt}%
+  \Crefname{enumiii}{Punkt}{Punkt}%
+  \Crefname{enumiv}{Punkt}{Punkt}%
+  \Crefname{enumv}{Punkt}{Punkt}%
+  \Crefname{footnote}{Fotnot}{Fotnot}%
+  \Crefname{theorem}{Sats}{Sats}%
+  \Crefname{lemma}{Lemma}{Lemmas}%
+  \Crefname{corollary}{F\"oljdsats}{F\"oljdsats}%
+  \Crefname{proposition}{Proposition}{Proposition}%
+  \Crefname{definition}{Definition}{Definition}%
+  \Crefname{result}{Resultat}{Resultat}%
+  \Crefname{example}{Exempel}{Exempel}%
+  \Crefname{remark}{Anm\"arkning}{Anm\"arkning}%
+  \Crefname{note}{Notering}{Notering}%
+  \Crefname{algorithm}{Algoritm}{Algoritm}%
+  \Crefname{listing}{Kodlistning}{Kodlistning}%
+  \Crefname{line}{Rad}{Rad}%
+ %
+  \if@cref@capitalise%  capitalise set
+    \if@cref@abbrev%
+      \crefname{equation}{Ekv.}{Ekv.}%
+      \crefname{figure}{Fig.}{Fig.}%
+      \crefname{subfigure}{Fig.}{Fig.}%
+    \else%
+      \crefname{equation}{Ekvation}{Ekvation}%
+      \crefname{figure}{Figur}{Figur}%
+      \crefname{subfigure}{Figur}{Figur}%
+    \fi%
+    \crefname{page}{Sida}{Sida}%
+    \crefname{table}{Tablell}{Tabell}%
+    \crefname{subtable}{Tabell}{Tabell}%
+    \crefname{part}{Del}{Del}%
+    \crefname{chapter}{Kapitel}{Kapitel}%
+    \crefname{section}{Avsnitt}{Avsnitt}%
+    \crefname{subsection}{Avsnitt}{Avsnitt}%
+    \crefname{subsubsection}{Avsnitt}{Avsnitt}%
+    \crefname{appendix}{Appendix}{Appendix}%
+    \crefname{subappendix}{Appendix}{Appendix}%
+    \crefname{subsubappendix}{Appendix}{Appendix}%
+    \crefname{subsubsubappendix}{Appendix}{Appendix}%
+    \crefname{enumi}{Punkt}{Punkt}%
+    \crefname{enumii}{Punkt}{Punkt}%
+    \crefname{enumiii}{Punkt}{Punkt}%
+    \crefname{enumiv}{Punkt}{Punkt}%
+    \crefname{enumv}{Punkt}{Punkt}%
+    \crefname{footnote}{Fotnot}{Fotnot}%
+    \crefname{theorem}{Sats}{Sats}%
+    \crefname{lemma}{Lemma}{Lemmas}%
+    \crefname{corollary}{F\"oljdsats}{F\"oljdsats}%
+    \crefname{proposition}{Proposition}{Proposition}%
+    \crefname{definition}{Definition}{Definition}%
+    \crefname{result}{Resultat}{Resultat}%
+    \crefname{example}{Exempel}{Exempel}%
+    \crefname{remark}{Anm\"arkning}{Anm\"arkning}%
+    \crefname{note}{Notering}{Notering}%
+    \crefname{algorithm}{Algoritm}{Algoritm}%
+    \crefname{listing}{Kodlistning}{Kodlistnings}%
+    \crefname{line}{Rad}{Rad}%
+ %
+  \else%  capitalise unset
+    \if@cref@abbrev%
+      \crefname{equation}{ekv.}{ekv.}%
+      \crefname{figure}{fig.}{fig.}%
+      \crefname{subfigure}{fig.}{fig.}%
+      \crefname{page}{s.}{ss.}%
+    \else%
+      \crefname{equation}{ekvation}{ekvation}%
+      \crefname{figure}{figur}{figur}%
+      \crefname{subfigure}{figur}{figur}%
+      \crefname{page}{sida}{sida}%
+    \fi%
+    \crefname{table}{tablell}{tabell}%
+    \crefname{subtable}{tabell}{tabell}%
+    \crefname{part}{del}{del}%
+    \crefname{chapter}{kapitel}{kapitel}%
+    \crefname{section}{avsnitt}{avsnitt}%
+    \crefname{subsection}{avsnitt}{avsnitt}%
+    \crefname{subsubsection}{avsnitt}{avsnitt}%
+    \crefname{appendix}{appendix}{appendix}%
+    \crefname{subappendix}{appendix}{appendix}%
+    \crefname{subsubappendix}{appendix}{appendix}%
+    \crefname{subsubsubappendix}{appendix}{appendix}%
+    \crefname{enumi}{punkt}{punkt}%
+    \crefname{enumii}{punkt}{punkt}%
+    \crefname{enumiii}{punkt}{punkt}%
+    \crefname{enumiv}{punkt}{punkt}%
+    \crefname{enumv}{punkt}{punkt}%
+    \crefname{footnote}{fotnot}{fotnot}%
+    \crefname{theorem}{sats}{sats}%
+    \crefname{lemma}{lemma}{lemmas}%
+    \crefname{corollary}{f\"oljdsats}{f\"oljdsats}%
+    \crefname{proposition}{proposition}{proposition}%
+    \crefname{definition}{definition}{definition}%
+    \crefname{result}{resultat}{resultat}%
+    \crefname{example}{exempel}{exempel}%
+    \crefname{remark}{anm\"arkning}{anm\"arkning}%
+    \crefname{note}{notering}{notering}%
+    \crefname{algorithm}{algoritm}{algoritm}%
+    \crefname{listing}{kodlistning}{kodlistnings}%
+    \crefname{line}{rad}{rad}%
+  \fi}% end \cref@addlangagedefs
+\DeclareOption{brazilian}{%
+  \AtBeginDocument{%
+    \def\crefrangeconjunction@preamble{ a\nobreakspace}%
+    \def\crefrangepreconjunction@preamble{}%
+    \def\crefrangepostconjunction@preamble{}%
+    \def\crefpairconjunction@preamble{ e\nobreakspace}%
+    \def\crefmiddleconjunction@preamble{, }%
+    \def\creflastconjunction@preamble{ e\nobreakspace}%
+    \def\crefpairgroupconjunction@preamble{ e\nobreakspace}%
+    \def\crefmiddlegroupconjunction@preamble{, }%
+    \def\creflastgroupconjunction@preamble{, e\nobreakspace}%
+ %
+    \Crefname@preamble{equation}{Equa\c c\~ao}{Equa\c c\~oes}%
+    \Crefname@preamble{figure}{Figura}{Figuras}%
+    \Crefname@preamble{table}{Tabela}{Tabelas}%
+    \Crefname@preamble{page}{P\'agina}{P\'aginas}%
+    \Crefname@preamble{part}{Parte}{Partes}%
+    \Crefname@preamble{chapter}{Cap\'itulo}{Cap\'itulos}%
+    \Crefname@preamble{section}{Se\c c\~ao}{Se\c c\~oes}%
+    \Crefname@preamble{appendix}{Ap\^endice}{Ap\^endices}%
+    \Crefname@preamble{enumi}{Item}{Itens}%
+    \Crefname@preamble{footnote}{Nota de rodap\'e}{Notas de rodap\'e}%
+    \Crefname@preamble{theorem}{Teorema}{Teoremas}%
+    \Crefname@preamble{lemma}{Lema}{Lemas}%
+    \Crefname@preamble{corollary}{Corol\'ario}{Corol\'arios}%
+    \Crefname@preamble{proposition}{Proposi\c c\~ao}{Proposi\c c\~oes}%
+    \Crefname@preamble{definition}{Defini\c c\~ao}{Defini\c c\~oes}%
+    \Crefname@preamble{result}{Resultado}{Resultados}%
+    \Crefname@preamble{example}{Exemplo}{Exemplos}%
+    \Crefname@preamble{remark}{Observa\c c\~ao}{Observa\c c\~oes}%
+    \Crefname@preamble{note}{Nota}{Notas}%
+    \Crefname@preamble{algorithm}{Algoritmo}{Algoritmos}%
+    \Crefname@preamble{listing}{Listagem}{Listagens}%
+    \Crefname@preamble{line}{Linha}{Linhas}%
+ %
+    \if@cref@capitalise%  capitalise set
+      \if@cref@abbrev%
+        \crefname@preamble{equation}{Eq.}{Eqs.}%
+        \crefname@preamble{figure}{Fig.}{Figs.}%
+      \else%
+        \crefname@preamble{equation}{Equa\c c\~ao}{Equa\c c\~oes}%
+        \crefname@preamble{figure}{Figura}{Figuras}%
+      \fi%
+      \crefname@preamble{page}{P\'agina}{P\'aginas}%
+      \crefname@preamble{table}{Tabela}{Tabelas}%
+      \crefname@preamble{part}{Parte}{Partes}%
+      \crefname@preamble{chapter}{Cap\'itulo}{Cap\'itulos}%
+      \crefname@preamble{section}{Se\c c\~ao}{Se\c c\~oes}%
+      \crefname@preamble{appendix}{Ap\^endice}{Ap\^endices}%
+      \crefname@preamble{enumi}{Item}{Itens}%
+      \crefname@preamble{footnote}{Nota de rodap\'e}{Notas de rodap\'e}%
+      \crefname@preamble{theorem}{Teorema}{Teoremas}%
+      \crefname@preamble{lemma}{Lema}{Lemas}%
+      \crefname@preamble{corollary}{Corol\'ario}{Corol\'arios}%
+      \crefname@preamble{proposition}{Proposi\c c\~ao}{Proposi\c c\~oes}%
+      \crefname@preamble{definition}{Defini\c c\~ao}{Defini\c c\~oes}%
+      \crefname@preamble{result}{Resultado}{Resultados}%
+      \crefname@preamble{example}{Exemplo}{Exemplos}%
+      \crefname@preamble{remark}{Observa\c c\~ao}{Observa\c c\~oes}%
+      \crefname@preamble{note}{Nota}{Notas}%
+      \crefname@preamble{algorithm}{Algoritmo}{Algoritmos}%
+      \crefname@preamble{listing}{Listagem}{Listagens}%
+      \crefname@preamble{line}{Linha}{Linhas}%
+ %
+    \else%  capitalise unset
+      \if@cref@abbrev%
+        \crefname@preamble{equation}{eq.}{eqs.}%
+        \crefname@preamble{figure}{fig.}{figs.}%
+      \else%
+        \crefname@preamble{equation}{equa\c c\~ao}{equa\c c\~oes}%
+        \crefname@preamble{figure}{figura}{figuras}%
+      \fi%
+      \crefname@preamble{page}{p\'agina}{p\'aginas}%
+      \crefname@preamble{table}{tabela}{tabelas}%
+      \crefname@preamble{part}{parte}{partes}%
+      \crefname@preamble{chapter}{cap\'itulo}{cap\'itulos}%
+      \crefname@preamble{section}{se\c c\~ao}{se\c c\~oes}%
+      \crefname@preamble{appendix}{ap\^endice}{ap\^endices}%
+      \crefname@preamble{enumi}{item}{itens}%
+      \crefname@preamble{footnote}{nota de rodap\'e}{notas de rodap\'e}%
+      \crefname@preamble{theorem}{teorema}{teoremas}%
+      \crefname@preamble{lemma}{lema}{lemas}%
+      \crefname@preamble{corollary}{corol\'ario}{corol\'arios}%
+      \crefname@preamble{proposition}{proposi\c c\~ao}{proposi\c c\~oes}%
+      \crefname@preamble{definition}{defini\c c\~ao}{defini\c c\~oes}%
+      \crefname@preamble{result}{resultado}{resultados}%
+      \crefname@preamble{example}{exemplo}{exemplos}%
+      \crefname@preamble{remark}{observa\c c\~ao}{observa\c c\~oes}%
+      \crefname@preamble{note}{nota}{notas}%
+      \crefname@preamble{algorithm}{algoritmo}{algoritmos}%
+      \crefname@preamble{listing}{listagem}{listagens}%
+      \crefname@preamble{line}{linha}{linhas}%
+    \fi%
+    \def\cref@language{brazilian}%
+  }}% end \AtBeginDocument and \DeclareOption
+\cref@addlanguagedefs{brazilian}{%
+  \PackageInfo{cleveref}{loaded `brazilian' language definitions}%
+  \renewcommand{\crefrangeconjunction}{ a\nobreakspace}%
+  \renewcommand\crefrangepreconjunction{}%
+  \renewcommand\crefrangepostconjunction{}%
+  \renewcommand{\crefpairconjunction}{ e\nobreakspace}%
+  \renewcommand{\crefmiddleconjunction}{, }%
+  \renewcommand{\creflastconjunction}{ e\nobreakspace}%
+  \renewcommand{\crefpairgroupconjunction}{ e\nobreakspace}%
+  \renewcommand{\crefmiddlegroupconjunction}{, }%
+  \renewcommand{\creflastgroupconjunction}{ e\nobreakspace}%
+ %
+  \Crefname{equation}{Equa\c c\~ao}{Equa\c c\~oes}%
+  \Crefname{figure}{Figura}{Figuras}%
+  \Crefname{subfigure}{Figura}{Figuras}%
+  \Crefname{table}{Tabela}{Tabelas}%
+  \Crefname{subtable}{Tabela}{Tabelas}%
+  \Crefname{page}{P\'agina}{P\'aginas}%
+  \Crefname{part}{Parte}{Partes}%
+  \Crefname{chapter}{Cap\'itulo}{Cap\'itulos}%
+  \Crefname{section}{Se\c c\~ao}{Se\c c\~oes}%
+  \Crefname{subsection}{Se\c c\~ao}{Se\c c\~oes}%
+  \Crefname{subsubsection}{Se\c c\~ao}{Se\c c\~oes}%
+  \Crefname{appendix}{Ap\^endice}{Ap\^endices}%
+  \Crefname{subappendix}{Ap\^endice}{Ap\^endices}%
+  \Crefname{subsubappendix}{Ap\^endice}{Ap\^endices}%
+  \Crefname{subsubsubappendix}{Ap\^endice}{Ap\^endices}%
+  \Crefname{enumi}{Item}{Itens}%
+  \Crefname{enumii}{Item}{Itens}%
+  \Crefname{enumiii}{Item}{Itens}%
+  \Crefname{enumiv}{Item}{Itens}%
+  \Crefname{enumv}{Item}{Itens}%
+  \Crefname{footnote}{Nota de rodap\'e}{Notas de rodap\'e}%
+  \Crefname{theorem}{Teorema}{Teoremas}%
+  \Crefname{lemma}{Lema}{Lemas}%
+  \Crefname{corollary}{Corol\'ario}{Corol\'arios}%
+  \Crefname{proposition}{Proposi\c c\~ao}{Proposi\c c\~oes}%
+  \Crefname{definition}{Defini\c c\~ao}{Defini\c c\~oes}%
+  \Crefname{result}{Resultado}{Resultados}%
+  \Crefname{example}{Exemplo}{Exemplos}%
+  \Crefname{remark}{Observa\c c\~ao}{Observa\c c\~oes}%
+  \Crefname{note}{Nota}{Notas}%
+  \Crefname{algorithm}{Algoritmo}{Algoritmos}%
+  \Crefname{listing}{Listagem}{Listagens}%
+  \Crefname{line}{Linha}{Linhas}%
+ %
+  \if@cref@capitalise%  capitalise set
+    \if@cref@abbrev%
+      \crefname{equation}{Eq.}{Eqs.}%
+      \crefname{figure}{Fig.}{Figs.}%
+      \crefname{subfigure}{Fig.}{Figs.}%
+    \else%
+      \crefname{equation}{Equa\c c\~ao}{Equa\c c\~oes}%
+      \crefname{figure}{Figura}{Figuras}%
+      \crefname{subfigure}{Figura}{Figuras}%
+    \fi%
+    \crefname{page}{P\'agina}{P\'aginas}%
+    \crefname{table}{Tabela}{Tabelas}%
+    \crefname{subtable}{Tabela}{Tabelas}%
+    \crefname{part}{Parte}{Partes}%
+    \crefname{chapter}{Cap\'itulo}{Cap\'itulos}%
+    \crefname{section}{Se\c c\~ao}{Se\c c\~oes}%
+    \crefname{subsection}{Se\c c\~ao}{Se\c c\~oes}%
+    \crefname{subsubsection}{Se\c c\~ao}{Se\c c\~oes}%
+    \crefname{appendix}{Ap\^endice}{Ap\^endices}%
+    \crefname{subappendix}{Ap\^endice}{Ap\^endices}%
+    \crefname{subsubappendix}{Ap\^endice}{Ap\^endices}%
+    \crefname{subsubsubappendix}{Ap\^endice}{Ap\^endices}%
+    \crefname{enumi}{Item}{Itens}%
+    \crefname{enumii}{Item}{Itens}%
+    \crefname{enumiii}{Item}{Itens}%
+    \crefname{enumiv}{Item}{Itens}%
+    \crefname{enumv}{Item}{Itens}%
+    \crefname{footnote}{Nota de rodap\'e}{Notas de rodap\'e}%
+    \crefname{theorem}{Teorema}{Teoremas}%
+    \crefname{lemma}{Lema}{Lemas}%
+    \crefname{corollary}{Corol\'ario}{Corol\'arios}%
+    \crefname{proposition}{Proposi\c c\~ao}{Proposi\c c\~oes}%
+    \crefname{definition}{Defini\c c\~ao}{Defini\c c\~oes}%
+    \crefname{result}{Resultado}{Resultados}%
+    \crefname{example}{Exemplo}{Exemplos}%
+    \crefname{remark}{Observa\c c\~ao}{Observa\c c\~oes}%
+    \crefname{note}{Nota}{Notas}%
+    \crefname{algorithm}{Algoritmo}{Algoritmos}%
+    \crefname{listing}{Listagem}{Listagens}%
+    \crefname{line}{Linha}{Linhas}%
+ %
+  \else%  capitalise unset
+    \if@cref@abbrev%
+      \crefname{equation}{eq.}{eqs.}%
+      \crefname{figure}{fig.}{figs.}%
+      \crefname{subfigure}{fig.}{figs.}%
+    \else%
+      \crefname{equation}{equa\c c\~ao}{equa\c c\~oes}%
+      \crefname{figure}{figura}{figuras}%
+      \crefname{subfigure}{figura}{figuras}%
+    \fi%
+    \crefname{table}{tabela}{tabelas}%
+    \crefname{subtable}{tabela}{tabelas}%
+    \crefname{page}{p\'agina}{p\'aginas}%
+    \crefname{part}{parte}{partes}%
+    \crefname{chapter}{cap\'itulo}{cap\'itulos}%
+    \crefname{section}{se\c c\~ao}{se\c c\~oes}%
+    \crefname{subsection}{se\c c\~ao}{se\c c\~oes}%
+    \crefname{subsubsection}{se\c c\~ao}{se\c c\~oes}%
+    \crefname{appendix}{ap\^endice}{ap\^endices}%
+    \crefname{subappendix}{ap\^endice}{ap\^endices}%
+    \crefname{subsubappendix}{ap\^endice}{ap\^endices}%
+    \crefname{subsubsubappendix}{ap\^endice}{ap\^endices}%
+    \crefname{enumi}{item}{itens}%
+    \crefname{enumii}{item}{itens}%
+    \crefname{enumiii}{item}{itens}%
+    \crefname{enumiv}{item}{itens}%
+    \crefname{enumv}{item}{itens}%
+    \crefname{footnote}{nota de rodap\'e}{notas de rodap\'e}%
+    \crefname{theorem}{teorema}{teoremas}%
+    \crefname{lemma}{lema}{lemas}%
+    \crefname{corollary}{corol\'ario}{corol\'arios}%
+    \crefname{proposition}{proposi\c c\~ao}{proposi\c c\~oes}%
+    \crefname{definition}{defini\c c\~ao}{defini\c c\~oes}%
+    \crefname{result}{resultado}{resultados}%
+    \crefname{example}{exemplo}{exemplos}%
+    \crefname{remark}{observa\c c\~ao}{observa\c c\~oes}%
+    \crefname{note}{nota}{notas}%
+    \crefname{algorithm}{algoritmo}{algoritmos}%
+    \crefname{listing}{listagem}{listagens}%
+    \crefname{line}{linha}{linhas}%
+  \fi}% end \cref@addlangagedefs
 \edef\@curroptions{\@ptionlist{\@currname.\@currext}}%
 \@expandtwoargs\in@{,capitalise,}{%
   ,\@classoptionslist,\@curroptions,}%
@@ -5496,8 +7470,27 @@
     \ExecuteOptions{capitalise}%
   \fi%
 \fi%
-\ExecuteOptions{english}
-\ProcessOptions*\relax
+\@expandtwoargs\in@{,nameinlink,}{%
+  ,\@classoptionslist,\@curroptions,}%
+\ifin@%
+  \ExecuteOptions{nameinlink}%
+\fi%
+\crefdefaultlabelformat{#2#1#3}%
+\if@cref@nameinlink%
+  \creflabelformat{equation}{#2\textup{(#1)}#3}%
+\else%
+  \creflabelformat{equation}{\textup{(#2#1#3)}}%
+\fi%
+\@labelcrefdefinedefaultformats%
+\@ifpackageloaded{polyglossia}%
+  {\ifcsdef{languagename}%
+    {\ExecuteOptions{\languagename}}%
+    {\PackageWarning{cleveref}%
+       {`polyglossia' loaded but default language not set
+         - defaulting to english}%
+     \ExecuteOptions{english}}}%
+  {\ExecuteOptions{english}}%
+\ProcessOptions*\relax%
 \AtBeginDocument{%
   \edef\@tempa{%
     \expandafter\noexpand\csname extras\cref@language\endcsname}%
@@ -5609,12 +7602,14 @@
         \csname cref@\@tempa @name\endcsname}%
       \expandafter\def\expandafter\@tempc\expandafter{%
         \csname cref@\@tempa @name@preamble\endcsname}%
-      \expandafter\expandafter\expandafter\let\expandafter\@tempb\@tempc%
+      \expandafter\expandafter\expandafter%
+        \let\expandafter\@tempb\@tempc%
       \expandafter\def\expandafter\@tempb\expandafter{%
         \csname cref@\@tempa @name@plural\endcsname}%
       \expandafter\def\expandafter\@tempc\expandafter{%
         \csname cref@\@tempa @name@plural@preamble\endcsname}%
-      \expandafter\expandafter\expandafter\let\expandafter\@tempb\@tempc%
+      \expandafter\expandafter\expandafter%
+        \let\expandafter\@tempb\@tempc%
     }{%
       \edef\@tempb{%
         \expandafter\noexpand\csname extras\cref@language\endcsname}%
@@ -5638,12 +7633,14 @@
         \csname Cref@\@tempa @name\endcsname}%
       \expandafter\def\expandafter\@tempc\expandafter{%
         \csname Cref@\@tempa @name@preamble\endcsname}%
-      \expandafter\expandafter\expandafter\let\expandafter\@tempb\@tempc%
+      \expandafter\expandafter\expandafter%
+        \let\expandafter\@tempb\@tempc%
       \expandafter\def\expandafter\@tempb\expandafter{%
         \csname Cref@\@tempa @name@plural\endcsname}%
       \expandafter\def\expandafter\@tempc\expandafter{%
         \csname Cref@\@tempa @name@plural@preamble\endcsname}%
-      \expandafter\expandafter\expandafter\let\expandafter\@tempb\@tempc%
+      \expandafter\expandafter\expandafter%
+        \let\expandafter\@tempb\@tempc%
     }{%
       \edef\@tempb{%
         \expandafter\noexpand\csname extras\cref@language\endcsname}%
@@ -5679,134 +7676,134 @@
     \cref@isstackfull{\@tempstack}}%
     \@ifundefined{cref@subsection@name}{%
       \let\cref@subsection@name\cref@section@name%
-      \let\cref@subsection@name@plural\cref@section@name@plural}{}%
+        \let\cref@subsection@name@plural\cref@section@name@plural}{}%
     \@ifundefined{Cref@subsection@name}{%
       \let\Cref@subsection@name\Cref@section@name%
-      \let\Cref@subsection@name@plural\Cref@section@name@plural}{}%
+        \let\Cref@subsection@name@plural\Cref@section@name@plural}{}%
     \@ifundefined{cref@subsection@format}{%
       \let\cref@subsection@format\cref@section@format}{}%
     \@ifundefined{Cref@subsection@format}{%
       \let\Cref@subsection@format\Cref@section@format}{}%
     \@ifundefined{crefrange@subsection@format}{%
       \let\crefrange@subsection@format%
-      \crefrange@section@format}{}%
+        \crefrange@section@format}{}%
     \@ifundefined{Crefrange@subsection@format}{%
       \let\Crefrange@subsection@format%
-      \Crefrange@section@format}{}%
+        \Crefrange@section@format}{}%
     \@ifundefined{cref@subsection@format@first}{%
       \let\cref@subsection@format@first%
-      \cref@section@format@first}{}%
+        \cref@section@format@first}{}%
     \@ifundefined{Cref@subsection@format@first}{%
       \let\Cref@subsection@format@first%
-      \Cref@section@format@first}{}%
+        \Cref@section@format@first}{}%
     \@ifundefined{cref@subsection@format@second}{%
       \let\cref@subsection@format@second%
-      \cref@section@format@second}{}%
+        \cref@section@format@second}{}%
     \@ifundefined{Cref@subsection@format@second}{%
       \let\Cref@subsection@format@second%
-      \Cref@section@format@second}{}%
+        \Cref@section@format@second}{}%
     \@ifundefined{cref@subsection@format@middle}{%
       \let\cref@subsection@format@middle%
-      \cref@section@format@middle}{}%
+        \cref@section@format@middle}{}%
     \@ifundefined{Cref@subsection@format@middle}{%
       \let\Cref@subsection@format@middle%
-      \Cref@section@format@middle}{}%
+        \Cref@section@format@middle}{}%
     \@ifundefined{cref@subsection@format@last}{%
       \let\cref@subsection@format@last%
-      \cref@section@format@last}{}%
+        \cref@section@format@last}{}%
     \@ifundefined{Cref@subsection@format@last}{%
       \let\Cref@subsection@format@last%
-      \Cref@section@format@last}{}%
+        \Cref@section@format@last}{}%
     \@ifundefined{crefrange@subsection@format@first}{%
       \let\crefrange@subsection@format@first%
-      \crefrange@section@format@first}{}%
+        \crefrange@section@format@first}{}%
     \@ifundefined{Crefrange@subsection@format@first}{%
       \let\Crefrange@subsection@format@first%
-      \Crefrange@section@format@first}{}%
+        \Crefrange@section@format@first}{}%
     \@ifundefined{crefrange@subsection@format@second}{%
       \let\crefrange@subsection@format@second%
-      \crefrange@section@format@second}{}%
+        \crefrange@section@format@second}{}%
     \@ifundefined{Crefrange@subsection@format@second}{%
       \let\Crefrange@subsection@format@second%
-      \Crefrange@section@format@second}{}%
+        \Crefrange@section@format@second}{}%
     \@ifundefined{crefrange@subsection@format@middle}{%
       \let\crefrange@subsection@format@middle%
-      \crefrange@section@format@middle}{}%
+        \crefrange@section@format@middle}{}%
     \@ifundefined{Crefrange@subsection@format@middle}{%
       \let\Crefrange@subsection@format@middle%
-      \Crefrange@section@format@middle}{}%
+        \Crefrange@section@format@middle}{}%
     \@ifundefined{crefrange@subsection@format@last}{%
       \let\crefrange@subsection@format@last%
-      \crefrange@section@format@last}{}%
+        \crefrange@section@format@last}{}%
     \@ifundefined{Crefrange@subsection@format@last}{%
       \let\Crefrange@subsection@format@last%
-      \Crefrange@section@format@last}{}%
+        \Crefrange@section@format@last}{}%
     \@ifundefined{cref@subsubsection@name}{%
       \let\cref@subsubsection@name\cref@section@name%
-      \let\cref@subsubsection@name@plural\cref@section@name@plural}{}%
+        \let\cref@subsubsection@name@plural\cref@section@name@plural}{}%
     \@ifundefined{Cref@subsection@name}{%
       \let\Cref@subsection@name\Cref@section@name%
-      \let\Cref@subsection@name@plural\Cref@section@name@plural}{}%
+        \let\Cref@subsection@name@plural\Cref@section@name@plural}{}%
     \@ifundefined{cref@subsubsection@format}{%
       \let\cref@subsubsection@format%
-      \cref@subsection@format}{}%
+        \cref@subsection@format}{}%
     \@ifundefined{Cref@subsubsection@format}{%
       \let\Cref@subsubsection@format%
-      \Cref@subsection@format}{}%
+        \Cref@subsection@format}{}%
     \@ifundefined{crefrange@subsubsection@format}{%
       \let\crefrange@subsubsection@format%
-      \crefrange@subsection@format}{}%
+        \crefrange@subsection@format}{}%
     \@ifundefined{Crefrange@subsubsection@format}{%
       \let\Crefrange@subsubsection@format%
-      \Crefrange@subsection@format}{}%
+        \Crefrange@subsection@format}{}%
     \@ifundefined{cref@subsubsection@format@first}{%
       \let\cref@subsubsection@format@first%
-      \cref@subsection@format@first}{}%
+        \cref@subsection@format@first}{}%
     \@ifundefined{Cref@subsubsection@format@first}{%
       \let\Cref@subsubsection@format@first%
-      \Cref@subsection@format@first}{}%
+        \Cref@subsection@format@first}{}%
     \@ifundefined{cref@subsubsection@format@second}{%
       \let\cref@subsubsection@format@second%
-      \cref@subsection@format@second}{}%
+        \cref@subsection@format@second}{}%
     \@ifundefined{Cref@subsubsection@format@second}{%
       \let\Cref@subsubsection@format@second%
-      \Cref@subsection@format@second}{}%
+        \Cref@subsection@format@second}{}%
     \@ifundefined{cref@subsubsection@format@middle}{%
       \let\cref@subsubsection@format@middle%
-      \cref@subsection@format@middle}{}%
+        \cref@subsection@format@middle}{}%
     \@ifundefined{Cref@subsubsection@format@middle}{%
       \let\Cref@subsubsection@format@middle%
-      \Cref@subsection@format@middle}{}%
+        \Cref@subsection@format@middle}{}%
     \@ifundefined{cref@subsubsection@format@last}{%
       \let\cref@subsubsection@format@last%
-      \cref@subsection@format@last}{}%
+        \cref@subsection@format@last}{}%
     \@ifundefined{Cref@subsubsection@format@last}{%
       \let\Cref@subsubsection@format@last%
-      \Cref@subsection@format@last}{}%
+        \Cref@subsection@format@last}{}%
     \@ifundefined{crefrange@subsubsection@format@first}{%
       \let\crefrange@subsubsection@format@first%
-      \crefrange@subsection@format@first}{}%
+        \crefrange@subsection@format@first}{}%
     \@ifundefined{Crefrange@subsubsection@format@first}{%
       \let\Crefrange@subsubsection@format@first%
-      \Crefrange@subsection@format@first}{}%
+        \Crefrange@subsection@format@first}{}%
     \@ifundefined{crefrange@subsubsection@format@second}{%
       \let\crefrange@subsubsection@format@second%
-      \crefrange@subsection@format@second}{}%
+        \crefrange@subsection@format@second}{}%
     \@ifundefined{Crefrange@subsubsection@format@second}{%
       \let\Crefrange@subsubsection@format@second%
-      \Crefrange@subsection@format@second}{}%
+        \Crefrange@subsection@format@second}{}%
     \@ifundefined{crefrange@subsubsection@format@middle}{%
       \let\crefrange@subsubsection@format@middle%
-      \crefrange@subsection@format@middle}{}%
+        \crefrange@subsection@format@middle}{}%
     \@ifundefined{Crefrange@subsubsection@format@middle}{%
       \let\Crefrange@subsubsection@format@middle%
-      \Crefrange@subsection@format@middle}{}%
+        \Crefrange@subsection@format@middle}{}%
     \@ifundefined{crefrange@subsubsection@format@last}{%
       \let\crefrange@subsubsection@format@last%
-      \crefrange@subsection@format@last}{}%
+        \crefrange@subsection@format@last}{}%
     \@ifundefined{Crefrange@subsubsection@format@last}{%
       \let\Crefrange@subsubsection@format@last%
-      \Crefrange@subsection@format@last}{}%
+        \Crefrange@subsection@format@last}{}%
     \@ifundefined{cref@subappendix@name}{%
       \let\cref@subappendix@name\cref@appendix@name%
       \let\cref@subappendix@name@plural%
@@ -5821,58 +7818,58 @@
       \let\Cref@subappendix@format\Cref@appendix@format}{}%
     \@ifundefined{crefrange@subappendix@format}{%
       \let\crefrange@subappendix@format%
-      \crefrange@appendix@format}{}%
+        \crefrange@appendix@format}{}%
     \@ifundefined{Crefrange@subappendix@format}{%
       \let\Crefrange@subappendix@format%
-      \Crefrange@appendix@format}{}%
+        \Crefrange@appendix@format}{}%
     \@ifundefined{cref@subappendix@format@first}{%
       \let\cref@subappendix@format@first%
-      \cref@appendix@format@first}{}%
+        \cref@appendix@format@first}{}%
     \@ifundefined{Cref@subappendix@format@first}{%
       \let\Cref@subappendix@format@first%
-      \Cref@appendix@format@first}{}%
+        \Cref@appendix@format@first}{}%
     \@ifundefined{cref@subappendix@format@second}{%
       \let\cref@subappendix@format@second%
-      \cref@appendix@format@second}{}%
+        \cref@appendix@format@second}{}%
     \@ifundefined{Cref@subappendix@format@second}{%
       \let\Cref@subappendix@format@second%
-      \Cref@appendix@format@second}{}%
+        \Cref@appendix@format@second}{}%
     \@ifundefined{cref@subappendix@format@middle}{%
       \let\cref@subappendix@format@middle%
-      \cref@appendix@format@middle}{}%
+        \cref@appendix@format@middle}{}%
     \@ifundefined{Cref@subappendix@format@middle}{%
       \let\Cref@subappendix@format@middle%
-      \Cref@appendix@format@middle}{}%
+        \Cref@appendix@format@middle}{}%
     \@ifundefined{cref@subappendix@format@last}{%
       \let\cref@subappendix@format@last%
-      \cref@appendix@format@last}{}%
+        \cref@appendix@format@last}{}%
     \@ifundefined{Cref@subappendix@format@last}{%
       \let\Cref@subappendix@format@last%
-      \Cref@appendix@format@last}{}%
+        \Cref@appendix@format@last}{}%
     \@ifundefined{crefrange@subappendix@format@first}{%
       \let\crefrange@subappendix@format@first%
-      \crefrange@appendix@format@first}{}%
+        \crefrange@appendix@format@first}{}%
     \@ifundefined{Crefrange@subappendix@format@first}{%
       \let\Crefrange@subappendix@format@first%
-      \Crefrange@appendix@format@first}{}%
+        \Crefrange@appendix@format@first}{}%
     \@ifundefined{crefrange@subappendix@format@second}{%
       \let\crefrange@subappendix@format@second%
-      \crefrange@appendix@format@second}{}%
+        \crefrange@appendix@format@second}{}%
     \@ifundefined{Crefrange@subappendix@format@second}{%
       \let\Crefrange@subappendix@format@second%
-      \Crefrange@appendix@format@second}{}%
+        \Crefrange@appendix@format@second}{}%
     \@ifundefined{crefrange@subappendix@format@middle}{%
       \let\crefrange@subappendix@format@middle%
-      \crefrange@appendix@format@middle}{}%
+        \crefrange@appendix@format@middle}{}%
     \@ifundefined{Crefrange@subappendix@format@middle}{%
       \let\Crefrange@subappendix@format@middle%
-      \Crefrange@appendix@format@middle}{}%
+        \Crefrange@appendix@format@middle}{}%
     \@ifundefined{crefrange@subappendix@format@last}{%
       \let\crefrange@subappendix@format@last%
-      \crefrange@appendix@format@last}{}%
+        \crefrange@appendix@format@last}{}%
     \@ifundefined{Crefrange@subappendix@format@last}{%
       \let\Crefrange@subappendix@format@last%
-      \Crefrange@appendix@format@last}{}%
+        \Crefrange@appendix@format@last}{}%
     \@ifundefined{cref@subsubappendix@name}{%
       \let\cref@subsubappendix@name\cref@appendix@name%
       \let\cref@subsubappendix@name@plural%
@@ -5883,486 +7880,548 @@
         \Cref@appendix@name@plural}{}%
     \@ifundefined{cref@subsubappendix@format}{%
       \let\cref@subsubappendix@format%
-      \cref@subappendix@format}{}%
+        \cref@subappendix@format}{}%
     \@ifundefined{Cref@subsubappendix@format}{%
       \let\Cref@subsubappendix@format%
-      \Cref@subappendix@format}{}%
+        \Cref@subappendix@format}{}%
     \@ifundefined{crefrange@subsubappendix@format}{%
       \let\crefrange@subsubappendix@format%
-      \crefrange@subappendix@format}{}%
+        \crefrange@subappendix@format}{}%
     \@ifundefined{Crefrange@subsubappendix@format}{%
       \let\Crefrange@subsubappendix@format%
-      \Crefrange@subappendix@format}{}%
+        \Crefrange@subappendix@format}{}%
     \@ifundefined{cref@subsubappendix@format@first}{%
       \let\cref@subsubappendix@format@first%
-      \cref@subappendix@format@first}{}%
+        \cref@subappendix@format@first}{}%
     \@ifundefined{Cref@subsubappendix@format@first}{%
       \let\Cref@subsubappendix@format@first%
-      \Cref@subappendix@format@first}{}%
+        \Cref@subappendix@format@first}{}%
     \@ifundefined{cref@subsubappendix@format@second}{%
       \let\cref@subsubappendix@format@second%
-      \cref@subappendix@format@second}{}%
+        \cref@subappendix@format@second}{}%
     \@ifundefined{Cref@subsubappendix@format@second}{%
       \let\Cref@subsubappendix@format@second%
-      \Cref@subappendix@format@second}{}%
+        \Cref@subappendix@format@second}{}%
     \@ifundefined{cref@subsubappendix@format@middle}{%
       \let\cref@subsubappendix@format@middle%
-      \cref@subappendix@format@middle}{}%
+        \cref@subappendix@format@middle}{}%
     \@ifundefined{Cref@subsubappendix@format@middle}{%
       \let\Cref@subsubappendix@format@middle%
-      \Cref@subappendix@format@middle}{}%
+        \Cref@subappendix@format@middle}{}%
     \@ifundefined{cref@subsubappendix@format@last}{%
       \let\cref@subsubappendix@format@last%
-      \cref@subappendix@format@last}{}%
+        \cref@subappendix@format@last}{}%
     \@ifundefined{Cref@subsubappendix@format@last}{%
       \let\Cref@subsubappendix@format@last%
-      \Cref@subappendix@format@last}{}%
+        \Cref@subappendix@format@last}{}%
     \@ifundefined{crefrange@subsubappendix@format@first}{%
       \let\crefrange@subsubappendix@format@first%
-      \crefrange@subappendix@format@first}{}%
+        \crefrange@subappendix@format@first}{}%
     \@ifundefined{Crefrange@subsubappendix@format@first}{%
       \let\Crefrange@subsubappendix@format@first%
-      \Crefrange@subappendix@format@first}{}%
+        \Crefrange@subappendix@format@first}{}%
     \@ifundefined{crefrange@subsubappendix@format@second}{%
       \let\crefrange@subsubappendix@format@second%
-      \crefrange@subappendix@format@second}{}%
+        \crefrange@subappendix@format@second}{}%
     \@ifundefined{Crefrange@subsubappendix@format@second}{%
       \let\Crefrange@subsubappendix@format@second%
-      \Crefrange@subappendix@format@second}{}%
+        \Crefrange@subappendix@format@second}{}%
     \@ifundefined{crefrange@subsubappendix@format@middle}{%
       \let\crefrange@subsubappendix@format@middle%
-      \crefrange@subappendix@format@middle}{}%
+        \crefrange@subappendix@format@middle}{}%
     \@ifundefined{Crefrange@subsubappendix@format@middle}{%
       \let\Crefrange@subsubappendix@format@middle%
-      \Crefrange@subappendix@format@middle}{}%
+        \Crefrange@subappendix@format@middle}{}%
     \@ifundefined{crefrange@subsubappendix@format@last}{%
       \let\crefrange@subsubappendix@format@last%
-      \crefrange@subappendix@format@last}{}%
+        \crefrange@subappendix@format@last}{}%
     \@ifundefined{Crefrange@subsubappendix@format@last}{%
       \let\Crefrange@subsubappendix@format@last%
-      \Crefrange@subappendix@format@last}{}%
+        \Crefrange@subappendix@format@last}{}%
     \@ifundefined{cref@subsubsubappendix@format}{%
       \let\cref@subsubsubappendix@format%
-      \cref@subsubappendix@format}{}%
+        \cref@subsubappendix@format}{}%
     \@ifundefined{Cref@subsubsubappendix@format}{%
       \let\Cref@subsubsubappendix@format%
-      \Cref@subsubappendix@format}{}%
+        \Cref@subsubappendix@format}{}%
     \@ifundefined{crefrange@subsubsubappendix@format}{%
       \let\crefrange@subsubsubappendix@format%
-      \crefrange@subsubappendix@format}{}%
+        \crefrange@subsubappendix@format}{}%
     \@ifundefined{Crefrange@subsubsubappendix@format}{%
       \let\Crefrange@subsubsubappendix@format%
-      \Crefrange@subsubappendix@format}{}%
+        \Crefrange@subsubappendix@format}{}%
     \@ifundefined{cref@subsubsubappendix@format@first}{%
       \let\cref@subsubsubappendix@format@first%
-      \cref@subsubappendix@format@first}{}%
+        \cref@subsubappendix@format@first}{}%
     \@ifundefined{Cref@subsubsubappendix@format@first}{%
       \let\Cref@subsubsubappendix@format@first%
-      \Cref@subsubappendix@format@first}{}%
+        \Cref@subsubappendix@format@first}{}%
     \@ifundefined{cref@subsubsubappendix@format@second}{%
       \let\cref@subsubsubappendix@format@second%
-      \cref@subsubappendix@format@second}{}%
+        \cref@subsubappendix@format@second}{}%
     \@ifundefined{Cref@subsubsubappendix@format@second}{%
       \let\Cref@subsubsubappendix@format@second%
-      \Cref@subsubappendix@format@second}{}%
+        \Cref@subsubappendix@format@second}{}%
     \@ifundefined{cref@subsubsubappendix@format@middle}{%
       \let\cref@subsubsubappendix@format@middle%
-      \cref@subsubappendix@format@middle}{}%
+        \cref@subsubappendix@format@middle}{}%
     \@ifundefined{Cref@subsubsubappendix@format@middle}{%
       \let\Cref@subsubsubappendix@format@middle%
-      \Cref@subsubappendix@format@middle}{}%
+        \Cref@subsubappendix@format@middle}{}%
     \@ifundefined{cref@subsubsubappendix@format@last}{%
       \let\cref@subsubsubappendix@format@last%
-      \cref@subsubappendix@format@last}{}%
+        \cref@subsubappendix@format@last}{}%
     \@ifundefined{Cref@subsubsubappendix@format@last}{%
       \let\Cref@subsubsubappendix@format@last%
-      \Cref@subsubappendix@format@last}{}%
+        \Cref@subsubappendix@format@last}{}%
     \@ifundefined{crefrange@subsubsubappendix@format@first}{%
       \let\crefrange@subsubsubappendix@format@first%
-      \crefrange@subsubappendix@format@first}{}%
+        \crefrange@subsubappendix@format@first}{}%
     \@ifundefined{Crefrange@subsubsubappendix@format@first}{%
       \let\Crefrange@subsubsubappendix@format@first%
-      \Crefrange@subsubappendix@format@first}{}%
+        \Crefrange@subsubappendix@format@first}{}%
     \@ifundefined{crefrange@subsubsubappendix@format@second}{%
       \let\crefrange@subsubsubappendix@format@second%
-      \crefrange@subsubappendix@format@second}{}%
+        \crefrange@subsubappendix@format@second}{}%
     \@ifundefined{Crefrange@subsubsubappendix@format@second}{%
       \let\Crefrange@subsubsubappendix@format@second%
-      \Crefrange@subsubappendix@format@second}{}%
+        \Crefrange@subsubappendix@format@second}{}%
     \@ifundefined{crefrange@subsubsubappendix@format@middle}{%
       \let\crefrange@subsubsubappendix@format@middle%
-      \crefrange@subsubappendix@format@middle}{}%
+        \crefrange@subsubappendix@format@middle}{}%
     \@ifundefined{Crefrange@subsubsubappendix@format@middle}{%
       \let\Crefrange@subsubsubappendix@format@middle%
-      \Crefrange@subsubappendix@format@middle}{}%
+        \Crefrange@subsubappendix@format@middle}{}%
     \@ifundefined{crefrange@subsubsubappendix@format@last}{%
       \let\crefrange@subsubsubappendix@format@last%
-      \crefrange@subsubappendix@format@last}{}%
+        \crefrange@subsubappendix@format@last}{}%
     \@ifundefined{Crefrange@subsubsubappendix@format@last}{%
       \let\Crefrange@subsubsubappendix@format@last%
-      \Crefrange@subsubappendix@format@last}{}%
+        \Crefrange@subsubappendix@format@last}{}%
     \@ifundefined{cref@subfigure@format}{%
       \let\cref@subfigure@format%
-      \cref@figure@format}{}%
+        \cref@figure@format}{}%
     \@ifundefined{Cref@subfigure@format}{%
       \let\Cref@subfigure@format%
-      \Cref@figure@format}{}%
+        \Cref@figure@format}{}%
     \@ifundefined{crefrange@subfigure@format}{%
       \let\crefrange@subfigure@format%
-      \crefrange@figure@format}{}%
+        \crefrange@figure@format}{}%
     \@ifundefined{Crefrange@subfigure@format}{%
       \let\Crefrange@subfigure@format%
-      \Crefrange@figure@format}{}%
+        \Crefrange@figure@format}{}%
     \@ifundefined{cref@subfigure@format@first}{%
       \let\cref@subfigure@format@first%
-      \cref@figure@format@first}{}%
+        \cref@figure@format@first}{}%
     \@ifundefined{Cref@subfigure@format@first}{%
       \let\Cref@subfigure@format@first%
-      \Cref@figure@format@first}{}%
+        \Cref@figure@format@first}{}%
     \@ifundefined{cref@subfigure@format@second}{%
       \let\cref@subfigure@format@second%
-      \cref@figure@format@second}{}%
+        \cref@figure@format@second}{}%
     \@ifundefined{Cref@subfigure@format@second}{%
       \let\Cref@subfigure@format@second%
-      \Cref@figure@format@second}{}%
+        \Cref@figure@format@second}{}%
     \@ifundefined{cref@subfigure@format@middle}{%
       \let\cref@subfigure@format@middle%
-      \cref@figure@format@middle}{}%
+        \cref@figure@format@middle}{}%
     \@ifundefined{Cref@subfigure@format@middle}{%
       \let\Cref@subfigure@format@middle%
-      \Cref@figure@format@middle}{}%
+        \Cref@figure@format@middle}{}%
     \@ifundefined{cref@subfigure@format@last}{%
       \let\cref@subfigure@format@last%
-      \cref@figure@format@last}{}%
+        \cref@figure@format@last}{}%
     \@ifundefined{Cref@subfigure@format@last}{%
       \let\Cref@subfigure@format@last%
-      \Cref@figure@format@last}{}%
+        \Cref@figure@format@last}{}%
     \@ifundefined{crefrange@subfigure@format@first}{%
       \let\crefrange@subfigure@format@first%
-      \crefrange@figure@format@first}{}%
+        \crefrange@figure@format@first}{}%
     \@ifundefined{Crefrange@subfigure@format@first}{%
       \let\Crefrange@subfigure@format@first%
-      \Crefrange@figure@format@first}{}%
+        \Crefrange@figure@format@first}{}%
     \@ifundefined{crefrange@subfigure@format@second}{%
       \let\crefrange@subfigure@format@second%
-      \crefrange@figure@format@second}{}%
+        \crefrange@figure@format@second}{}%
     \@ifundefined{Crefrange@subfigure@format@second}{%
       \let\Crefrange@subfigure@format@second%
-      \Crefrange@figure@format@second}{}%
+        \Crefrange@figure@format@second}{}%
     \@ifundefined{crefrange@subfigure@format@middle}{%
       \let\crefrange@subfigure@format@middle%
-      \crefrange@figure@format@middle}{}%
+        \crefrange@figure@format@middle}{}%
     \@ifundefined{Crefrange@subfigure@format@middle}{%
       \let\Crefrange@subfigure@format@middle%
-      \Crefrange@figure@format@middle}{}%
+        \Crefrange@figure@format@middle}{}%
     \@ifundefined{crefrange@subfigure@format@last}{%
       \let\crefrange@subfigure@format@last%
-      \crefrange@figure@format@last}{}%
+        \crefrange@figure@format@last}{}%
     \@ifundefined{Crefrange@subfigure@format@last}{%
       \let\Crefrange@subfigure@format@last%
-      \Crefrange@figure@format@last}{}%
+        \Crefrange@figure@format@last}{}%
     \@ifundefined{cref@subtable@format}{%
       \let\cref@subtable@format%
-      \cref@table@format}{}%
+        \cref@table@format}{}%
     \@ifundefined{Cref@subtable@format}{%
       \let\Cref@subtable@format%
-      \Cref@table@format}{}%
+        \Cref@table@format}{}%
     \@ifundefined{crefrange@subtable@format}{%
       \let\crefrange@subtable@format%
-      \crefrange@table@format}{}%
+        \crefrange@table@format}{}%
     \@ifundefined{Crefrange@subtable@format}{%
       \let\Crefrange@subtable@format%
-      \Crefrange@table@format}{}%
+        \Crefrange@table@format}{}%
     \@ifundefined{cref@subtable@format@first}{%
       \let\cref@subtable@format@first%
-      \cref@table@format@first}{}%
+        \cref@table@format@first}{}%
     \@ifundefined{Cref@subtable@format@first}{%
       \let\Cref@subtable@format@first%
-      \Cref@table@format@first}{}%
+        \Cref@table@format@first}{}%
     \@ifundefined{cref@subtable@format@second}{%
       \let\cref@subtable@format@second%
-      \cref@table@format@second}{}%
+        \cref@table@format@second}{}%
     \@ifundefined{Cref@subtable@format@second}{%
       \let\Cref@subtable@format@second%
-      \Cref@table@format@second}{}%
+        \Cref@table@format@second}{}%
     \@ifundefined{cref@subtable@format@middle}{%
       \let\cref@subtable@format@middle%
-      \cref@table@format@middle}{}%
+        \cref@table@format@middle}{}%
     \@ifundefined{Cref@subtable@format@middle}{%
       \let\Cref@subtable@format@middle%
-      \Cref@table@format@middle}{}%
+        \Cref@table@format@middle}{}%
     \@ifundefined{cref@subtable@format@last}{%
       \let\cref@subtable@format@last%
-      \cref@table@format@last}{}%
+        \cref@table@format@last}{}%
     \@ifundefined{Cref@subtable@format@last}{%
       \let\Cref@subtable@format@last%
-      \Cref@table@format@last}{}%
+        \Cref@table@format@last}{}%
     \@ifundefined{crefrange@subtable@format@first}{%
       \let\crefrange@subtable@format@first%
-      \crefrange@table@format@first}{}%
+        \crefrange@table@format@first}{}%
     \@ifundefined{Crefrange@subtable@format@first}{%
       \let\Crefrange@subtable@format@first%
-      \Crefrange@table@format@first}{}%
+        \Crefrange@table@format@first}{}%
     \@ifundefined{crefrange@subtable@format@second}{%
       \let\crefrange@subtable@format@second%
-      \crefrange@table@format@second}{}%
+        \crefrange@table@format@second}{}%
     \@ifundefined{Crefrange@subtable@format@second}{%
       \let\Crefrange@subtable@format@second%
-      \Crefrange@table@format@second}{}%
+        \Crefrange@table@format@second}{}%
     \@ifundefined{crefrange@subtable@format@middle}{%
       \let\crefrange@subtable@format@middle%
-      \crefrange@table@format@middle}{}%
+        \crefrange@table@format@middle}{}%
     \@ifundefined{Crefrange@subtable@format@middle}{%
       \let\Crefrange@subtable@format@middle%
-      \Crefrange@table@format@middle}{}%
+        \Crefrange@table@format@middle}{}%
     \@ifundefined{crefrange@subtable@format@last}{%
       \let\crefrange@subtable@format@last%
-      \crefrange@table@format@last}{}%
+        \crefrange@table@format@last}{}%
     \@ifundefined{Crefrange@subtable@format@last}{%
       \let\Crefrange@subtable@format@last%
-      \Crefrange@table@format@last}{}%
+        \Crefrange@table@format@last}{}%
+    \@ifundefined{cref@subequation@format}{%
+      \let\cref@subequation@format%
+        \cref@equation@format}{}%
+    \@ifundefined{Cref@subequation@format}{%
+      \let\Cref@subequation@format%
+        \Cref@equation@format}{}%
+    \@ifundefined{crefrange@subequation@format}{%
+      \let\crefrange@subequation@format%
+        \crefrange@equation@format}{}%
+    \@ifundefined{Crefrange@subequation@format}{%
+      \let\Crefrange@subequation@format%
+        \Crefrange@equation@format}{}%
+    \@ifundefined{cref@subequation@format@first}{%
+      \let\cref@subequation@format@first%
+        \cref@equation@format@first}{}%
+    \@ifundefined{Cref@subequation@format@first}{%
+      \let\Cref@subequation@format@first%
+        \Cref@equation@format@first}{}%
+    \@ifundefined{cref@subequation@format@second}{%
+      \let\cref@subequation@format@second%
+        \cref@equation@format@second}{}%
+    \@ifundefined{Cref@subequation@format@second}{%
+      \let\Cref@subequation@format@second%
+        \Cref@equation@format@second}{}%
+    \@ifundefined{cref@subequation@format@middle}{%
+      \let\cref@subequation@format@middle%
+        \cref@equation@format@middle}{}%
+    \@ifundefined{Cref@subequation@format@middle}{%
+      \let\Cref@subequation@format@middle%
+        \Cref@equation@format@middle}{}%
+    \@ifundefined{cref@subequation@format@last}{%
+      \let\cref@subequation@format@last%
+        \cref@equation@format@last}{}%
+    \@ifundefined{Cref@subequation@format@last}{%
+      \let\Cref@subequation@format@last%
+        \Cref@equation@format@last}{}%
+    \@ifundefined{crefrange@subequation@format@first}{%
+      \let\crefrange@subequation@format@first%
+        \crefrange@equation@format@first}{}%
+    \@ifundefined{Crefrange@subequation@format@first}{%
+      \let\Crefrange@subequation@format@first%
+        \Crefrange@equation@format@first}{}%
+    \@ifundefined{crefrange@subequation@format@second}{%
+      \let\crefrange@subequation@format@second%
+        \crefrange@equation@format@second}{}%
+    \@ifundefined{Crefrange@subequation@format@second}{%
+      \let\Crefrange@subequation@format@second%
+        \Crefrange@equation@format@second}{}%
+    \@ifundefined{crefrange@subequation@format@middle}{%
+      \let\crefrange@subequation@format@middle%
+        \crefrange@equation@format@middle}{}%
+    \@ifundefined{Crefrange@subequation@format@middle}{%
+      \let\Crefrange@subequation@format@middle%
+        \Crefrange@equation@format@middle}{}%
+    \@ifundefined{crefrange@subequation@format@last}{%
+      \let\crefrange@subequation@format@last%
+        \crefrange@equation@format@last}{}%
+    \@ifundefined{Crefrange@subequation@format@last}{%
+      \let\Crefrange@subequation@format@last%
+        \Crefrange@equation@format@last}{}%
     \@ifundefined{cref@enumii@format}{%
       \let\cref@enumii@format%
-      \cref@enumi@format}{}%
+        \cref@enumi@format}{}%
     \@ifundefined{Cref@enumii@format}{%
       \let\Cref@enumii@format%
-      \Cref@enumi@format}{}%
+        \Cref@enumi@format}{}%
     \@ifundefined{crefrange@enumii@format}{%
       \let\crefrange@enumii@format%
-      \crefrange@enumi@format}{}%
+        \crefrange@enumi@format}{}%
     \@ifundefined{Crefrange@enumii@format}{%
       \let\Crefrange@enumii@format%
-      \Crefrange@enumi@format}{}%
+        \Crefrange@enumi@format}{}%
     \@ifundefined{cref@enumii@format@first}{%
       \let\cref@enumii@format@first%
-      \cref@enumi@format@first}{}%
+        \cref@enumi@format@first}{}%
     \@ifundefined{Cref@enumii@format@first}{%
       \let\Cref@enumii@format@first%
-      \Cref@enumi@format@first}{}%
+        \Cref@enumi@format@first}{}%
     \@ifundefined{cref@enumii@format@second}{%
       \let\cref@enumii@format@second%
-      \cref@enumi@format@second}{}%
+        \cref@enumi@format@second}{}%
     \@ifundefined{Cref@enumii@format@second}{%
       \let\Cref@enumii@format@second%
-      \Cref@enumi@format@second}{}%
+        \Cref@enumi@format@second}{}%
     \@ifundefined{cref@enumii@format@middle}{%
       \let\cref@enumii@format@middle%
-      \cref@enumi@format@middle}{}%
+        \cref@enumi@format@middle}{}%
     \@ifundefined{Cref@enumii@format@middle}{%
       \let\Cref@enumii@format@middle%
-      \Cref@enumi@format@middle}{}%
+        \Cref@enumi@format@middle}{}%
     \@ifundefined{cref@enumii@format@last}{%
       \let\cref@enumii@format@last%
-      \cref@enumi@format@last}{}%
+        \cref@enumi@format@last}{}%
     \@ifundefined{Cref@enumii@format@last}{%
       \let\Cref@enumii@format@last%
-      \Cref@enumi@format@last}{}%
+        \Cref@enumi@format@last}{}%
     \@ifundefined{crefrange@enumii@format@first}{%
       \let\crefrange@enumii@format@first%
-      \crefrange@enumi@format@first}{}%
+        \crefrange@enumi@format@first}{}%
     \@ifundefined{Crefrange@enumii@format@first}{%
       \let\Crefrange@enumii@format@first%
-      \Crefrange@enumi@format@first}{}%
+        \Crefrange@enumi@format@first}{}%
     \@ifundefined{crefrange@enumii@format@second}{%
       \let\crefrange@enumii@format@second%
-      \crefrange@enumi@format@second}{}%
+        \crefrange@enumi@format@second}{}%
     \@ifundefined{Crefrange@enumii@format@second}{%
       \let\Crefrange@enumii@format@second%
-      \Crefrange@enumi@format@second}{}%
+        \Crefrange@enumi@format@second}{}%
     \@ifundefined{crefrange@enumii@format@middle}{%
       \let\crefrange@enumii@format@middle%
-      \crefrange@enumi@format@middle}{}%
+        \crefrange@enumi@format@middle}{}%
     \@ifundefined{Crefrange@enumii@format@middle}{%
       \let\Crefrange@enumii@format@middle%
-      \Crefrange@enumi@format@middle}{}%
+        \Crefrange@enumi@format@middle}{}%
     \@ifundefined{crefrange@enumii@format@last}{%
       \let\crefrange@enumii@format@last%
-      \crefrange@enumi@format@last}{}%
+        \crefrange@enumi@format@last}{}%
     \@ifundefined{Crefrange@enumii@format@last}{%
       \let\Crefrange@enumii@format@last%
-      \Crefrange@enumi@format@last}{}%
+        \Crefrange@enumi@format@last}{}%
     \@ifundefined{cref@enumiii@format}{%
       \let\cref@enumiii@format%
-      \cref@enumii@format}{}%
+        \cref@enumii@format}{}%
     \@ifundefined{Cref@enumiii@format}{%
       \let\Cref@enumiii@format%
-      \Cref@enumii@format}{}%
+        \Cref@enumii@format}{}%
     \@ifundefined{crefrange@enumiii@format}{%
       \let\crefrange@enumiii@format%
-      \crefrange@enumii@format}{}%
+        \crefrange@enumii@format}{}%
     \@ifundefined{Crefrange@enumiii@format}{%
       \let\Crefrange@enumiii@format%
-      \Crefrange@enumii@format}{}%
+        \Crefrange@enumii@format}{}%
     \@ifundefined{cref@enumiii@format@first}{%
       \let\cref@enumiii@format@first%
-      \cref@enumii@format@first}{}%
+        \cref@enumii@format@first}{}%
     \@ifundefined{Cref@enumiii@format@first}{%
       \let\Cref@enumiii@format@first%
-      \Cref@enumii@format@first}{}%
+        \Cref@enumii@format@first}{}%
     \@ifundefined{cref@enumiii@format@second}{%
       \let\cref@enumiii@format@second%
-      \cref@enumii@format@second}{}%
+        \cref@enumii@format@second}{}%
     \@ifundefined{Cref@enumiii@format@second}{%
       \let\Cref@enumiii@format@second%
-      \Cref@enumii@format@second}{}%
+        \Cref@enumii@format@second}{}%
     \@ifundefined{cref@enumiii@format@middle}{%
       \let\cref@enumiii@format@middle%
-      \cref@enumii@format@middle}{}%
+        \cref@enumii@format@middle}{}%
     \@ifundefined{Cref@enumiii@format@middle}{%
       \let\Cref@enumiii@format@middle%
-      \Cref@enumii@format@middle}{}%
+        \Cref@enumii@format@middle}{}%
     \@ifundefined{cref@enumiii@format@last}{%
       \let\cref@enumiii@format@last%
-      \cref@enumii@format@last}{}%
+        \cref@enumii@format@last}{}%
     \@ifundefined{Cref@enumiii@format@last}{%
       \let\Cref@enumiii@format@last%
-      \Cref@enumii@format@last}{}%
+        \Cref@enumii@format@last}{}%
     \@ifundefined{crefrange@enumiii@format@first}{%
       \let\crefrange@enumiii@format@first%
-      \crefrange@enumii@format@first}{}%
+        \crefrange@enumii@format@first}{}%
     \@ifundefined{Crefrange@enumiii@format@first}{%
       \let\Crefrange@enumiii@format@first%
-      \Crefrange@enumii@format@first}{}%
+        \Crefrange@enumii@format@first}{}%
     \@ifundefined{crefrange@enumiii@format@second}{%
       \let\crefrange@enumiii@format@second%
-      \crefrange@enumii@format@second}{}%
+        \crefrange@enumii@format@second}{}%
     \@ifundefined{Crefrange@enumiii@format@second}{%
       \let\Crefrange@enumiii@format@second%
-      \Crefrange@enumii@format@second}{}%
+        \Crefrange@enumii@format@second}{}%
     \@ifundefined{crefrange@enumiii@format@middle}{%
       \let\crefrange@enumiii@format@middle%
-      \crefrange@enumii@format@middle}{}%
+        \crefrange@enumii@format@middle}{}%
     \@ifundefined{Crefrange@enumiii@format@middle}{%
       \let\Crefrange@enumiii@format@middle%
-      \Crefrange@enumii@format@middle}{}%
+        \Crefrange@enumii@format@middle}{}%
     \@ifundefined{crefrange@enumiii@format@last}{%
       \let\crefrange@enumiii@format@last%
-      \crefrange@enumii@format@last}{}%
+        \crefrange@enumii@format@last}{}%
     \@ifundefined{Crefrange@enumiii@format@last}{%
       \let\Crefrange@enumiii@format@last%
-      \Crefrange@enumii@format@last}{}%
+        \Crefrange@enumii@format@last}{}%
     \@ifundefined{cref@enumiv@format}{%
       \let\cref@enumiv@format%
-      \cref@enumiii@format}{}%
+        \cref@enumiii@format}{}%
     \@ifundefined{Cref@enumiv@format}{%
       \let\Cref@enumiv@format%
-      \Cref@enumiii@format}{}%
+        \Cref@enumiii@format}{}%
     \@ifundefined{crefrange@enumiv@format}{%
       \let\crefrange@enumiv@format%
-      \crefrange@enumiii@format}{}%
+        \crefrange@enumiii@format}{}%
     \@ifundefined{Crefrange@enumiv@format}{%
       \let\Crefrange@enumiv@format%
-      \Crefrange@enumiii@format}{}%
+        \Crefrange@enumiii@format}{}%
     \@ifundefined{cref@enumiv@format@first}{%
       \let\cref@enumiv@format@first%
-      \cref@enumiii@format@first}{}%
+        \cref@enumiii@format@first}{}%
     \@ifundefined{Cref@enumiv@format@first}{%
       \let\Cref@enumiv@format@first%
-      \Cref@enumiii@format@first}{}%
+        \Cref@enumiii@format@first}{}%
     \@ifundefined{cref@enumiv@format@second}{%
       \let\cref@enumiv@format@second%
-      \cref@enumiii@format@second}{}%
+        \cref@enumiii@format@second}{}%
     \@ifundefined{Cref@enumiv@format@second}{%
       \let\Cref@enumiv@format@second%
-      \Cref@enumiii@format@second}{}%
+        \Cref@enumiii@format@second}{}%
     \@ifundefined{cref@enumiv@format@middle}{%
       \let\cref@enumiv@format@middle%
-      \cref@enumiii@format@middle}{}%
+        \cref@enumiii@format@middle}{}%
     \@ifundefined{Cref@enumiv@format@middle}{%
       \let\Cref@enumiv@format@middle%
-      \Cref@enumiii@format@middle}{}%
+        \Cref@enumiii@format@middle}{}%
     \@ifundefined{cref@enumiv@format@last}{%
       \let\cref@enumiv@format@last%
-      \cref@enumiii@format@last}{}%
+        \cref@enumiii@format@last}{}%
     \@ifundefined{Cref@enumiv@format@last}{%
       \let\Cref@enumiv@format@last%
-      \Cref@enumiii@format@last}{}%
+        \Cref@enumiii@format@last}{}%
     \@ifundefined{crefrange@enumiv@format@first}{%
       \let\crefrange@enumiv@format@first%
-      \crefrange@enumiii@format@first}{}%
+        \crefrange@enumiii@format@first}{}%
     \@ifundefined{Crefrange@enumiv@format@first}{%
       \let\Crefrange@enumiv@format@first%
-      \Crefrange@enumiii@format@first}{}%
+        \Crefrange@enumiii@format@first}{}%
     \@ifundefined{crefrange@enumiv@format@second}{%
       \let\crefrange@enumiv@format@second%
-      \crefrange@enumiii@format@second}{}%
+        \crefrange@enumiii@format@second}{}%
     \@ifundefined{Crefrange@enumiv@format@second}{%
       \let\Crefrange@enumiv@format@second%
-      \Crefrange@enumiii@format@second}{}%
+        \Crefrange@enumiii@format@second}{}%
     \@ifundefined{crefrange@enumiv@format@middle}{%
       \let\crefrange@enumiv@format@middle%
-      \crefrange@enumiii@format@middle}{}%
+        \crefrange@enumiii@format@middle}{}%
     \@ifundefined{Crefrange@enumiv@format@middle}{%
       \let\Crefrange@enumiv@format@middle%
-      \Crefrange@enumiii@format@middle}{}%
+        \Crefrange@enumiii@format@middle}{}%
     \@ifundefined{crefrange@enumiv@format@last}{%
       \let\crefrange@enumiv@format@last%
-      \crefrange@enumiii@format@last}{}%
+        \crefrange@enumiii@format@last}{}%
     \@ifundefined{Crefrange@enumiv@format@last}{%
       \let\Crefrange@enumiv@format@last%
-      \Crefrange@enumiii@format@last}{}%
+        \Crefrange@enumiii@format@last}{}%
     \@ifundefined{cref@enumv@format}{%
       \let\cref@enumv@format%
-      \cref@enumiv@format}{}%
+        \cref@enumiv@format}{}%
     \@ifundefined{Cref@enumv@format}{%
       \let\Cref@enumv@format%
-      \Cref@enumiv@format}{}%
+        \Cref@enumiv@format}{}%
     \@ifundefined{crefrange@enumv@format}{%
       \let\crefrange@enumv@format%
-      \crefrange@enumiv@format}{}%
+        \crefrange@enumiv@format}{}%
     \@ifundefined{Crefrange@enumv@format}{%
       \let\Crefrange@enumv@format%
-      \Crefrange@enumiv@format}{}%
+        \Crefrange@enumiv@format}{}%
     \@ifundefined{cref@enumv@format@first}{%
       \let\cref@enumv@format@first%
-      \cref@enumiv@format@first}{}%
+        \cref@enumiv@format@first}{}%
     \@ifundefined{Cref@enumv@format@first}{%
       \let\Cref@enumv@format@first%
-      \Cref@enumiv@format@first}{}%
+        \Cref@enumiv@format@first}{}%
     \@ifundefined{cref@enumv@format@second}{%
       \let\cref@enumv@format@second%
-      \cref@enumiv@format@second}{}%
+        \cref@enumiv@format@second}{}%
     \@ifundefined{Cref@enumv@format@second}{%
       \let\Cref@enumv@format@second%
-      \Cref@enumiv@format@second}{}%
+        \Cref@enumiv@format@second}{}%
     \@ifundefined{cref@enumv@format@middle}{%
       \let\cref@enumv@format@middle%
-      \cref@enumiv@format@middle}{}%
+        \cref@enumiv@format@middle}{}%
     \@ifundefined{Cref@enumv@format@middle}{%
       \let\Cref@enumv@format@middle%
-      \Cref@enumiv@format@middle}{}%
+        \Cref@enumiv@format@middle}{}%
     \@ifundefined{cref@enumv@format@last}{%
       \let\cref@enumv@format@last%
-      \cref@enumiv@format@last}{}%
+        \cref@enumiv@format@last}{}%
     \@ifundefined{Cref@enumv@format@last}{%
       \let\Cref@enumv@format@last%
-      \Cref@enumiv@format@last}{}%
+        \Cref@enumiv@format@last}{}%
     \@ifundefined{crefrange@enumv@format@first}{%
       \let\crefrange@enumv@format@first%
-      \crefrange@enumiv@format@first}{}%
+        \crefrange@enumiv@format@first}{}%
     \@ifundefined{Crefrange@enumv@format@first}{%
       \let\Crefrange@enumv@format@first%
-      \Crefrange@enumiv@format@first}{}%
+        \Crefrange@enumiv@format@first}{}%
     \@ifundefined{crefrange@enumv@format@second}{%
       \let\crefrange@enumv@format@second%
-      \crefrange@enumiv@format@second}{}%
+        \crefrange@enumiv@format@second}{}%
     \@ifundefined{Crefrange@enumv@format@second}{%
       \let\Crefrange@enumv@format@second%
-      \Crefrange@enumiv@format@second}{}%
+        \Crefrange@enumiv@format@second}{}%
     \@ifundefined{crefrange@enumv@format@middle}{%
       \let\crefrange@enumv@format@middle%
-      \crefrange@enumiv@format@middle}{}%
+        \crefrange@enumiv@format@middle}{}%
     \@ifundefined{Crefrange@enumv@format@middle}{%
       \let\Crefrange@enumv@format@middle%
-      \Crefrange@enumiv@format@middle}{}%
+        \Crefrange@enumiv@format@middle}{}%
     \@ifundefined{crefrange@enumv@format@last}{%
       \let\crefrange@enumv@format@last%
-      \crefrange@enumiv@format@last}{}%
+        \crefrange@enumiv@format@last}{}%
     \@ifundefined{Crefrange@enumv@format@last}{%
       \let\Crefrange@enumv@format@last%
-      \Crefrange@enumiv@format@last}{}%
+        \Crefrange@enumiv@format@last}{}%
   \let\cref@language\relax%
 }%  end of \AtBeginDocument
+\InputIfFileExists{cleveref.cfg}%
+  {\PackageInfo{cleveref}{reading definitions from cleveref.cfg}}{}%
 \endinput
 %%
 %% End of file `cleveref.sty'.


### PR DESCRIPTION
I'm trying to get the book to compile with htlatex so that we can have a
nice kindle-compatible epub, and it requires updating cleveref.
(Although I am a fan of MathML and the epubs for #287, e.g., of
@loopspace and @dvanduzer, Kindle doesn't currently support MathML at
all, and htlatex uses embedded images for the math.)
