### PR TITLE
Path induction

### DIFF
--- a/preliminaries.tex
+++ b/preliminaries.tex
@@ -1759,19 +1759,19 @@ all possible instantiations of based path induction at once.
 Define
 \begin{align*}
 D &: \prd{x,y:A} (\id[A]{x}{y}) \to \UU, \\
-D(x,y,p) &\defeq \prd{C : \prd{z:A} (\id[A]{x}{z}) \to \UU} C(x,\refl{x}) \to C(y,p).
+D(x,y,p) &\defeq C(x,\refl{x}) \to C(y,p).
 \end{align*}
 Then we can construct the function
 \begin{align*}
 d &: \prd{x : A} D(x,x,\refl{x}), \\
-d &\defeq \lamu{x:A}\lamu{C:\prd{z:A}{p : \id[A]{x}{z}} \UU}\lam{c:C(x,\refl{x})} c
+d &\defeq \lamu{x:A}\lam{e:C(x,\refl{x})} e
 \end{align*}
 and hence using path induction obtain
 \[ f : \prd{x,y:A}{p:\id[A]{x}{y}} D(x,y,p) \]
 with $f(x,x,\refl{x}) \defeq d(x)$. Unfolding the definition of $D$, we can expand the type of $f$:
-\[ f : \prd{x,y:A}{p:\id[A]{x}{y}}{C : \prd{z:A} (\id[A]{x}{z}) \to \UU} C(x,\refl{x}) \to C(y,p). \]
+\[ f : \prd{x,y:A}{p:\id[A]{x}{y}} C(x,\refl{x}) \to C(y,p). \]
 Now given $x:A$ and $p:\id[A]{a}{x}$, we can derive the conclusion of based path induction:
-\[ f(a,x,p,C,c) : C(x,p). \]
+\[ f(a,x,p,c) : C(x,p). \]
 Notice that we also obtain the correct definitional equality.
 
 Another proof is to observe that any use of based path induction is an instance of $\indidb{A}$  and to define
@@ -1780,9 +1780,9 @@ Another proof is to observe that any use of based path induction is an instance 
 \indid{A}
   \begin{aligned}[t]
     \big(
-    &\big(\lamu{x,y:A}{p:\id[A]{x}{y}} \tprd{C : \prd{z:A} (\id[A]{x}{z}) \to \UU} C(x,\refl{x}) \to C(y,p) \big),\\
-    &(\lamu{x:A}{C:\prd{z:A} (\id[A]{x}{z}) \to \UU}{d:C(x,\refl{x})} d),
-     a, x, p, C, c \big) 
+    &\big(\lamu{u:A}{y:A}{q:\id[A]{u}{y}} C(u,\refl{u}) \to C(y,q) \big),
+    (\lamu{v:A}{e:C(v,\refl{v})} e),
+     a, x, p, c \big).  
    \end{aligned}
 \end{narrowmultline*}
 


### PR DESCRIPTION
I tried to correct a few typos.

Independently of the changes proposed in this pull request, I think we might insert a sentence before the "Define" on line 1759 https://github.com/HoTT/book/blob/master/preliminaries.tex#L1759 to introduce the element a:A, the family C(y,p):U, and the element c:C(a,refl_a).
