### PR TITLE
8.4.4(iii): mention that we need to equate these as pointed maps

### DIFF
--- a/homotopy.tex
+++ b/homotopy.tex
@@ -1003,7 +1003,7 @@ space $Y$, the total space\index{total!space} $X$, and the fiber $F\defeq \hfib 
   \begin{enumerate}
   \item The fiber of $f^{(1)}\defeq \proj1 : \hfib f {y_0} \to X$ is equivalent to $\Omega Y$.\label{item:fibseq1}
   \item Similarly, the fiber of $f^{(2)} : \Omega Y \to \hfib f {y_0}$ is equivalent to $\Omega X$.\label{item:fibseq2}
-  \item Under these equivalences, the map $f^{(3)} : \Omega X\to \Omega Y$ is identified with $\Omega f\circ\rev{(\blank)}$.\label{item:fibseq3}
+  \item Under these equivalences, the pointed map $f^{(3)} : \Omega X\to \Omega Y$ is identified with the pointed map $\Omega f\circ\rev{(\blank)}$.\label{item:fibseq3}
   \end{enumerate}
 \end{lem}
 \begin{proof}
@@ -1024,7 +1024,7 @@ space $Y$, the total space\index{total!space} $X$, and the fiber $F\defeq \hfib 
   \cref{item:fibseq2} follows immediately by applying~\ref{item:fibseq1} to $f^{(1)}$ in place of $f$.
   % The resulting equivalence sends $(((x,p),p'),q') : \hfib{f^{(2)}}{(x_0,f_0)}$ to $\ap{f}{\opp {q'}} \ct p'$, while its inverse sends $s:x_0=x_0$ to $(((x_0,f_0), s), \refl{(x_0,f_0)})$.
   Since $(f^{(1)})_0 \defeq \refl{x_0}$, under this equivalence $f^{(3)}$ is identified with the map $\Omega X \to \hfib {f^{(1)}}{x_0}$ defined by $s \mapsto ((x_0,f_0),s)$.
-  Thus, when we compose with the previous equivalence $\hfib {f^{(1)}}{x_0} \eqvsym \Omega Y$, we see that $s$ maps to $\opp{f_0} \ct \ap{f}{\opp s} \ct f_0$, which is by definition $(\Omega f)(\opp s)$, giving~\ref{item:fibseq3}.
+  Thus, when we compose with the previous equivalence $\hfib {f^{(1)}}{x_0} \eqvsym \Omega Y$, we see that $s$ maps to $\opp{f_0} \ct \ap{f}{\opp s} \ct f_0$, which is by definition $(\Omega f)(\opp s)$. We omit the proof that this is an equality of pointed maps rather than just of functions.
 \end{proof}
 
 Thus, the fiber sequence of $f:X\to Y$ can be pictured as:


### PR DESCRIPTION
We need this, because otherwise we cannot prove that `f⁽⁶⁾` is identified with `Ω²(f)` (because to get a homotopy between `Ω(f⁽³⁾)` and `Ω²(f)` we need a *pointed* homotopy between `f⁽³⁾` and `Ω(f)`). Feel free to reword any of these changes; this might not be the best way to formulate it.