### PR TITLE
Type theoretical axiom of choice, Section 1.6

### DIFF
--- a/preliminaries.tex
+++ b/preliminaries.tex
@@ -817,14 +817,14 @@ with the defining equation
 As before, the recursor is the special case of induction
 when the family $C$ is constant.
 
-As a further example, consider the following principle, where $A$ and $B$ are types and $R:A\to B\to \UU$.
+As a further example, consider the following principle, where $A$ and $B$ are types and $R:A\to B\to \UU$. We shall define
 \[ \ac : \Parens{\tprd{x:A} \tsm{y :B} R(x,y)} \to
-\Parens{\tsm{f:A\to B} \tprd{x:A} R(x,f(x))}
+\Parens{\tsm{f:A\to B} \tprd{x:A} R(x,f(x))}.
 \]
 We may regard $R$ as a ``proof-relevant relation''
 \index{mathematics!proof-relevant}%
 between $A$ and $B$, with $R(a,b)$ the type of witnesses for relatedness of $a:A$ and $b:B$.
-Then $\ac$ says intuitively that if we have a dependent function $g$ assigning to every $a:A$ a dependent pair $(b,r)$ where $b:B$ and $r:R(a,b)$, then we have a function $f:A\to B$ and a dependent function assigning to every $a:A$ a witness that $R(a,f(a))$.
+Then $\ac$ will say intuitively that if we have a dependent function $g$ assigning to every $a:A$ a dependent pair $(b,r)$ where $b:B$ and $r:R(a,b)$, then we have a function $f:A\to B$ and a dependent function assigning to every $a:A$ a witness that $R(a,f(a))$.
 Our intuition tells us that we can just split up the values of $g$ into their components.
 Indeed, using the projections we have just defined, we can define:
 \[ \ac(g) \defeq \Parens{\lamu{x:A} \fst(g(x)),\, \lamu{x:A} \snd(g(x))}. \]


### PR DESCRIPTION
This is about lines 820 to 827 of

https://github.com/HoTT/book/blob/master/preliminaries.tex#L820.

Since there is a display ending with no punctuation mark between two complete sentences, I believe something needs to be fixed, but, even if I am right, there is probably a better fix.
