### PR TITLE
fix hole in the proof of Theorem 8.8.3

### DIFF
--- a/errata.tex
+++ b/errata.tex
@@ -695,6 +695,13 @@ While the page numbering may differ between copies with different version marker
   & 474-g5289470
   & $\pi_3(\Sn^2)=\Z$ should be stated as \cref{thm:pi3s2}, following from \cref{cor:pis2-hopf,thm:pinsn}.\\
   %
+  \cref{thm:whiteheadn}
+  & % merge of 1026-g8c2bc9d
+  & There was a hole in the last line of the proof of \cref{thm:whiteheadn}. After applying the
+  induction hypothesis, it needs to be checked that for any $p : a = a$ the map $\pi_k(\apfunc
+  f):\pi_k(x = x,p) \to \pi_k(f(x) = f(x),\apfunc f(p))$ is a bijection, while the proof only
+  checked this for $p\equiv\refl{a}$.\\
+  %
   % Chapter 9
   %
   \cref{ct:functor}

--- a/homotopy.tex
+++ b/homotopy.tex
@@ -2426,7 +2426,7 @@ Now we can prove the truncated Whitehead's principle.
 \begin{thm}\label{thm:whiteheadn}
   Suppose $A$ and $B$ are $n$-types and $f:A\to B$ is such that
   \begin{enumerate}
-  \item $\trunc0f:\trunc0A \to \trunc0B$ is an isomorphism, and\label{item:wh0}
+  \item $\trunc0f:\trunc0A \to \trunc0B$ is a bijection, and\label{item:wh0}
   \item $\pi_k(f):\pi_k(A,x) \to \pi_k(B,f(x))$ is a bijection for all $k\ge 1$ and all $x:A$.\label{item:whk}
   \end{enumerate}
   Then $f$ is an equivalence.
@@ -2440,7 +2440,16 @@ Condition~\ref{item:wh0} is almost the case of~\ref{item:whk} when $k=0$, except
   When $n=-2$, the statement is trivial.
   Thus, suppose it to be true for all functions between $n$-types, and let $A$ and $B$ be $(n+1)$-types and $f:A\to B$ as above.
   The first condition in \cref{thm:whitehead1} holds by assumption, so it will suffice to show that for any $x:A$, the function $\apfunc f: \Omega(A,x) \to \Omega(B,f(x))$ is an equivalence.
-  However, $\Omega(A,x)$ and $\Omega(B,f(x))$ are $n$-types, and $\pi_k(\apfunc f) = \pi_{k+1}(f)$, so this follows from the inductive hypothesis.
+  % in the following sentence we use \Vert instead of \trunc, because otherwise the vertical bars
+  % are so large it's ugly.
+  Since $\Omega(A,x)$ and $\Omega(B,f(x))$ are $n$-types we can apply the induction hypothesis.  We
+  need to check that $\Vert \apfunc f\Vert_0$ is a bijection and that for all $p : x = x$ the map
+  $\pi_k(\apfunc f):\pi_k(x = x,p) \to \pi_k(f(x) = f(x),\apfunc f(p))$ is a bijection for $k\geq1$.
+  The first statement is given, since $\Vert \apfunc f\Vert_0=\pi_1(f)$. To prove the second
+  statement, we generalize it first. We prove that for all $y : A$ and $p : x = y$ we have
+  $\pi_k(\apfunc f):\pi_k(x = y,p) \to \pi_k(f(x) = f(y),\apfunc f(p))$. To prove this, we use path
+  induction, so it's sufficient to prove it for $p \equiv \refl{a}$. In this case, we have
+  $\pi_k(\apfunc f) = \pi_{k+1}(f)$, and it's given that $\pi_{k+1}(f)$ is an bijection.
 \end{proof}
 
 Note that if $A$ and $B$ are not $n$-types for any finite $n$, then there is no way for the induction to get started.

