### PR TITLE
Fix ind(D,d,x,y,p) in (i), (ii) and (iii) of Lemma 2.1.4

### DIFF
--- a/basics.tex
+++ b/basics.tex
@@ -417,7 +417,7 @@ It is a familiar fact in topology that when we concatenate a path $p$ with the r
     \begin{equation*}
       d\defeq\lam{x} \refl{\refl{x}}:\prd{x:A} D(x,x,\refl{x}).
     \end{equation*}
-    Now the induction principle for identity types gives an element $\indid{A}(D,d,p):(p= p\ct\refl{y})$ for each $p:x= y$.
+    Now the induction principle for identity types gives an element $\indid{A}(D,d,x,y,p):(p= p\ct\refl{y})$ for each $p:x= y$.
     The other equality is proven similarly.
 
     \mentalpause
@@ -435,7 +435,7 @@ It is a familiar fact in topology that when we concatenate a path $p$ with the r
     \begin{equation*}
       d\defeq\lam{x} \refl{\refl{x}}:\prd{x:A} D(x,x,\refl{x}).
     \end{equation*}
-    Now path induction gives an element $\indid{A}(D,d,p):\opp{p}\ct p=\refl{y}$ for each $p:x= y$ in $A$.
+    Now path induction gives an element $\indid{A}(D,d,x,y,p):\opp{p}\ct p=\refl{y}$ for each $p:x= y$ in $A$.
     The other equality is similar.
 
     \mentalpause
@@ -453,7 +453,7 @@ It is a familiar fact in topology that when we concatenate a path $p$ with the r
     \begin{equation*}
       d\defeq\lam{x} \refl{\refl{x}}:\prd{x:A} D(x,x,\refl{x}).
     \end{equation*}
-    Now path induction gives an element $\indid{A}(D,d,p):\opp{\opp{p}}= p$ for each $p:x= y$.
+    Now path induction gives an element $\indid{A}(D,d,x,y,p):\opp{\opp{p}}= p$ for each $p:x= y$.
 
     \mentalpause
 


### PR DESCRIPTION
If I understand Section 1.12.1 (Path induction) correctly, ind(D,d) : \Pi_{x,y : A} \Pi_{p : x = y} D(x,y,p) where d : \Pi_{x : A} D(x,x,refl_x). There may be some convention that I have overlooked on my first reading of the book but I thought in reviewing the proof of Lemma 2.1.4 (i), (ii) and (iii) that it would require a small fix to be consistent with the path induction principle given in Section 1.12.1.

With kind regards,
Alex
