### PR TITLE
Last rule of Section A.2.2, lines 591 and 592

### DIFF
--- a/formal.tex
+++ b/formal.tex
@@ -588,8 +588,8 @@ assume that judgmental equality is an equivalence relation respected by typing.
 Additionally, for all the type formers below, we assume rules stating that each constructor preserves definitional equality in each of its arguments; for instance, along with the $\Pi$-\rintro\ rule, we assume the rule
 \[
   \inferrule*[right=$\Pi$-\rintro-eq]
-  {\jdeqtp\Gamma{A}{A'}{\UU_i} \\
-   \jdeqtp{\Gamma,\tmtp xA}{B}{B'}{\UU_i} \\
+  {\oftp\Gamma{A}{\UU_i} \\
+   \oftp{\Gamma,\tmtp xA}{B}{\UU_i} \\
    \jdeqtp{\Gamma,\tmtp xA}{b}{b'}{B}}
   {\jdeqtp\Gamma{\lamu{x:A} b}{\lamu{x:A'} b'}{\tprd{x:A} B}}
 \]


### PR DESCRIPTION
In the last rule of Section A.2.2 I put
- A : \UU_i instead of A \equiv A' : \UU_i in the first hypothesis, and 
- B : \UU_i instead of B \equiv B' : \UU_i in the second hypothesis.

(See lines 591 and 592 of https://github.com/HoTT/book/blob/master/formal.tex#L591.)

I think this corrects a typo, but I am far from being sure I am right.