--- a/homotopy.tex
+++ b/homotopy.tex
@@ -960,7 +960,7 @@ We call this the \define{zero map}\indexdef{zero!map}\indexdef{function!zero} an
 Recall that every pointed type $(X,x_0)$ has a loop space\index{loop space} $\Omega (X,x_0)$.
 We now note that this operation is functorial on pointed maps.\index{loop space!functoriality of}\index{functor!loop space}
 
-\begin{defn}
+\begin{defn}\label{def:loopfunctor}
   Given a pointed map between pointed types $f:X \to Y$, we define a pointed
   map $\Omega f:\Omega X
   \to \Omega Y$ by
@@ -2393,13 +2393,13 @@ It may be regarded as a type-theoretic, $\infty$-group\-oid\-al version of the c
   Hence $\hfib f b$ is inhabited, and thus merely inhabited.
 \end{proof}
 
-Since homotopy groups are truncations of loop spaces\index{loop space}, rather than path spaces, we need to modify this theorem to speak about these instead.
+Since homotopy groups are truncations of loop spaces\index{loop space}, rather than path spaces, we need to modify this theorem to speak about these instead. Recall the map $\Omega f$ from \cref{def:loopfunctor}.
 
 \begin{cor}\label{thm:whitehead1}
   Suppose $f:A\to B$ is a function such that
   \begin{enumerate}
   \item $\trunc0 f : \trunc0 A \to \trunc0 B$ is a bijection, and
-  \item for any $x:A$, the function $\apfunc f : \Omega(A,x) \to \Omega(B,f(x))$ is an equivalence.
+  \item for any $x:A$, the function $\Omega f : \Omega(A,x) \to \Omega(B,f(x))$ is an equivalence.
   \end{enumerate}
   Then $f$ is an equivalence.
 \end{cor}
