### PR TITLE
8.4.8: do k = 0 separately

### DIFF
--- a/exercise_solutions.tex
+++ b/exercise_solutions.tex
@@ -1441,6 +1441,32 @@ By \cref{ex:connectivity-inductively}, to show that $\prd{x:X} Y(x)$ is $(n+1)$-
 But also by \cref{ex:connectivity-inductively}, each $Y(x)$ is $(-1)$-connected and all its path types are $n$-connected.
 Applying function extensionality to characterize the path types of $\prd{x:X} Y(x)$, the claim follows from the $(-1)$-connected and $n$-connected axioms of choice.
 
+\subsection*{Solution to \cref{ex:is-conn-trunc-functor}}
+
+We distinguish the cases $k \le n$ and $k \ge n$. If $k \le n$, we know by
+Lemma~\ref{lem:connected-map-equiv-truncation} that $\trunc nf : \trunc nA \to \trunc nB$ is an
+equivalence. We can now prove that $\trunc kf$ is also an equivalence. This follows from the fact
+that $\trunc kf$ is homotopic to $\trunc k{\trunc nf}$, under the equivalence given by
+Lemma~\ref{lem:truncation-le}. This homotopy is easily proven by truncation induction. Now since
+$\trunc kf$ is an equivalence, it's clearly $n$-connected.
+
+If $k \ge n$ we apply Lemma~\ref{prop:nconnected_tested_by_lv_n_dependent types}. It is sufficient
+to show that the map $\lam{s} s\circ \trunc kf : \Parens{\prd{b:\trunc kB}
+P(b)}\to\Parens{\prd{a:\trunc kA}P(\trunc kf(a))}$ has a section, for all $P : \trunc
+kB\to\type$. We know that the map $\lam{s} s\circ f :\Parens{\prd{b:B}
+Q(b)}\to\Parens{\prd{a:A}Q(f(a))}$ has a section $g$, for $Q:B\to\type$ defined by $Q(b)\defeq
+P(\tproj kb)$. We define $h : \Parens{\prd{a:\trunc kA}P(\trunc kf(a))}\to\Parens{\prd{b:\trunc kB}
+P(b)}$ by $h(t,\tproj kb):\equiv g(t \circ \tprojf k, b)$. The function $h$ is indeed a section,
+which means that we need to show that for $t : \prd{a:\trunc kA}P(\trunc kf(a))$ we have
+$h(t)\circ \trunc kf = t$. By function extensionality and truncation induction, it is sufficient to
+show that the functions have the same value when applied to $\tproj ka$, for $a : A$. This follows
+from the following computation
+\begin{align*}
+  (h(t)\circ \trunc kf)(\tproj ka) & \equiv h(t, \tproj k{f(a)})\\
+  & \equiv g(t \circ \tprojf k, f(a)) \\
+  &= (t \circ \tprojf k)(a) \tag{since $g$ is a section of $\lam{s} s\circ f$}\\
+  & \equiv t(\tproj ka).
+\end{align*}
 
 \section*{Exercises from \cref{cha:homotopy}}
 
@@ -1570,7 +1596,7 @@ $j_{n+1}(i_n(y)) = j_{n+1}(\north_{n+1})$. Composing the proof of the first step
 with the proof of the second step we conclude the exercise.
 
 To construct a $D_{\blank} : \prd{n:\nat} j_n(\north_n) = j_0(\north_0)$ we
-proceed by induction on $n$. For the base case we can 
+proceed by induction on $n$. For the base case we can
 use $\refl{j_0(\north_0)}$. For the inductive case, we have by inductive
 hypothesis $j_n(\north_n) = j_0(\north_0)$. By our definition of $i_{\blank}$,
 we have that $\north_{n+1} \equiv i_n(\north_n)$. So $j_{n+1} (\north_{n+1})$
@@ -1677,7 +1703,7 @@ points $y_1,y_2 : Y$ are merely equal we can use the first point $y_1$ to get
 a pointed space $(Y,y_1)$, and then use the remark.
 
 We note that it suffices to show that for any $y_1,y_2:Y$ we have
-$\trunc {} {\hfib{f}{y_1} = \hfib{f}{y_2}}$ because 
+$\trunc {} {\hfib{f}{y_1} = \hfib{f}{y_2}}$ because
 $\hfib{f}{y_1} = \hfib{f}{y_2}$ implies (using $\idtoeqv$)
 $\hfib{f}{y_1}\simeq \hfib{f}{y_2}$
 and thus, by recursion on the truncation of $\hfib{f}{y_1} = \hfib{f}{y_2}$,

