### PR TITLE
fix typo & variable renaming

### DIFF
--- a/formal.tex
+++ b/formal.tex
@@ -411,18 +411,18 @@ as $\supp(x,u)$:
 %
 \begin{itemize}
 \item if $A:\UU_n$ and $B: A \rightarrow \UU_n$, then $\wtype{x:A}B(x) : \UU_n$
-\item if moreover, $a:A$ and $g:B(a)\rightarrow \wtype{x:A}B(x)$ then $\supp(a,g):\wtype{x:A}B(x)$.
+\item if moreover, $a:A$ and $u:B(a)\rightarrow \wtype{x:A}B(x)$ then $\supp(a,u):\wtype{x:A}B(x)$.
 \end{itemize}
 % 
 Here also we can define functions by total recursion. If we have $A$ and $B$
-as above and $C : \wtype{x:A}B(x) \rightarrow \UU_m$, then we can introduce a defined constant
+as above and $C : (\wtype{x:A}B(x)) \rightarrow \UU_m$, then we can introduce a defined constant
 $f:\tprd{z:\wtype{x:A}B(x)} C(z)$ whenever we have
 \[
-  d:\tprd{x:A}{u:B(x) \rightarrow \wtype{x:A}B(x)}((\tprd{y:B(x)}C(u(y))) \rightarrow C(\supp(x,u)))
+  d:\tprd{a:A}{u:B(a) \rightarrow \wtype{x:A}B(x)}((\tprd{y:B(a)}C(u(y))) \rightarrow C(\supp(a,u)))
 \]
 with the defining equation
 \[
-  f(\supp(x,u)) \defeq d(x,u,f\circ u).
+  f(\supp(a,u)) \defeq d(a,u,f\circ u).
 \]
 
 \subsection{Identity types}


### PR DESCRIPTION
I'm assuming that '\wtype' ("W-type") has about the same precedence as '\tprd' ("for all") and '\sm' ("exists").