### PR TITLE
Fix the nightly build script (hopefully)

### DIFF
--- a/etc/ci/update_nightlies.sh
+++ b/etc/ci/update_nightlies.sh
@@ -106,8 +106,8 @@ fi
 
 git reset --hard || exit 1
 
-(git rebase origin gh-pages && git cherry-pick "$NIGHTLY_COMMIT" && "$DIR"/push_remote.sh HEAD:gh-pages) || exit 1
+(git remote update && git checkout origin/gh-pages && git cherry-pick "$NIGHTLY_COMMIT" && "$DIR"/push_remote.sh HEAD:gh-pages) || exit 1
 
-(cd book.wiki && git push origin HEAD:gh-pages) || exit 1
+(cd book.wiki && git push origin HEAD:master) || exit 1
 
 popd 1>/dev/null

--- a/etc/ci/update_nightlies.sh
+++ b/etc/ci/update_nightlies.sh
@@ -47,6 +47,7 @@ PDFS="$(grep '^NIGHTLY: ' build-nightlies.log | sed s'/^NIGHTLY: //g')"
 WIKIPAGE="$(grep '^NIGHTLY-WIKI: ' build-nightlies.log | sed s'/^NIGHTLY-WIKI: //g')"
 
 "$DIR"/configure_commit.sh || exit 1
+git remote -v
 git branch -a
 git --no-pager diff HEAD
 git --no-pager diff HEAD..origin/master
@@ -70,6 +71,10 @@ git mv $PDFS nightly/ || exit 1
 
 git commit -m "Update nightly builds (auto)" || exit 1
 NIGHTLY_COMMIT="$(git rev-parse HEAD)"
+
+git --no-pager diff HEAD
+git --no-pager diff HEAD..origin/gh-pages
+git --no-pager diff HEAD..upstream/gh-pages
 
 git clone https://github.com/HoTT/book.wiki.git || exit 1
 


### PR DESCRIPTION
Previously, the cherry-pick failed because rebasing did not discard the commit.
It's not entirely clear if we should use rebase or checkout+cherry-pick; they
should be equivalent, so it shouldn't matter.  I think checkout+cherry-pick
will be slightly more robust, e.g., with respect to other people modifying
history.