### PR TITLE
emphasize that UA is required for pi_1(S^1)=Z, close #736

### DIFF
--- a/homotopy.tex
+++ b/homotopy.tex
@@ -785,6 +785,12 @@ This suggests a third approach.
 Of course, this proof also contains essentially the same elements as the previous two.
 Roughly, we can say that it unifies the proofs of \cref{thm:pi1s1-decode,lem:s1-encode-decode}, performing the requisite inductive argument only once in a generic case.
 
+\begin{rmk}
+  Note that all of the above proofs that $\pi_1(\Sn^1)=\Z$ use the univalence axiom in an essential way.
+  This is unavoidable: univalence or something like it is \emph{necessary} in order to prove $\pi_1(\Sn^1)=\Z$.
+  In the absence of univalence, it is consistent to assume the statement ``all types are sets'' (a.k.a.\ ``uniqueness of identity proofs'' or ``Axiom K'', as discussed in \cref{sec:hedberg}), and this statement implies instead that $\pi_1(\Sn^1) = \unit$.
+  In fact, the (non)triviality of $\pi_1(\Sn^1)$ detects exactly whether all types are sets: the proof of \cref{thm:loop-nontrivial} showed conversely that if $\lloop=\refl{\base}$ then all types are sets.
+\end{rmk}
 
 \section{Connectedness of suspensions}
 \label{sec:conn-susp}

--- a/homotopy.tex
+++ b/homotopy.tex
@@ -786,9 +786,9 @@ Of course, this proof also contains essentially the same elements as the previou
 Roughly, we can say that it unifies the proofs of \cref{thm:pi1s1-decode,lem:s1-encode-decode}, performing the requisite inductive argument only once in a generic case.
 
 \begin{rmk}
-  Note that all of the above proofs that $\pi_1(\Sn^1)=\Z$ use the univalence axiom in an essential way.
-  This is unavoidable: univalence or something like it is \emph{necessary} in order to prove $\pi_1(\Sn^1)=\Z$.
-  In the absence of univalence, it is consistent to assume the statement ``all types are sets'' (a.k.a.\ ``uniqueness of identity proofs'' or ``Axiom K'', as discussed in \cref{sec:hedberg}), and this statement implies instead that $\pi_1(\Sn^1) = \unit$.
+  Note that all of the above proofs that $\eqv{\pi_1(\Sn^1)}{\Z}$ use the univalence axiom in an essential way.
+  This is unavoidable: univalence or something like it is \emph{necessary} in order to prove $\eqv{\pi_1(\Sn^1)}{\Z}$.
+  In the absence of univalence, it is consistent to assume the statement ``all types are sets'' (a.k.a.\ ``uniqueness of identity proofs'' or ``Axiom K'', as discussed in \cref{sec:hedberg}), and this statement implies instead that $\eqv{\pi_1(\Sn^1)}{\unit}$.
   In fact, the (non)triviality of $\pi_1(\Sn^1)$ detects exactly whether all types are sets: the proof of \cref{thm:loop-nontrivial} showed conversely that if $\lloop=\refl{\base}$ then all types are sets.
 \end{rmk}
 


### PR DESCRIPTION
Since the {rmk} is added at the end of a section, it doesn't change the numbering of anything else, so it is allowable as an addition to the first edition.