### PR TITLE
minor correction concerning "idtoeqv" as an elimination rule

### DIFF
--- a/basics.tex
+++ b/basics.tex
@@ -1743,9 +1743,9 @@ As we did in previous sections, it is useful to break this equivalence into:
   \[
   \ua : ({\eqv A B}) \to (\id[\type]{A}{B}).
   \]
-\item The elimination rule, which is $\idtoeqv$,
+\item The elimination rule,
   \[
-  \idtoeqv \jdeq \transfibf{X \mapsto X} : (\id[\type]{A}{B}) \to (\eqv A B).
+  \idtoeqv : (\id[\type]{A}{B}) \to (\eqv A B).
   \]
 \item The propositional computation rule\index{computation rule!propositional!for univalence},
   \[


### PR DESCRIPTION
$transport^{X \mapsto X}(p)$ would be of type "A -> B", not of type "A \equiv B".