@@ -2411,7 +2411,7 @@ Since homotopy groups are truncations of loop spaces\index{loop space}, rather t
   But now the following square commutes up to homotopy:
   \begin{equation*}
   \vcenter{\xymatrix@C=3pc{
-      \Omega(A,x)\ar[r]^-{\blank\ct p}\ar[d]_{\apfunc f} &
+      \Omega(A,x)\ar[r]^-{\blank\ct p}\ar[d]_{\Omega f} &
       (\id[A]xy) \ar[d]^{\apfunc f}\\
       \Omega(B,f(x))\ar[r]_-{\blank\ct f(p)} &
       (\id[B]{f(x)}{f(y)}).
@@ -2439,17 +2439,18 @@ Condition~\ref{item:wh0} is almost the case of~\ref{item:whk} when $k=0$, except
   We proceed by induction on $n$.
   When $n=-2$, the statement is trivial.
   Thus, suppose it to be true for all functions between $n$-types, and let $A$ and $B$ be $(n+1)$-types and $f:A\to B$ as above.
-  The first condition in \cref{thm:whitehead1} holds by assumption, so it will suffice to show that for any $x:A$, the function $\apfunc f: \Omega(A,x) \to \Omega(B,f(x))$ is an equivalence.
-  % in the following sentence we use \Vert instead of \trunc, because otherwise the vertical bars
-  % are so large it's ugly.
+  The first condition in \cref{thm:whitehead1} holds by assumption, so it will suffice to show that for any $x:A$, the function $\Omega f: \Omega(A,x) \to \Omega(B,f(x))$ is an equivalence.
+
   Since $\Omega(A,x)$ and $\Omega(B,f(x))$ are $n$-types we can apply the induction hypothesis.  We
-  need to check that $\Vert \apfunc f\Vert_0$ is a bijection and that for all $p : x = x$ the map
-  $\pi_k(\apfunc f):\pi_k(x = x,p) \to \pi_k(f(x) = f(x),\apfunc f(p))$ is a bijection for $k\geq1$.
-  The first statement is given, since $\Vert \apfunc f\Vert_0=\pi_1(f)$. To prove the second
-  statement, we generalize it first. We prove that for all $y : A$ and $p : x = y$ we have
-  $\pi_k(\apfunc f):\pi_k(x = y,p) \to \pi_k(f(x) = f(y),\apfunc f(p))$. To prove this, we use path
-  induction, so it's sufficient to prove it for $p \equiv \refl{a}$. In this case, we have
-  $\pi_k(\apfunc f) = \pi_{k+1}(f)$, and it's given that $\pi_{k+1}(f)$ is an bijection.
+  need to check that $\trunc 0{\Omega f}$ is a bijection and that for all $p : x = x$ the map
+  $\pi_k(\Omega f):\pi_k(x = x,p) \to \pi_k(f(x) = f(x),\Omega f(p))$ is a bijection for $k\geq1$.
+  The first statement is given, since $\trunc 0{\Omega f}=\pi_1(f)$. To prove the second statement,
+  we generalize it first. We prove that for all $y : A$ and $q : x = y$ we have $\pi_k(\apfunc
+  f):\pi_k(x = y,q) \to \pi_k(f(x) = f(y),\apfunc f(q))$. This is indeed a generalization, because
+  $\pi_k(\Omega f)=\pi_k(\apfunc f)$ if we identify the base points $\Omega f(p)=\apfunc f(p)$. To
+  prove the generalization, we use path induction, so it's sufficient to prove it for $q \equiv
+  \refl{a}$. In this case, we have $\pi_k(\apfunc f) = \pi_k(\Omega f) = \pi_{k+1}(f)$, and it's
+  given that $\pi_{k+1}(f)$ is an bijection.
 \end{proof}
 
 Note that if $A$ and $B$ are not $n$-types for any finite $n$, then there is no way for the induction to get started.


### PR DESCRIPTION
In the last line of the proof of theorem 8.8.3, it says

> (...) In this case, we have \pi_k(\ap_f) = \pi_{k+1}(f), and it's given that \pi_{k+1}(f) is a bijection.

Indeed, it's given that `\pi_{k+1}(f) : \pi_{k+1}(A, a) -> \pi_{k+1}(B, f(a))` is an bijection. However, to be able to apply the induction hypothesis, we need to prove that for all `p : a = a` the map
`\pi_k(ap_f) : \pi_k(a = a, p) -> \pi_k(f(a) = f(a), \ap_f(p))`. The sentence in the book only proves this for `p ≡ refl_a`. To prove the full statement, we can generalize `p` to a path from `a` to an arbitrary point `p` and apply path induction. Then it follows from the givens.

Two remarks about my changes:
- I also changed the word "isomorphism" to bijection in the theorem statement. "isomorphism" sounds like there is more structure which the map preserves
- I also went through all of section 8.8 and distinguished between the maps `ap_f : a = b -> f(a) = f(b)` and `\Omega f : \Omega(A,a) -> \Omega(B, f(a))`. These maps are not definitionally the same (even when `b ≡ a`) since the latter map composes with reflexivity on both sides. This comes back in the proof of Theorem 8.8.3, because the two maps

```
\pi_k(\Omega f)  : \pi_k(x = x,p) \to \pi_k(f(x) = f(x),\Omega f(p))
\pi_k(\apfunc f) : \pi_k(x = x,p) \to \pi_k(f(x) = f(x),\apfunc f(p))
```

have different types, because the base points `\Omega f(p)` and `\apfunc f(p)` are not definitionally equal. This means we cannot even ask whether these maps are homotopic (however, they are homotopic if we compose either of the maps with a map which is a change of basepoint). 

(note: in the last sentence I write `\pi_k(\apfunc f) = \pi_k(\Omega f)`, where in this case the - implicit - base point is reflexivity. In this case, these functions have the same type, since `\Omega f(\refl_a)` and `\apfunc f(\refl_a)` are both definitionally `\refl_{f(a)}`. So in this case, this equality type-checks)

A Lean formalization of this proof is at the bottom of [this file](https://github.com/fpvandoorn/lean/blob/personal/hott/homotopy/homotopy_group.hlean).
