### PR TITLE
Fix notation $\in V$

### DIFF
--- a/errata.tex
+++ b/errata.tex
@@ -757,6 +757,10 @@ While the page numbering may differ between copies with different version marker
   & 706-ged2c765
   & The proof that membership is well-defined should end with ``hence $x = g(b)$ and $x \in \vset(B,g)$.''\\
   %
+  \cref{sec:cumulative-hierarchy}
+  & % merge a6d82d7
+  & In the definition of $V$-set, the notation $v \in V$ should be $v:V$.\\
+  %
   \cref{thm:VisCST}
   & 708-g6f53189
   & In the pairing axiom, the pair class should be denoted $\{u, v\}$, not $u\cup v$.\\
@@ -769,12 +773,18 @@ While the page numbering may differ between copies with different version marker
   \cref{thm:VisCST}
   & 706-ged2c765
   & In the proof of the function set axiom, ``the types of elements $[u] \mono V$ and $[u] \mono V$'' should be ``the types of members $[u] \mono V$ and $[v] \mono V$.''\\
+  %
   \cref{ex:strong-collection}
   & % merge 0c4f868
   & Extra parentheses around $\fall{x\in v}\exis{y} R(x,y)$ are needed to make the formula unambiguous.\\
+  %
   \cref{ex:choice-cumulative-hierarchy-choice}
   & % merge c395527
   & Extra parentheses around $\fall{y\in x}\exis{z\in V} z\in y$ are needed to make the formula unambiguous.\\
+  %
+  \cref{ex:choice-cumulative-hierarchy-choice}
+  & % merge a6d82d7
+  & The notation $\in V$ should be $:V$.\\
   %
   % Chapter 11
   %

--- a/setmath.tex
+++ b/setmath.tex
@@ -1529,7 +1529,7 @@ A \define{class}
 may be taken to be a mere predicate on~$V$. We can say that a class $C : V \to \prop$ is a
 \define{$V$-set}
 \indexdef{set!in the cumulative hierarchy}%
-if there merely exists $v\in V$ such that
+if there merely exists $v:V$ such that
 %
 \begin{equation*}
   \fall{x : V} C(x) \Leftrightarrow x \in v.
@@ -1914,7 +1914,7 @@ The idea of algebraic set theory, which informs our development in \cref{sec:cum
 \begin{ex}\label{ex:choice-cumulative-hierarchy-choice}
 Verify that, if we assume $\choice{}$, then the cumulative hierarchy $V$ satisfies the usual set-theoretic axiom of choice, which may be stated in the form:
   \[
-   \fall{x\in V} \Parens{(\fall{y\in x}\exis{z\in V} z\in y) \Rightarrow  \exis{c\in(\cup x)^x}\fall{y\in x} c(y)\in y}
+   \fall{x:V} \Parens{(\fall{y\in x}\exis{z:V} z\in y) \Rightarrow  \exis{c\in(\cup x)^x}\fall{y\in x} c(y)\in y}
    \]
 \end{ex}
 


### PR DESCRIPTION
Fix https://github.com/HoTT/book/issues/912.
`\fall{? \in ?}` is not fixed because the definition is given in the proof of Corollary 10.5.9.