### PR TITLE
Add another \texorpdfstring

### DIFF
--- a/induction.tex
+++ b/induction.tex
@@ -251,7 +251,7 @@ In \autoref{sec:initial-alg} we will see that inductive types actually do have a
 \index{universal property}
 
 
-\section{$\w$-types}
+\section{\texorpdfstring{$\w$}{W}-types}
 \label{sec:w-types}
 
 Inductive types are very general, which is excellent for their usefulness and applicability, but makes them difficult to study as a whole.


### PR DESCRIPTION
Another thing to think about: sometimes we use `$W$`, sometimes we use `$\w`, sometimes we use `W`, and sometimes we use `$\mathsf{W}$` (all in (sub)section titles).  Should we uniformize this?
