### PR TITLE
removed hyphens in path-constructor (Issue #882)

### DIFF
--- a/errata.tex
+++ b/errata.tex
@@ -410,7 +410,7 @@ While the page numbering may differ between copies with different version marker
   %
   \cref{thm:equiv-iso-adj}
   & 275-g8ea9f71
-  & In the proof, the path concatenations in the definitions of $\epsilon'$ and $\tau$ were written in reverse order.\\
+  & In the proof, the path-concatenations in the definitions of $\epsilon'$ and $\tau$ were written in reverse order.\\
   %
   \cref{lem:coh-hprop}
   & 296-ge3dc076
@@ -597,7 +597,7 @@ While the page numbering may differ between copies with different version marker
   \cref{thm:flattening-rect}
   & 961-gde36592
   & The subscript of $\apfunc{}$ should also be $x\mapsto \cct'(g(b),x)$ in the third, fourth, and fifth displays.
-  In the fourth and fifth displays, the path-concatenations should be in the other order.
+  In the fourth and fifth displays, the path concatenations should be in the other order.
   And in the fifth display, $\refl{g(b)}$ should be $\refl{\cc(g(b))}$.\\
   %
   \cref{thm:ap-sigma-rect-path-pair}

--- a/errata.tex
+++ b/errata.tex
@@ -410,7 +410,7 @@ While the page numbering may differ between copies with different version marker
   %
   \cref{thm:equiv-iso-adj}
   & 275-g8ea9f71
-  & In the proof, the path-concatenations in the definitions of $\epsilon'$ and $\tau$ were written in reverse order.\\
+  & In the proof, the path concatenations in the definitions of $\epsilon'$ and $\tau$ were written in reverse order.\\
   %
   \cref{lem:coh-hprop}
   & 296-ge3dc076
@@ -597,7 +597,7 @@ While the page numbering may differ between copies with different version marker
   \cref{thm:flattening-rect}
   & 961-gde36592
   & The subscript of $\apfunc{}$ should also be $x\mapsto \cct'(g(b),x)$ in the third, fourth, and fifth displays.
-  In the fourth and fifth displays, the path concatenations should be in the other order.
+  In the fourth and fifth displays, the path-concatenations should be in the other order.
   And in the fifth display, $\refl{g(b)}$ should be $\refl{\cc(g(b))}$.\\
   %
   \cref{thm:ap-sigma-rect-path-pair}

--- a/hits.tex
+++ b/hits.tex
@@ -789,7 +789,7 @@ That is, we regard a disc\index{disc} as consisting of a cone point (or ``hub'')
   \label{fig:hub-and-spokes}
 \end{figure}
 
-We can use this idea to express higher inductive types containing $n$-dimensional path-con\-struc\-tors for $n>1$ in terms of ones containing only 1-di\-men\-sion\-al path-con\-struc\-tors.
+We can use this idea to express higher inductive types containing $n$-dimensional path con\-struc\-tors for $n>1$ in terms of ones containing only 1-di\-men\-sion\-al path con\-struc\-tors.
 The point is that we can obtain an $n$-dimensional path as a continuous family of 1-dimensional paths parametrized by an $(n-1)$-di\-men\-sion\-al object.
 The simplest $(n-1)$-dimensional object to use is the $(n-1)$-sphere, although in some cases a different one may be preferable.
 (Recall that we were able to define the spheres in \cref{sec:suspension} inductively using suspensions, which involve only 1-dimensional path constructors.
@@ -1438,7 +1438,7 @@ We will sometimes denote a function $f:\prd{z:\Z} P(z)$ obtained from \cref{thm:
   f(\suc(n)) &\defid d_+(n,f(n))\\
   f(-\suc(n)) &\defid d_-(n,f(-n))
 \end{align*}
-We use $\defid$ rather than $\defeq$, as we did for the path-constructors of higher inductive types, to indicate that the ``computation'' rules implied by \cref{thm:sign-induction} are only propositional equalities.
+We use $\defid$ rather than $\defeq$, as we did for the path constructors of higher inductive types, to indicate that the ``computation'' rules implied by \cref{thm:sign-induction} are only propositional equalities.
 For example, in this way we can define the $n$-fold concatenation of a loop for any integer $n$.
 
 \begin{cor}\label{thm:looptothe}

--- a/setmath.tex
+++ b/setmath.tex
@@ -1476,7 +1476,7 @@ The hierarchy $V$ is
 bootstrapped from the empty map $\rec\emptyt(V) : \emptyt \to V$, which gives the empty set as $\emptyset = \vset(\emptyt,\rec\emptyt(V))$.
 Then the singleton $\{\emptyset\}$ enters $V$ through $\unit \to V$, defined as $\ttt \mapsto \emptyset$, and so
 on.
-(The definition can also be adapted to include an arbitrary set of ``atoms'' or ``urelements'', by adding an additional point-constructor.)
+(The definition can also be adapted to include an arbitrary set of ``atoms'' or ``urelements'', by adding an additional point constructor.)
 The type $V$ lives in the same universe as the base universe $\UU$.
 
 The second constructor of $V$ has a form unlike any we have seen before: it involves not only paths in $V$ (which in \cref{sec:hittruncations} we claimed were slightly fishy) but truncations of sums of them.
@@ -1575,10 +1575,10 @@ For any $u,v:V$ we have $(u=_V v) = (u \bisim v)$.
 An easy induction shows that $\bisim$ is reflexive, so by transport we have $(u=_V v)\to (u \bisim v)$.
 Thus, it remains to show that $(u \bisim v)\to (u=_V v)$.
 By induction on $u$ and $v$, we may assume they are $\vset(A,f)$ and $\vset(B,g)$ respectively.
-(We can ignore the path-constructors of $V$, since $(u \bisim v)\to (u=_V v)$ is a mere proposition.)
+(We can ignore the path constructors of $V$, since $(u \bisim v)\to (u=_V v)$ is a mere proposition.)
 Then by definition, $\vset(A,f)\bisim\vset(B,g)$ implies $(\fall{a:A}\exis{b:B}f(a)  \bisim g(b))$ and conversely.
 But the inductive hypothesis then tells us that $(\fall{a:A}\exis{b:B}f(a) = g(b))$ and conversely.
-So by the path-con\-struc\-tor for $V$ we have $\vset(A,f) =_V \vset(B,g)$.
+So by the path con\-struc\-tor for $V$ we have $\vset(A,f) =_V \vset(B,g)$.
 \end{proof}
 
 One might think that we could omit the 0-truncation constructor of $V$ and \emph{prove} that $V$ is 0-truncated by applying \cref{thm:h-set-refrel-in-paths-sets} to the bisimulation.

--- a/symbols.tex
+++ b/symbols.tex
@@ -41,7 +41,7 @@
 \symbolindex{$\ttt$	}{canonical inhabitant of $\unit$, \pg{sec:finite-product-types}}
 \symbolindex{$\bool$	}{type of booleans, \pg{sec:type-booleans}}
 \symbolindex{$\btrue$, $\bfalse$	}{constructors of $\bool$, \pg{sec:type-booleans}}
-\symbolindex{$\izero$, $\ione$	}{point-constructors of the interval $\interval$, \pg{sec:interval}}
+\symbolindex{$\izero$, $\ione$	}{point constructors of the interval $\interval$, \pg{sec:interval}}
 %%%%%%%%%% A %%%%%%%%%%
 \symbolindex{$\choice{}$	}{axiom of choice, \pg{eq:ac}}
 \symbolindex{$\choice{\infty}$	}{``type-theoretic axiom of choice'', \pg{thm:ttac}}
@@ -85,8 +85,8 @@
 \symbolindex{$\encode$	}{encoding function for paths, \pg{sec:compute-coprod}, \pg{S1-universal-cover}, \pg{sec:general-encode-decode}}
 \symbolindex{$\mreturn^\modal_A$ or $\mreturn_A$	}{the function $A\to\modal A$, \pg{defn:reflective-subuniverse} and \pg{defn:modality}}
 \symbolindex{$A \epi B$	}{epimorphism or surjection}
-\symbolindex{$\noeq(x,y)$	}{path-constructor of the surreals, \pg{defn:surreals}}
-\symbolindex{$\rceq(u,v)$	}{path-constructor of the Cauchy reals, \pg{defn:cauchy-reals}}
+\symbolindex{$\noeq(x,y)$	}{path constructor of the surreals, \pg{defn:surreals}}
+\symbolindex{$\rceq(u,v)$	}{path constructor of the Cauchy reals, \pg{defn:cauchy-reals}}
 \symbolindex{$a \eqr b$	}{an equivalence relation, \pg{equivalencerelation}}
 \symbolindex{$\eqv{X}{Y}$	}{type of equivalences, \pg{eq:eqv}}
 \symbolindex{$\texteqv{X}{Y}$	}{type of equivalences (same as $\eqv{X}{Y}$)}
@@ -162,7 +162,7 @@
 \symbolindex{$\rclim(x)$	}{limit of a Cauchy approximation, \pg{defn:cauchy-reals}}
 \symbolindex{$\linv(f)$	}{type of left inverses to $f$, \pg{defn:linv-rinv}}
 \symbolindex{$\lst{X}$	}{type of lists of elements of $X$, \pg{lst} and \pg{lst-freemonoid}}
-\symbolindex{$\lloop$	}{path-constructor of $\Sn^1$, \pg{sec:intro-hits}}
+\symbolindex{$\lloop$	}{path constructor of $\Sn^1$, \pg{sec:intro-hits}}
 %%%%%%%%%% M %%%%%%%%%%
 \symbolindex{$\Map_*(A,B)$	}{type of based maps, \pg{based-maps}}
 \symbolindex{$x\mapsto b$	}{alternative notation for $\lambda$-abstraction, \pg{mapsto}}
@@ -224,7 +224,7 @@
 %%%%%%%%%% S %%%%%%%%%%
 \symbolindex{$\south$	}{south pole of $\susp A$, \pg{sec:suspension}}
 \symbolindex{$\Sn^n$	}{$n$-dimensional sphere, \pg{sec:circle}}
-\symbolindex{$\seg$	}{path-constructor of the interval $\interval$, \pg{sec:interval}}
+\symbolindex{$\seg$	}{path constructor of the interval $\interval$, \pg{sec:interval}}
 \symbolindex{$\set$, $\setU$	}{universe of sets, \pg{setU}}
 \symbolindex{$\uset$	}{category of sets, \pg{ct:precatset}}
 \symbolindex{$\vset(A,f)$	}{constructor of the cumulative hierarchy, \pg{defn:V}}


### PR DESCRIPTION
This addresses Issue #882. I changed the occurrences of "path-constructor" to "path constructor", and analogously for "point-constructor", to make it consistent in the book.