### PR TITLE
clash of notations between pairing and union

### DIFF
--- a/setmath.tex
+++ b/setmath.tex
@@ -1613,7 +1613,7 @@ For every $u:V$ there is a given $A_u:\UU$ and monic $m_u: A_u \mono V$ such tha
     %
      \item \emph{empty set:} for all $x:V$, we have $\neg (x\in \emptyset)$.
     %
-    \item \emph{pairing:} for all $u, v:V$, the class $u\cup v \defeq \setof{ x | x = u \vee x = v}$ is a $V$-set.
+    \item \emph{pairing:} for all $u, v:V$, the class $\{u, v\} \defeq \setof{ x | x = u \vee x = v}$ is a $V$-set.
       %
     \item \emph{infinity:}\index{axiom!of infinity}  there is a $v:V$ with $\emptyset\in v$ and $x\in v$ implies $x\cup \{x\}\in v$.
     %


### PR DESCRIPTION
The \cup notation for the pairing seems strange, and clashes with the \cup in the axiom of infinity next line, which seems to denote the actual union of sets
