### PR TITLE
Clarify the notations in 10.8.5.(viii)

### DIFF
--- a/setmath.tex
+++ b/setmath.tex
@@ -1624,10 +1624,10 @@ For every $u:V$ there is a given $A_u:\UU$ and monic $m_u: A_u \mono V$ such tha
     %
    \item \emph{$\in$-induction:} if $C : V \to \prop$ is a class such that $C(a)$ holds whenever $C(x)$ for all $x\in a$, then $C(v)$ for all $v:V$.
    %
-     \item \emph{replacement:}\index{axiom!of replacement} given any $r : V \to V$ and $a : V$, the class
+     \item \emph{replacement:}\index{axiom!of replacement} given any $r : V \to V$ and $x : V$, the class
        %
        \begin{equation*}
-         \setof{ x | \exis{y : V} y \in a \land x = r(y)}
+         \setof{ y | \exis{z : V} z \in x \land y = r(z)}
        \end{equation*}
        %
        is a $V$-set.
@@ -1669,7 +1669,8 @@ For every $u:V$ there is a given $A_u:\UU$ and monic $m_u: A_u \mono V$ such tha
 
   \item $\in$-induction: let $C : V \to \prop$ be a class such that $C(a)$ holds whenever $C(x)$ for all $x\in a$, and take any $v=\vset(B,g)$.  To show that $C(v)$ by induction, assume that $C(g(b))$ for all $b:B$.  For every $x\in v$ there merely exists some $b:B$ with $x = g(b)$, and so $C(x)$.  Thus $C(v)$.
 
-  \item Replacement: the statement ``$C$ is a $V$-set'' is a mere proposition, so we may
+  \item Replacement: let $C$ denote the class in question.
+    The statement ``$C$ is a $V$-set'' is a mere proposition, so we may
     proceed by induction as follows. Supposing $x$ is $\vset(A, f)$, we claim that $w
     \defeq \vset(A, r \circ f)$ is the set we are looking for.  If $C(y)$ then there merely exists
     $z : V$ and $a : A$ such that $z = f(a)$ and $y = r(z)$, therefore $y \in w$.


### PR DESCRIPTION
I renamed some variables to have coherent notations between the theorem and its proof. Also included mikeshulman's remark about the class C in the proof.

(I deleted the other pull request because of some bad manipulation I couldn't fix, sorry about that I'm new to git)
