### PR TITLE
Fix the travis push script

### DIFF
--- a/etc/ci/checkout-and-cherry-pick-and-push.sh
+++ b/etc/ci/checkout-and-cherry-pick-and-push.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+PS4='$ '
+set -x
+
+# in case we're run from out of git repo
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd "$DIR" 1>/dev/null
+
+# now change to the git root
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+BASE_BRANCH="$1"
+COMMIT_TO_CHERRY_PICK="$2"
+REMOTE_BRANCH="$3"
+
+MASTER_COMMIT="$(git rev-parse HEAD)"
+
+git remote update || exit 1
+git reset --hard || exit 1
+git checkout "$BASE_BRANCH" || exit 1
+git cherry-pick "$COMMIT_TO_CHERRY_PICK" || exit 1
+COMMIT_TO_PUSH="$(git rev-parse HEAD)"
+git checkout "$MASTER_COMMIT" || exit 1
+"$DIR"/push_remote.sh "$COMMIT_TO_PUSH:$REMOTE_BRANCH" || exit 1
+git checkout "$MASTER_COMMIT" || exit 1
+
+popd 1>/dev/null

--- a/etc/ci/update_nightlies.sh
+++ b/etc/ci/update_nightlies.sh
@@ -58,6 +58,8 @@ UPSTREAM_LOG="$(git log HEAD..upstream/master)"
 #MASTER_LOG="$(git log HEAD..master)"
 #ORIGIN_LOG="$(git log HEAD..origin/master)"
 
+MASTER_COMMIT="$(git rev-parse HEAD)"
+
 git checkout -b gh-pages upstream/gh-pages || exit 1
 
 git rm -rf nightly || true
@@ -111,7 +113,9 @@ fi
 
 git reset --hard || exit 1
 
-(git remote update && git checkout upstream/gh-pages && git cherry-pick "$NIGHTLY_COMMIT" && "$DIR"/push_remote.sh HEAD:gh-pages) || exit 1
+git checkout "$MASTER_COMMIT"
+
+"$DIR"/checkout-and-cherry-pick-and-push.sh upstream/gh-pages "$NIGHTLY_COMMIT" gh-pages || exit 1
 
 (cd book.wiki && git push origin HEAD:master) || exit 1
 


### PR DESCRIPTION
The push_remote script did not exist when checked out to another branch.
So save the current commit hash before checking out the other branch,
and go back to it before pushing.  Also move the relevant logic into a
separate file.