--- a/exercise_solutions.tex
+++ b/exercise_solutions.tex
@@ -1443,15 +1443,15 @@ Applying function extensionality to characterize the path types of $\prd{x:X} Y(
 
 \subsection*{Solution to \cref{ex:is-conn-trunc-functor}}
 
-We distinguish the cases $k \le n$ and $k \ge n$. If $k \le n$, we know by
-Lemma~\ref{lem:connected-map-equiv-truncation} that $\trunc nf : \trunc nA \to \trunc nB$ is an
+We distinguish the cases $k \le n$ and $k \ge n$. If $k \le n$, we know
+by \cref{lem:connected-map-equiv-truncation} that $\trunc nf : \trunc nA \to \trunc nB$ is an
 equivalence. We can now prove that $\trunc kf$ is also an equivalence. This follows from the fact
-that $\trunc kf$ is homotopic to $\trunc k{\trunc nf}$, under the equivalence given by
-Lemma~\ref{lem:truncation-le}. This homotopy is easily proven by truncation induction. Now since
+that $\trunc kf$ is homotopic to $\trunc k{\trunc nf}$, under the equivalence given
+by \cref{lem:truncation-le}. This homotopy is easily proven by truncation induction. Now since
 $\trunc kf$ is an equivalence, it's clearly $n$-connected.
 
-If $k \ge n$ we apply Lemma~\ref{prop:nconnected_tested_by_lv_n_dependent types}. It is sufficient
-to show that the map $\lam{s} s\circ \trunc kf : \Parens{\prd{b:\trunc kB}
+If $k \ge n$ we apply \cref{prop:nconnected_tested_by_lv_n_dependent types}. It is sufficient to
+show that the map $\lam{s} s\circ \trunc kf : \Parens{\prd{b:\trunc kB}
 P(b)}\to\Parens{\prd{a:\trunc kA}P(\trunc kf(a))}$ has a section, for all $P : \trunc
 kB\to\type$. We know that the map $\lam{s} s\circ f :\Parens{\prd{b:B}
 Q(b)}\to\Parens{\prd{a:A}Q(f(a))}$ has a section $g$, for $Q:B\to\type$ defined by $Q(b)\defeq

--- a/hlevels.tex
+++ b/hlevels.tex
@@ -2095,7 +2095,7 @@ The modalities we have considered in this chapter are all idempotent, whereas th
   \end{itemize}
   (This is a ``second-order approximation'' to a fully homotopy-theoretic notions of diagram and colimit, which ought to involve ``coherence paths'' of this sort at all higher levels.
   Defining such things in type theory is an important open problem.)
-  
+
   Exhibit a graph with composition $\Gamma$ such that $\Gamma_0$ is a set and each type $\Gamma_1(x,y)$ is a mere proposition, and a diagram $F$ over $\Gamma$ such that $F(x)=\unit$ for all $x$, for which $\colim(F)=\Sn^2$.
 \end{ex}
 
@@ -2103,6 +2103,10 @@ The modalities we have considered in this chapter are all idempotent, whereas th
   Comparing \cref{lem:nconnected_postcomp_variation,prop:nconn_fiber_to_total}, one might be tempted to conjecture that if $f:A\to B$ is $n$-connected and $g:\prd{a:A} P(a) \to Q(f(a))$ induces an $n$-connected map $\Parens{\sm{a:A} P(a)} \to \Parens{\sm{b:B} Q(b)}$, then $g$ is fiberwise $n$-connected.
   Give a counterexample to show that this is false.
   (In fact, when generalized to modalities, this property characterizes the left exact ones; see \cref{ex:prop-modalities}.)
+\end{ex}
+
+\begin{ex}\label{ex:is-conn-trunc-functor}
+  Show that if $f : A \to B$ is $n$-connected, then $\trunc kf : \trunc kA \to \trunc kB$ is also $n$-connected.
 \end{ex}
 
 %%% Local Variables:

--- a/homotopy.tex
+++ b/homotopy.tex
@@ -1153,12 +1153,12 @@ As an immediate application, we can now quantify in what way $n$-connectedness o
 \begin{cor}\label{thm:conn-pik}
   Let $f:A\to B$ be $n$-connected and $a:A$, and define $b\defeq f(a)$.  Then:
   \begin{enumerate}
-  \item If $k\le n$, then $\pi_k(f):\pi_k(A,a) \to \pi_k(B,b)$ is an isomorphism.
+  \item If $k\le n$, then $\pi_k(f):\pi_k(A,a) \to \pi_k(B,b)$ is an isomorphism.\label{item:conn-pik1}
   \item If $k=n+1$, then $\pi_k(f):\pi_k(A,a) \to \pi_k(B,b)$ is surjective.
   \end{enumerate}
 \end{cor}
 \begin{proof}
-  As part of the long exact sequence, for each $k$ we have an exact sequence
+  For $k=0$, part~\ref{item:conn-pik1} follows from Lemma~\ref{lem:connected-map-equiv-truncation}, noticing that $\pi_0(f)\equiv\trunc 0f$. For $k>0$ we have as part of the long exact sequence an exact sequence
   \[\xymatrix{\pi_k(\hfib f b) \ar[r]& \pi_k(A,a) \ar^f[r] & \pi_k(B,b) \ar[r] & \pi_{k-1}(\hfib f b).}\]
   Now since $f$ is $n$-connected, $\trunc n{\hfib f b}$ is contractible.
   Therefore, if $k\le n$, then $\pi_k(\hfib f b) = \trunc0{\Omega^k(\hfib f b)} = \Omega^k(\trunc k{\hfib f b})$ is also contractible.

--- a/homotopy.tex
+++ b/homotopy.tex
@@ -1158,8 +1158,8 @@ As an immediate application, we can now quantify in what way $n$-connectedness o
   \end{enumerate}
 \end{cor}
 \begin{proof}
-  For $k=0$, part~\ref{item:conn-pik1} follows from Lemma~\ref{lem:connected-map-equiv-truncation}, noticing that $\pi_0(f)\equiv\trunc 0f$.
-  For $k=0$ part~\ref{item:conn-pik2} follows from Exercise~\ref{ex:is-conn-trunc-functor}, noticing that a function is surjective iff it's $(-1)$-connected, by Lemma \ref{thm:minusoneconn-surjective}.
+  For $k=0$, part~\ref{item:conn-pik1} follows from \cref{lem:connected-map-equiv-truncation}, noticing that $\pi_0(f)\equiv\trunc 0f$.
+  For $k=0$ part~\ref{item:conn-pik2} follows from \cref{ex:is-conn-trunc-functor}, noticing that a function is surjective iff it's $(-1)$-connected, by \cref{thm:minusoneconn-surjective}.
   For $k>0$ we have as part of the long exact sequence an exact sequence
   \[\xymatrix{\pi_k(\hfib f b) \ar[r]& \pi_k(A,a) \ar^f[r] & \pi_k(B,b) \ar[r] & \pi_{k-1}(\hfib f b).}\]
   Now since $f$ is $n$-connected, $\trunc n{\hfib f b}$ is contractible.

--- a/homotopy.tex
+++ b/homotopy.tex
@@ -1154,11 +1154,13 @@ As an immediate application, we can now quantify in what way $n$-connectedness o
   Let $f:A\to B$ be $n$-connected and $a:A$, and define $b\defeq f(a)$.  Then:
   \begin{enumerate}
   \item If $k\le n$, then $\pi_k(f):\pi_k(A,a) \to \pi_k(B,b)$ is an isomorphism.\label{item:conn-pik1}
-  \item If $k=n+1$, then $\pi_k(f):\pi_k(A,a) \to \pi_k(B,b)$ is surjective.
+  \item If $k=n+1$, then $\pi_k(f):\pi_k(A,a) \to \pi_k(B,b)$ is surjective.\label{item:conn-pik2}
   \end{enumerate}
 \end{cor}
 \begin{proof}
-  For $k=0$, part~\ref{item:conn-pik1} follows from Lemma~\ref{lem:connected-map-equiv-truncation}, noticing that $\pi_0(f)\equiv\trunc 0f$. For $k>0$ we have as part of the long exact sequence an exact sequence
+  For $k=0$, part~\ref{item:conn-pik1} follows from Lemma~\ref{lem:connected-map-equiv-truncation}, noticing that $\pi_0(f)\equiv\trunc 0f$.
+  For $k=0$ part~\ref{item:conn-pik2} follows from Exercise~\ref{ex:is-conn-trunc-functor}, noticing that a function is surjective iff it's $(-1)$-connected, by Lemma \ref{thm:minusoneconn-surjective}.
+  For $k>0$ we have as part of the long exact sequence an exact sequence
   \[\xymatrix{\pi_k(\hfib f b) \ar[r]& \pi_k(A,a) \ar^f[r] & \pi_k(B,b) \ar[r] & \pi_{k-1}(\hfib f b).}\]
   Now since $f$ is $n$-connected, $\trunc n{\hfib f b}$ is contractible.
   Therefore, if $k\le n$, then $\pi_k(\hfib f b) = \trunc0{\Omega^k(\hfib f b)} = \Omega^k(\trunc k{\hfib f b})$ is also contractible.


### PR DESCRIPTION
The proof didn't work for `k=0`.