### PR TITLE
Deleted an obsolete sentence

### DIFF
--- a/induction.tex
+++ b/induction.tex
@@ -82,9 +82,7 @@ This gives us the following induction principle:
 \item When proving a statement $E : \nat \to \type$ about \emph{all} natural numbers, it suffices to prove it for $0$ and for $\suc(n)$, assuming it holds
 for $n$, i.e., we construct $e_z : E(0)$ and $e_s : \prd{n : \nat} E(n) \to E(\suc(n))$.
 \end{itemize}
-The variable
-\index{variable}%
-$y$ represents our inductive hypothesis.  As in the case of booleans, we also have the associated computation rules for the function $\ind\nat(E,e_z,e_s) : \prd{x:\nat} E(x)$:
+As in the case of booleans, we also have the associated computation rules for the function $\ind\nat(E,e_z,e_s) : \prd{x:\nat} E(x)$:
 \index{computation rule!for natural numbers}%
 \begin{itemize}
 \item $\ind\nat(E,e_z,e_s,0) \jdeq e_z$.


### PR DESCRIPTION
The variable y doesn't exist anymore, it came from a previous version where the type E(n) \to E(\suc(n)) was expressed as a pi type with y : E(n)
