### PR TITLE
sigma instead of exists in the proof of 10.5.8.(ix)

### DIFF
--- a/setmath.tex
+++ b/setmath.tex
@@ -1688,7 +1688,7 @@ For every $u:V$ there is a given $A_u:\UU$ and monic $m_u: A_u \mono V$ such tha
   \end{equation*}
   %
   is a $V$-set.
-We need to show that any $\UU$-small  $C: V \to \propU$ is separable. Indeed, given $a=\vset(A,f)$, let $A' = \exis{x:A}C(fx)$, and take $f' = f\circ i$, where $i : A' \to A$ is the obvious inclusion.  Then we can take $a' = \vset(A',f')$ and we have $x\in a\wedge C(x) \Leftrightarrow x\in a'$ as claimed.  We needed the assumption that $C$ lands in $\UU$ in order for $A' = \exis{x:A}C(fx)$ to be in $\UU$.\qedhere
+We need to show that any $\UU$-small  $C: V \to \propU$ is separable. Indeed, given $a=\vset(A,f)$, let $A' = \sm{x:A}C(fx)$, and take $f' = f\circ i$, where $i : A' \to A$ is the obvious inclusion.  Then we can take $a' = \vset(A',f')$ and we have $x\in a\wedge C(x) \Leftrightarrow x\in a'$ as claimed.  We needed the assumption that $C$ lands in $\UU$ in order for $A' = \sm{x:A}C(fx)$ to be in $\UU$.\qedhere
 \end{enumerate}
 \end{proof}
 


### PR DESCRIPTION
The idea is that we want A' to be the subset of A (in the sense of §3.5) such that C(f x).
So the sigma mustn't be truncated, otherwise we cannot define the inclusion i : A' -> A.

Jérémy
