### PR TITLE
Replace pi notation for non-dependent functions

### DIFF
--- a/basics.tex
+++ b/basics.tex
@@ -466,7 +466,7 @@ It is a familiar fact in topology that when we concatenate a path $p$ with the r
     \begin{equation*}
       \prd{z,w:A}{q:x= z}{r:z= w} \big(\refl{x}\ct(q\ct r)= (\refl{x}\ct q)\ct r\big).
     \end{equation*}
-    To construct an element of this type, let $D_2:\prd{x,z:A}{q:x=z} \type$ be the type family
+    To construct an element of this type, let $D_2:\prd{x,z:A} (x=z) \to \type$ be the type family
     \begin{equation*}
       D_2 (x,z,q) \defeq \prd{w:A}{r:z=w} \big(\refl{x}\ct(q\ct r)= (\refl{x}\ct q)\ct r\big).
     \end{equation*}
@@ -474,7 +474,7 @@ It is a familiar fact in topology that when we concatenate a path $p$ with the r
     \begin{equation*}
       \prd{w:A}{r:x=w} \big(\refl{x}\ct(\refl{x}\ct r)= (\refl{x}\ct \refl{x})\ct r\big).
     \end{equation*}
-    To construct an element of \emph{this} type, let $D_3:\prd{x,w:A}{r:x=w} \type$ be the type family
+    To construct an element of \emph{this} type, let $D_3:\prd{x,w:A} (x=w) \to \type$ be the type family
     \begin{equation*}
       D_3(x,w,r) \defeq \big(\refl{x}\ct(\refl{x}\ct r)= (\refl{x}\ct \refl{x})\ct r\big).
     \end{equation*}


### PR DESCRIPTION
The style convention that ∏(x:A)B should be replaced with A -> B, if B is not dependent on x is not followed in the proof for associativity of concatenation. This commit fixes this.