### PR TITLE
Tweaks to allow latex (and not only pdflatex) to compile the book

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
  - wget http://mirrors.ctan.org/macros/latex/contrib/comment/comment.sty
  - wget http://www.ctan.org/tex-archive/macros/latex/contrib/misc/nextpage.sty
  - wget http://mirrors.ctan.org/fonts/stmaryrd.zip && unzip stmaryrd && mv stmaryrd/*.{mf,dtx} ./ && latex stmaryrd.dtx
+ - wget http://mirrors.ctan.org/macros/latex/contrib/pagecolor/pagecolor.dtx && tex pagecolor.dtx
  - wget http://mirrors.ctan.org/macros/latex/contrib/wallpaper/wallpaper.sty
  - wget http://mirrors.ctan.org/macros/generic/xstring/xstring.sty
  - wget http://mirrors.ctan.org/macros/generic/xstring/xstring.tex

--- a/macros.tex
+++ b/macros.tex
@@ -805,6 +805,41 @@
 \newcounter{symindex}
 \newcommand{\symlabel}[1]{\refstepcounter{symindex}\label{#1}}
 
+\makeatletter
+% Fix \includegraphics for dvi mode, but only if not making a pdf
+\ifpdf
+  \expandafter\@gobble
+\else
+  \expandafter\@firstofone
+\fi{%
+\let\Gin@ii@old=\Gin@ii
+\def\Gin@ii[#1]#2{%
+  \begingroup
+    \let\@found\@empty
+    \@for\@type:=\bmpsize@types\do{%
+      \ifx\@found\@empty
+        \@nameuse{bmpsize@read@\@type}{#2.\@type}%
+        \ifbmpsize@ok
+          \let\@found=\@type
+        \fi
+      \fi
+      \ifx\@found\@empty
+        \@nameuse{bmpsize@read@\@type}{#2}%
+        \ifbmpsize@ok
+          \let\@found=\@type
+        \fi
+      \fi
+    }%
+    \ifx\@found\@empty
+      \Gin@ii@old[#1]{#2}%
+    \else
+      \Gin@ii@old[natwidth=\bmpsize@width bp,natheight=\bmpsize@height bp,#1]{#2}%
+    \fi
+  \endgroup
+}
+}
+\makeatother
+
 % Local Variables:
 % mode: latex
 % TeX-master: "hott-online"

--- a/main.tex
+++ b/main.tex
@@ -61,7 +61,11 @@
 \usepackage{courier}
 \linespread{1.05} % Palatino looks better with this
 
+\usepackage{ifpdf}
+\usepackage{bmpsize-base} % for bounding boxes in dvi mode
+
 \usepackage{graphicx}
+\DeclareGraphicsExtensions{.png}
 \usepackage{comment}
 
 \usepackage{fancyhdr} % To set headers and footers
@@ -127,6 +131,7 @@
 
 % For some reason \pagecolor overlays the cover image,
 % unless we use it once before the document starts.
+\usepackage{pagecolor}
 \definecolor{covercolor}{cmyk}{\OPTcovercolor}
 \definecolor{covertext}{cmyk}{\OPTcovertextcolor}
 \pagecolor{white}

--- a/opt-black-white.tex
+++ b/opt-black-white.tex
@@ -5,10 +5,10 @@
 \def\OPTcovertextcolor{0,0,0,1}
 
 % COVER IMAGE
-\def\OPTlofrontimage{cover-lores-front-bw.png}
-\def\OPTlobackimage{cover-lores-back-bw.png}
-\def\OPThifrontimage{cover-hires-front-bw.png}
-\def\OPThibackimage{cover-hires-back-bw.png}
+\def\OPTlofrontimage{cover-lores-front-bw}
+\def\OPTlobackimage{cover-lores-back-bw}
+\def\OPThifrontimage{cover-hires-front-bw}
+\def\OPThibackimage{cover-hires-back-bw}
 
 % LINK COLORS
 \def\OPTlinkcolor{0,0,0}       % RGB components for clickable links

--- a/opt-color.tex
+++ b/opt-color.tex
@@ -5,10 +5,10 @@
 \def\OPTcovertextcolor{0,0,0,0.125}
 
 % COVER IMAGE
-\def\OPTlofrontimage{cover-lores-front.png}
-\def\OPTlobackimage{cover-lores-back.png}
-\def\OPThifrontimage{cover-hires-front.png}
-\def\OPThibackimage{cover-hires-back.png}
+\def\OPTlofrontimage{cover-lores-front}
+\def\OPTlobackimage{cover-lores-back}
+\def\OPThifrontimage{cover-hires-front}
+\def\OPThibackimage{cover-hires-back}
 
 % LINK COLORS
 \def\OPTlinkcolor{0,0.45,0}   % RGB components for clickable links


### PR DESCRIPTION
This is required for getting htlatex to work, for an eventual
html/non-MathML-epub target.  The main changes are:
(1) we use \DeclareGraphicsExtension and never pass .png explicitly
now
(2) we patch \includegraphics when not in pdf mode to read bounding
boxes using bmpsize-base, to silence "can't determine size" errors
