### PR TITLE
6.4: fix induction principle for S²

### DIFF
--- a/errata.tex
+++ b/errata.tex
@@ -537,6 +537,10 @@ While the page numbering may differ between copies with different version marker
   & 327-g7cbe31c
   & In the first sentence after the proof of \cref{thm:apd2}, ``$P:\Sn^2\to P$'' should be ``$P:\Sn^2\to\type$''.\\
   %
+  \cref{sec:circle}
+  & % merge of 1037-g9a1fc9d
+  & In the sentence after the proof of \cref{thm:apd2}, the type family in which $s$ is a dependent path should be $\lam{p} \dpath P p b b$ instead of $P$.\\
+  %
   \cref{sec:cell-complexes}
   & 289-gdefeb8c
   & In the induction principle for the torus, the types of $p'$ and $q'$ should be $\dpath P p {b'} {b'}$ and $\dpath P q b b$ respectively.\\

--- a/hits.tex
+++ b/hits.tex
@@ -523,7 +523,7 @@ We can now state the dependent version of \cref{thm:ap2}.
 \end{proof}
 
 \index{induction principle!for S2@for $\Sn^2$}%
-Now we can state the induction principle for $\Sn^2$: given $P:\Sn^2\to\type$ with $b:P(\base)$ and $s:\dpath P \surf {\refl b}{\refl b}$, there is a function $f:\prd{x:\Sn^2} P(x)$ such that $f(\base)\jdeq b$ and $\apdtwo f \surf = s$.
+Now we can state the induction principle for $\Sn^2$: suppose we are given $P:\Sn^2\to\type$ with $b:P(\base)$ and $s:\dpath Q \surf {\refl b}{\refl b}$ where $Q\defeq\lam{p} \dpath P p b b$. Then there is a function $f:\prd{x:\Sn^2} P(x)$ such that $f(\base)\jdeq b$ and $\apdtwo f \surf = s$.
 
 \index{type!2-sphere|)}%
 


### PR DESCRIPTION
There was a mistake/typo in the induction principle for `S²`, the type family of the dependent path `s` was wrong.