### PR TITLE
Checkout upstream/gh-pages, not origin/gh-pages, for nightly builds

### DIFF
--- a/etc/ci/update_nightlies.sh
+++ b/etc/ci/update_nightlies.sh
@@ -111,7 +111,7 @@ fi
 
 git reset --hard || exit 1
 
-(git remote update && git checkout origin/gh-pages && git cherry-pick "$NIGHTLY_COMMIT" && "$DIR"/push_remote.sh HEAD:gh-pages) || exit 1
+(git remote update && git checkout upstream/gh-pages && git cherry-pick "$NIGHTLY_COMMIT" && "$DIR"/push_remote.sh HEAD:gh-pages) || exit 1
 
 (cd book.wiki && git push origin HEAD:master) || exit 1
 


### PR DESCRIPTION
It shouldn't make a difference, but travis seems to think that
origin/gh-pages does not exist, but upstream/gh-pages does, even though
they point to the same url, and even after a `git remote update`...  So
we will use upstream/gh-pages.  Hopefully this will finally fix the
nightly builds.