### PR TITLE
convert the last two instance of US-style quotes to the "logical" one.

### DIFF
--- a/introduction.tex
+++ b/introduction.tex
@@ -298,13 +298,13 @@ For these we need to use the ``$(-1)$-truncated'' logic, in which only the homot
 Homotopy type theory is thus compatible with both constructive and classical conceptions of logic, and many more besides.
 
 \index{axiom!of choice}%
-More specifically, consider on one hand the \emph{axiom of choice}: ``if for every $x: A$ there exists a $y:B$ such that $R(x,y)$, there is a function $f : A\to B$ such that for all $x:A$ we have $R(x, f(x))$.''
+More specifically, consider on one hand the \emph{axiom of choice}: ``if for every $x: A$ there exists a $y:B$ such that $R(x,y)$, there is a function $f : A\to B$ such that for all $x:A$ we have $R(x, f(x))$''.
 The pure propositions-as-types notion of ``there exists'' is strong enough to make this statement simply provable --- yet it does not have all the consequences of the usual axiom of choice.
 However, in $(-1)$-truncated logic, this statement is not automatically true, but is a strong assumption with the same sorts of consequences as its counterpart in classical\index{mathematics!classical} set theory.
 
 \index{excluded middle}%
 \index{univalence axiom}%
-On the other hand, consider the \emph{law of excluded middle}: ``for all $A$, either $A$ or not $A$.''
+On the other hand, consider the \emph{law of excluded middle}: ``for all $A$, either $A$ or not $A$''.
 Interpreting this in the pure propositions-as-types logic yields a statement that is inconsistent with the univalence axiom.
 For since proving ``$A$'' means exhibiting an element of it, this assumption would give a uniform way of selecting an element from every nonempty type --- a sort of Hilbertian choice operator.
 Univalence implies that the element of $A$ selected by such a choice operator must be invariant under all self-equivalences of $A$, since these are identified with self-identities and every operation must respect identity; but clearly some types have automorphisms with no fixed points, e.g.\ we can swap the elements of a two-element type.


### PR DESCRIPTION
I've noticed that somehow 2 instance of the US quoting style are still in the last master branch after my old pull requests. To keep the style uniform across the book i've created this last request. 
