### PR TITLE
Add labels to a number of ct theorems and defns

### DIFF
--- a/categories.tex
+++ b/categories.tex
@@ -391,7 +391,7 @@ In particular, naturally isomorphic functors between categories (as opposed to p
 
 We now define all the usual ways to compose functors and natural transformations.
 
-\begin{defn}
+\begin{defn}\label{ct:functor-composition}
   For functors $F:A\to B$ and $G:B\to C$, their composite $G\circ F:A\to C$ is given by
   \begin{itemize}
   \item The composite $(G_0\circ F_0) : A_0 \to C_0$
@@ -401,7 +401,7 @@ We now define all the usual ways to compose functors and natural transformations
   It is easy to check the axioms.
 \end{defn}
 
-\begin{defn}
+\begin{defn}\label{ct:whisker}
   For functors $F:A\to B$ and $G,H:B\to C$ and a natural transformation $\gamma:G\to H$, the composite $(\gamma F):GF\to HF$ is given by
   \begin{itemize}
   \item For each $a:A$, the component $\gamma_{Fa}$.
@@ -480,7 +480,7 @@ See \autoref{ct:pre2cat,ct:2cat} for further development of these ideas.
 
 The definition of adjoint functors is straightforward; the main interesting aspect arises from proof-relevance.
 
-\begin{defn}
+\begin{defn}\label{ct:adjoints}
   A functor $F:A\to B$ is a \define{left adjoint}
   \indexdef{left!adjoint}%
   \indexdef{adjoint!functor}%
@@ -563,7 +563,7 @@ By \autoref{ct:adjprop,ct:isoprop}, if $A$ is a category, then the type ``$F$ is
   Just like the proof of \autoref{thm:equiv-iso-adj} for equivalences of types.
 \end{proof}
 
-\begin{defn}
+\begin{defn}\label{ct:full-faithful}
   We say a functor $F:A\to B$ is \define{faithful}
   \indexdef{functor!faithful}%
   \index{faithful functor}%a
@@ -578,7 +578,7 @@ By \autoref{ct:adjprop,ct:isoprop}, if $A$ is a category, then the type ``$F$ is
   \indexdef{fully faithful functor}%
 \end{defn}
 
-\begin{defn}
+\begin{defn}\label{ct:split-essentially-surjective}
   We say a functor $F:A\to B$ is \define{split essentially surjective}
   \indexdef{functor!split essentially surjective}%
   \indexdef{split!essentially surjective functor}%
@@ -639,7 +639,7 @@ By \autoref{ct:adjprop,ct:isoprop}, if $A$ is a category, then the type ``$F$ is
 However, if $B$ is not a category, then neither type in \autoref{ct:ffeso} may necessarily be a mere proposition.
 This suggests considering as well the following notions.
 
-\begin{defn}
+\begin{defn}\label{ct:essentially-surjective}
   A functor $F:A\to B$ is \define{essentially surjective}
   \indexdef{functor!essentially surjective}%
   \indexdef{essentially surjective functor}%
@@ -885,7 +885,7 @@ First we need to define opposites and products of (pre)categories.
   $A\op$ is a precategory with the same type of objects, with $\hom_{A\op}(a,b) \defeq \hom_A(b,a)$, and with identities and composition inherited from $A$.
 \end{defn}
 
-\begin{defn}
+\begin{defn}\label{ct:prod-cat}
   For precategories $A$ and $B$, their \define{product}
   \index{precategory!product of}%
   \index{category!product of}%
@@ -1075,7 +1075,7 @@ First we give a characterization of adjunctions in terms of representability.
 
 \index{bargaining|(}%
 
-\begin{defn}
+\begin{defn}\label{ct:strict-category}
   A \define{strict category}
   \indexdef{category!strict}%
   \indexdef{strict!category}%
@@ -1091,7 +1091,7 @@ The main advantage of this is that strict categories have a stricter notion of `
 
 Here is one origin of strict categories.
 
-\begin{eg}
+\begin{eg}\label{ct:mono-cat}
   Let $A$ be a precategory and $x:A$ an object.
   Then there is a precategory $\mathsf{mono}(A,x)$ as follows:
   \index{monomorphism}
@@ -1130,7 +1130,7 @@ Here is an interesting application of strict categories.
 
 It is also worth mentioning a useful kind of precategory whose type of objects is not a set, but which is not a category either.
 
-\begin{defn}
+\begin{defn}\label{ct:dagger-precategory}
   A \define{$\dagger$-precategory}
   \indexdef{.dagger-precategory@$\dagger$-precategory}%
   \indexdef{precategory!.dagger-@$\dagger$-}%
@@ -1163,7 +1163,7 @@ Thus for each $x,y:A$ we have a set of unitary isomorphisms from $x$ to $y$, whi
   But then $\dgr{(1_x)} \circ 1_x = 1_x\circ 1_x = 1_x$ and similarly.
 \end{proof}
 
-\begin{defn}
+\begin{defn}\label{ct:dagger-category}
   A \define{$\dagger$-category}
   \indexdef{.dagger-category@$\dagger$-category}%
   is a $\dagger$-precategory such that for all $x,y:A$, the function
@@ -1171,12 +1171,12 @@ Thus for each $x,y:A$ we have a set of unitary isomorphisms from $x$ to $y$, whi
   from \autoref{ct:idtounitary} is an equivalence.
 \end{defn}
 
-\begin{eg}
+\begin{eg}\label{ct:rel-dagger-cat}
   The category \urel from \autoref{ct:rel} becomes a $\dagger$-pre\-cat\-e\-go\-ry if we define $(\dgr R)(y,x) \defeq R(x,y)$.
   The proof that \urel is a category actually shows that every isomorphism is unitary; hence \urel is also a $\dagger$-category.
 \end{eg}
 
-\begin{eg}
+\begin{eg}\label{ct:groupoid-dagger-cat}
   Any groupoid becomes a $\dagger$-category if we define $\dgr f \defeq \inv{f}$.
 \end{eg}
 
@@ -1373,7 +1373,7 @@ Both rely on the fact that ``categories see weak equivalences as equivalences''.
 To prove this, we begin with a couple of lemmas which are completely standard category theory, phrased carefully so as to make sure we are using the eliminator for $\truncf{-1}$ correctly.
 One would have to be similarly careful in classical\index{mathematics!classical}\index{classical!category theory} category theory if one wanted to avoid the axiom of choice: any time we want to define a function, we need to characterize its values uniquely somehow.
 
-\begin{lem}
+\begin{lem}\label{ct:esosurj-postcomp-faithful}
   If $A,B,C$ are precategories and $H:A\to B$ is an essentially surjective functor, then $(\blank\circ H):C^B \to C^A$ is faithful.
 \end{lem}
 \begin{proof}
@@ -1694,7 +1694,7 @@ However, there are a few cases in which the Rezk completion is necessary to obta
 The Rezk completion also allows us to show that the notion of ``category'' is determined by the notion of ``weak equivalence of precategories''.
 Thus, insofar as the latter is inevitable, so is the former.
 
-\begin{thm}
+\begin{thm}\label{ct:weq-iso-precat-cat}
   A precategory $C$ is a category if and only if for every weak equivalence of precategories $H:A\to B$, the induced functor $(\blank\circ H):C^B \to C^A$ is an isomorphism of precategories.
 \end{thm}
 \begin{proof}


### PR DESCRIPTION
They were missing them, and I want them for HoTTBook.v in HoTT/HoTT.
