### PR TITLE
Fix errata (syntax of comment was wrong)

### DIFF
--- a/errata.tex
+++ b/errata.tex
@@ -758,7 +758,7 @@ While the page numbering may differ between copies with different version marker
   & The proof that membership is well-defined should end with ``hence $x = g(b)$ and $x \in \vset(B,g)$.''\\
   %
   \cref{sec:cumulative-hierarchy}
-  & % merge a6d82d7
+  & % merge of a6d82d7
   & In the definition of $V$-set, the notation $v \in V$ should be $v:V$.\\
   %
   \cref{thm:VisCST}
@@ -775,15 +775,15 @@ While the page numbering may differ between copies with different version marker
   & In the proof of the function set axiom, ``the types of elements $[u] \mono V$ and $[u] \mono V$'' should be ``the types of members $[u] \mono V$ and $[v] \mono V$.''\\
   %
   \cref{ex:strong-collection}
-  & % merge 0c4f868
+  & % merge of 0c4f868
   & Extra parentheses around $\fall{x\in v}\exis{y} R(x,y)$ are needed to make the formula unambiguous.\\
   %
   \cref{ex:choice-cumulative-hierarchy-choice}
-  & % merge c395527
+  & % merge of c395527
   & Extra parentheses around $\fall{y\in x}\exis{z\in V} z\in y$ are needed to make the formula unambiguous.\\
   %
   \cref{ex:choice-cumulative-hierarchy-choice}
-  & % merge a6d82d7
+  & % merge of a6d82d7
   & The notation $\in V$ should be $:V$.\\
   %
   % Chapter 11


### PR DESCRIPTION
In the pull requests I made (#911, #914), I made mistakes in comments to specify the commit hash (e.g. `% merge of 1234567`) in `errata.tex`. This pull request fixes them.