### PR TITLE
fix typo

### DIFF
--- a/induction.tex
+++ b/induction.tex
@@ -1200,7 +1200,7 @@ We can deduce a similar result for identity types $=_A$, regarded as a family va
 
 \begin{defn}
   An \define{identity system}
-  over a type $A$ is a family $R:A\to A\to \type$ equipped with a function $r_0:\prd{a:A} R(a,a)$ such that for any type family $D:\prd{a,b:A} R(a,b) \to \type$ and $d:\prd{a:A} D(a,a,r_0(a))$, there exists a function $f:\prd{a,b:A}{r:R(b)} D(a,b,r)$ such that $f(a,a,r_0(a))=d(a)$ for all $a:A$.
+  over a type $A$ is a family $R:A\to A\to \type$ equipped with a function $r_0:\prd{a:A} R(a,a)$ such that for any type family $D:\prd{a,b:A} R(a,b) \to \type$ and $d:\prd{a:A} D(a,a,r_0(a))$, there exists a function $f:\prd{a,b:A}{r:R(a,b)} D(a,b,r)$ such that $f(a,a,r_0(a))=d(a)$ for all $a:A$.
 \end{defn}
 
 \begin{thm}\label{thm:ML-identity-systems}


### PR DESCRIPTION
"r:R(a,b)"