### PR TITLE
Capitalise proper nouns in reference titles

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -510,7 +510,7 @@
 	Journal = {Typed lambda calculi and applications},
 	Note = {\href{http://arxiv.org/abs/0812.0409/}{arXiv:0812.0409}},
 	Pages = {1--19},
-	Title = {Weak omega-categories from intensional type theory},
+	Title = {Weak $\omega$-categories from intensional type theory},
 	Url = {http://www.springerlink.com/index/k5w4n04273035095.pdf},
 	Volume = {6},
 	Year = {2010},


### PR DESCRIPTION
There are other capitalised words in references.bib which are lowercased in the pdf. I don't know if these should be changed as well.
