### PR TITLE
Add Exercise (categorical connectivity, #920)

### DIFF
--- a/exercise_solutions.tex
+++ b/exercise_solutions.tex
@@ -1500,11 +1500,12 @@ Let us denote by $\mathsf{isConn}(A)$ the proposition that a type $A$ is connect
 	      \end{align*}
 	      and let $h(f)$ be $\inr(k_2 \circ f)$.
        \end{itemize}
-       Let us prove that this $h$ is indeed an inverse of $e_{A,B,C}$.\\
+       Let us prove that this $h$ is indeed an inverse of $e_{A,B,C}$.
        First we prove $e_{A,B,C}(h(f)) = f$ for every $f:A \to B + C$
-       by case analysis on $f(a)$:\\
+       by case analysis on $f(a)$:
        \begin{enumerate}[label=(\alph*)]
-        \item if $f(a) \jdeq \inl(u)$ for some $u:B$:
+        \item \label{enum:categorical-connectivity-inl}
+	      if $f(a) \jdeq \inl(u)$ for some $u:B$:
 	      We have $\inl(k_1(f(x))) = f(x)$ for every $x:A$
 	      by case analysis on $f(x)$:
 	      \begin{itemize}
@@ -1519,7 +1520,6 @@ Let us denote by $\mathsf{isConn}(A)$ the proposition that a type $A$ is connect
 	       e_{A,B,C}(h(f)) = e_{A,B,C}(\inl(k_1 \circ f))
 	       = \lam{x} \inl(k_1(f(x))) = f.
 	      \end{displaymath}
-	      \label{enum:categorical-connectivity-inl}
 	\item if $f(a) \jdeq \inr(u)$ for some $u:C$:
 	      Similar to \ref{enum:categorical-connectivity-inl}.
        \end{enumerate}
@@ -1554,7 +1554,7 @@ Let us denote by $\mathsf{isConn}(A)$ the proposition that a type $A$ is connect
 	\label{lem:cat-conn-neg-neg-eq-xy}
 	\prd{x, y:\susp P} \neg \neg (x =_{\susp P} y)
        \end{equation}
-       by case analysis on $x$ and $y$:\\
+       by case analysis on $x$ and $y$:
        \begin{enumerate}[label=(\alph*)]
 	\item if $x \jdeq \north$:
 	      \begin{itemize}
@@ -1611,10 +1611,10 @@ Let us denote by $\mathsf{isConn}(A)$ the proposition that a type $A$ is connect
 	\item if $(f(\north), f(\south)) \jdeq (\inr(u), \inl(v))$
 	      for some $u: C, v:B$: This case is also impossible.
        \end{itemize}
-       Let us prove that this $h$ is indeed an inverse of $e_{\susp P,B,C}$.\\
+       Let us prove that this $h$ is indeed an inverse of $e_{\susp P,B,C}$.
        First we prove $e_{\susp P,B,C}(h(f)) = f$ for every $f:\susp P\to B+C$.
        It is done by case analysis on
-       $(f(\north), f(\south)):(B + C) \times (B + C)$:\\
+       $(f(\north), f(\south)):(B + C) \times (B + C)$:
        \begin{enumerate}[label=(\alph*)]
         \item if $(f(\north), f(\south)) \jdeq (\inl(u_1), \inl(u_2))$
 	      for some $u_1, u_2:B$:

--- a/exercise_solutions.tex
+++ b/exercise_solutions.tex
@@ -1469,23 +1469,26 @@ from the following computation
 \end{align*}
 \subsection*{Solution to \cref{ex:categorical-connectivity}}
 
-Let us denote by $\mathsf{isConn}(A)$ the connectivity of type $A$. It is known that
+Let us denote by $\mathsf{isConn}(A)$ the proposition that a type $A$ is connected. It is known that
 \begin{displaymath}
- \mathsf{isConn}(A) \simeq \trunc {} A \times \prd{x,y:A} \trunc {} {\id[A]xy}
+ \eqv{\mathsf{isConn}(A)}{\brck A \times \prd{x,y:A} \brck {\id[A]xy}}
 \end{displaymath}
 (see \cref{ex:connectivity-inductively}).
 \begin{enumerate}
- \item Suppose a type $A$ is connected. The goal $\prd{B,C:\type} \isequiv(e_{A,B,C})$ is a mere proposition, so we can assume $a:A$ and $\prd{x,y:A} \trunc {} {x = y}$.
+ \item Suppose a type $A$ is connected. The goal $\prd{B,C:\type} \isequiv(e_{A,B,C})$ is a mere proposition, so we can assume $a:A$ and $\prd{x,y:A} \brck {x = y}$.
 
-       Let $B,C$ be types. We want to construct $h:(A\to B+C) \to (A\to B)+(A\to C)$ such that $h \circ e = \idfunc$ and $e \circ h = \idfunc$.
+       Let $B,C$ be types.
+       We want to construct $h:(A\to B+C) \to (A\to B)+(A\to C)$ such that
+       $h \circ e_{A,B,C} = \idfunc[(A \to B) + (A \to C)]$ and
+       $e_{A,B,C} \circ h = \idfunc[A \to B + C]$.
        Let $f:A \to B+C$ be an arbitrary function. We have case analysis on $f(a):B + C$.\\
-       (a) if $f(a) \equiv \inl(u)$ for some $u:B$:
+       (a) if $f(a) \jdeq \inl(u)$ for some $u:B$:
        We want a function $g:A\to B$ such that $f(x) = \inl(g(x))$ for every $x:A$. Let us define $k:B+C\to B$ by
        \begin{align*}
 	k(\inl(b)) &\defeq b;\\
-	k(\inr(c)) &\defeq f(a) \enspace,
+	k(\inr(c)) &\defeq f(a),
        \end{align*}
-       and $g \defeq k \circ f$. Then we have $\inl(g(x)) = \inl(k(f(x))) = f(x)$ for every $x:A$ (by case analysis on $f(x)$ and $\trunc {} {\id[A]{a}{x}}$).
+       and $g \defeq k \circ f$. Then we have $\inl(g(x)) = \inl(k(f(x))) = f(x)$ for every $x:A$ (by case analysis on $f(x)$ and $\brck {\id[A]{a}{x}}$).
        With this $g$, we define $h(f) \defeq \inl(g)$. Then we have
        \begin{displaymath}
 	e_{A,B,C}(h(f)) = e_{A,B,C}(\inl(g)) = \lam{x} \inl(g(x)) = f
@@ -1495,32 +1498,39 @@ Let us denote by $\mathsf{isConn}(A)$ the connectivity of type $A$. It is known 
 	h(e_{A,B,C}(\inl(v))) = h(\lam{x} \inl(v(x))) = \lam{x} k(\inl(v(x))) = v
        \end{displaymath}
        for any $v: A\to B$.\\
-       (b) if $f(a) \equiv \inr(u)$ for some $u:C$: Similar to (a).\\
+       (b) if $f(a) \jdeq \inr(u)$ for some $u:C$: Similar to (a).\\
  \item (Categorial connectivity to $\mathsf{isConn}$ implies $\LEM{}$):
        Assume for every type $A$,
-       $(\prd{B,C:\type}\isequiv(e_{A,B,C})) \to \mathsf{isConn}(A)$.
+       \begin{displaymath}
+	\Parens{\prd{B,C:\type}\isequiv(e_{A,B,C})} \to \mathsf{isConn}(A).
+       \end{displaymath}
        Assuming $\neg \neg P$ for a mere proposition $P$, we want to prove $P$.
        Let us define $A \defeq \susp P$.
-       Since $P \simeq (\id[\susp P]{\north}{\south}) \simeq \trunc {} {\id[\susp P]{\north}{\south}}$ (by \cref{prop:trunc_of_prop_is_set}
-       and since $P$ is mere) and $\mathsf{isConn}(\susp P)$ implies $\trunc {} {\id[\susp P]{\north}{\south}}$ (by \cref{ex:connectivity-inductively}),
+       Since $P \eqvsym (\id[\susp P]{\north}{\south}) \eqvsym \brck {\id[\susp P]{\north}{\south}}$ (by \cref{prop:trunc_of_prop_is_set}
+       and since $P$ is a mere proposition) and $\mathsf{isConn}(\susp P)$ implies $\brck {\id[\susp P]{\north}{\south}}$ (by \cref{ex:connectivity-inductively}),
        it suffices to prove $\prd{B,C:\type}\isequiv(e_{\susp P,B,C})$. The proof is done by case analysis on $(f(\north), f(\south))$ for $f:\susp P\to B+C$.
 
        ($\LEM{}$ implies categorial connectivity to $\mathsf{isConn}$):
-       Assume $\LEM{}$, $A:\type$ and $\prd{B,C:\type} \isequiv(e_{A,B,C})$.
-       We need to prove $\mathsf{isConn}(A)$.
-       By $\LEM{}$ We have $\trunc {} A$ because if $\neg \trunc {} A$ we have $A \simeq 0$ and $1 + 1 \simeq 1$, which is not the case.
-       Also by $\LEM{}$, for every $x,y:A$ we have $\trunc {} {x = y} + \neg \trunc {} {x = y}$. So if we fix $x:A$ we have a function $f_x:A \to 1 + 1$ such that
+       Assume $\LEM{}$, $A:\type$ and
+       \begin{displaymath}
+        \prd{B,C:\type} \isequiv(e_{A,B,C}).
+       \end{displaymath}
+We need to prove $\mathsf{isConn}(A)$.
+       By $\LEM{}$ we have $\brck A$, because if $\neg \brck A$ we have $\eqv{A}{\emptyt}$ and $\eqv{\unit + \unit}{\unit}$, which is not the case.
+       Also by $\LEM{}$, for every $x,y:A$ we have $\brck {x = y} + \neg \brck {x = y}$. So if we fix $x:A$ we have a function $f_x:A \to \unit + \unit$ such that
        \begin{displaymath}
 	f_x(y) \defeq \begin{cases}
-		     \inl(*) & \mbox{if } \trunc {} {x = y} \\ % TODO
-		     \inr(*) & \mbox{if } \neg \trunc {} {x = y}
+		     \inl(\ttt) & \mbox{if } \brck {x = y} \\
+		     \inr(\ttt) & \mbox{if } \neg \brck {x = y}
 		    \end{cases}
        \end{displaymath}
        Applying the assumption to $f_x$, we obtain
        \begin{displaymath}
-	e_{A,1,1}^{-1}(f_x): (A \to 1) + (A \to 1)
+	\inv{e_{A,\unit,\unit}}(f_x): (A \to \unit) + (A \to \unit)
        \end{displaymath}
-       but by definition of $e$ and because $f_x(x) = \inl(*)$, it must be equal to $\inl(\lam{y} *): (A \to 1) + (A \to 1)$, which means we have $\prd{y:A} \trunc {} {x = y}$.
+       but by definition of $e$ and because $f_x(x) = \inl(\ttt)$,
+       it must be equal to $\inl(\lam{y} \ttt): (A \to \unit) + (A \to \unit)$,
+       which means we have $\prd{y:A} \brck {x = y}$.
 \end{enumerate}
 
 

--- a/exercise_solutions.tex
+++ b/exercise_solutions.tex
@@ -1481,31 +1481,57 @@ Let us denote by $\mathsf{isConn}(A)$ the proposition that a type $A$ is connect
        We want to construct $h:(A\to B+C) \to (A\to B)+(A\to C)$ such that
        $h \circ e_{A,B,C} = \idfunc[(A \to B) + (A \to C)]$ and
        $e_{A,B,C} \circ h = \idfunc[A \to B + C]$.
-       Let $f:A \to B+C$ be an arbitrary function. We have case analysis on $f(a):B + C$.\\
-       (a) if $f(a) \jdeq \inl(u)$ for some $u:B$:
-       We want a function $g:A\to B$ such that $f(x) = \inl(g(x))$ for every $x:A$. Let us define $k:B+C\to B$ by
-       \begin{align*}
-	k(\inl(b)) &\defeq b;\\
-	k(\inr(c)) &\defeq f(a),
-       \end{align*}
-       and $g \defeq k \circ f$. Then we have $\inl(g(x)) = \inl(k(f(x))) = f(x)$ for every $x:A$ by case analysis on $f(x)$:
+       Let $f:A \to B+C$ be an arbitrary function.
+       Let us define $h(f):(A \to B) + (A \to C)$
+       by case analysis on $f(a):B + C$:
        \begin{itemize}
-	\item if $f(x) \jdeq \inl(v)$:
-	      $\inl(k(f(x))) = \inl(k(\inl(v))) = \inl(v) = f(x)$,
-	\item if $f(x) \jdeq \inr(v)$:
-	      we have $f(a) \neq f(x)$,
-	      which is impossible by $\brck {\id[A]{a}{x}}$.
+	\item if $f(a) \jdeq \inl(u)$ for some $u:B$:
+	      Let us define $k_1:B+C\to B$ by
+	      \begin{align*}
+	       k_1(\inl(b)) &\defeq b;\\
+	       k_1(\inr(c)) &\defeq u,
+	      \end{align*}
+	      and let $h(f)$ be $\inl(k_1 \circ f)$.
+	\item if $f(a) \jdeq \inr(u)$ for some $u:C$:
+	      Let us define $k_2:B+C\to C$ by
+	      \begin{align*}
+	       k_2(\inl(b)) &\defeq u;\\
+	       k_2(\inr(c)) &\defeq c,
+	      \end{align*}
+	      and let $h(f)$ be $\inr(k_2 \circ f)$.
        \end{itemize}
-       With this $g$, we define $h(f) \defeq \inl(g)$. Then we have
+       Let us prove that this $h$ is indeed an inverse of $e_{A,B,C}$.\\
+       First we prove $e_{A,B,C}(h(f)) = f$ for every $f:A \to B + C$
+       by case analysis on $f(a)$:\\
+       (a) if $f(a) \jdeq \inl(u)$ for some $u:B$:
+       We have $\inl(k_1(f(x))) = f(x)$ for every $x:A$
+       by case analysis on $f(x)$:
+       \begin{itemize}
+	\item if $f(x) \jdeq \inl(v)$ for some $v:B$:
+	      $\inl(k_1(f(x))) = \inl(k_1(\inl(v))) = \inl(v) = f(x)$,
+	\item if $f(x) \jdeq \inr(v)$ for some $v:C$:
+	      we have $f(a) \neq f(x)$,
+	      which contradicts $\brck {\id[A]{a}{x}}$.
+       \end{itemize}
+       Then we have
        \begin{displaymath}
-	e_{A,B,C}(h(f)) = e_{A,B,C}(\inl(g)) = \lam{x} \inl(g(x)) = f
+	e_{A,B,C}(h(f)) = e_{A,B,C}(\inl(k_1 \circ f))
+	= \lam{x} \inl(k_1(f(x))) = f.
        \end{displaymath}
-       and
-       \begin{displaymath}
-	h(e_{A,B,C}(\inl(v))) = h(\lam{x} \inl(v(x))) = \lam{x} k(\inl(v(x))) = v
-       \end{displaymath}
-       for any $v: A\to B$.\\
        (b) if $f(a) \jdeq \inr(u)$ for some $u:C$: Similar to (a).\\
+       Next we prove $h(e_{A,B,C}(f)) = f$ for every $f:(A \to B) + (A \to C)$
+       by case analysis on $f$:\\
+       (a) if $f \jdeq \inl(g)$ for some $g: A \to B$:
+       \begin{displaymath}
+	h(e_{A,B,C}(f)) = h(e_{A,B,C}(\inl(g))) = h(\lam{x} \inl(g(x)))
+	= \inl(\lam{x} g(x)) = f,
+       \end{displaymath}
+       (b) if $f \jdeq \inr(g)$ for some $g: A \to C$:
+       \begin{displaymath}
+	h(e_{A,B,C}(f)) = h(e_{A,B,C}(\inr(g))) = h(\lam{x} \inr(g(x)))
+	= \inr(\lam{x} g(x)) = f.
+       \end{displaymath}
+       Therefore we have $\isequiv(e_{A,B,C})$.
  \item (Categorial connectivity to $\mathsf{isConn}$ implies $\LEM{}$):
        Assume for every type $A$,
        \begin{displaymath}

--- a/exercise_solutions.tex
+++ b/exercise_solutions.tex
@@ -1467,7 +1467,7 @@ from the following computation
   &= (t \circ \tprojf k)(a) \tag{since $g$ is a section of $\lam{s} s\circ f$}\\
   & \equiv t(\tproj ka).
 \end{align*}
-\subsection*{Solution to \cref{ex:categorical-connectivity}}
+\subsection*{Solution to \cref{ex:categorical-connectedness}}
 
 Let us denote by $\mathsf{isConn}(A)$ the proposition that a type $A$ is connected. It is known that
 \begin{displaymath}
@@ -1504,7 +1504,7 @@ Let us denote by $\mathsf{isConn}(A)$ the proposition that a type $A$ is connect
        First we prove $e_{A,B,C}(h(f)) = f$ for every $f:A \to B + C$
        by case analysis on $f(a)$:
        \begin{enumerate}[label=(\alph*)]
-        \item \label{enum:categorical-connectivity-inl}
+        \item \label{enum:categorical-connectedness-inl}
 	      if $f(a) \jdeq \inl(u)$ for some $u:B$:
 	      We have $\inl(k_1(f(x))) = f(x)$ for every $x:A$
 	      by case analysis on $f(x)$:
@@ -1521,7 +1521,7 @@ Let us denote by $\mathsf{isConn}(A)$ the proposition that a type $A$ is connect
 	       = \lam{x} \inl(k_1(f(x))) = f.
 	      \end{displaymath}
 	\item if $f(a) \jdeq \inr(u)$ for some $u:C$:
-	      Similar to \ref{enum:categorical-connectivity-inl}.
+	      Similar to \ref{enum:categorical-connectedness-inl}.
        \end{enumerate}
        Next we prove $h(e_{A,B,C}(f)) = f$ for every $f:(A \to B) + (A \to C)$
        by case analysis on $f$:
@@ -1538,7 +1538,7 @@ Let us denote by $\mathsf{isConn}(A)$ the proposition that a type $A$ is connect
 	      \end{displaymath}
        \end{enumerate}
        Therefore we have $\isequiv(e_{A,B,C})$.
- \item (Categorial connectivity to $\mathsf{isConn}$ implies $\LEM{}$):
+ \item (Categorical connectedness to $\mathsf{isConn}$ implies $\LEM{}$):
        Assume for every type $A$,
        \begin{displaymath}
 	\Parens{\prd{B,C:\type}\isequiv(e_{A,B,C})} \to \mathsf{isConn}(A).
@@ -1568,9 +1568,9 @@ Let us denote by $\mathsf{isConn}(A)$ the proposition that a type $A$ is connect
 		     for every $y$ (see \cref{thm:isprop-forall}),
 		     we do not need to consider this case.
 	      \end{itemize}
-	      \label{enum:categorical-connectivity-north}
+	      \label{enum:categorical-connectedness-north}
 	\item if $x \jdeq \south$:
-	      Similar to \ref{enum:categorical-connectivity-north}.
+	      Similar to \ref{enum:categorical-connectedness-north}.
 	\item if $x$ varies on $\merid(p)$ for some $p: P$:
 	      Since $\prd{y:\susp P} \neg \neg (x =_{\susp P} y)$
 	      is a mere proposition for every $x$,
@@ -1655,7 +1655,7 @@ Let us denote by $\mathsf{isConn}(A)$ the proposition that a type $A$ is connect
        \end{enumerate}
        Therefore we have $\isequiv(e_{\susp P,B,C})$.
 
-       ($\LEM{}$ implies categorial connectivity to $\mathsf{isConn}$):
+       ($\LEM{}$ implies categorical connectedness to $\mathsf{isConn}$):
        Assume $\LEM{}$, $A:\type$ and
        \begin{displaymath}
         \prd{B,C:\type} \isequiv(e_{A,B,C}).

--- a/exercise_solutions.tex
+++ b/exercise_solutions.tex
@@ -1467,6 +1467,62 @@ from the following computation
   &= (t \circ \tprojf k)(a) \tag{since $g$ is a section of $\lam{s} s\circ f$}\\
   & \equiv t(\tproj ka).
 \end{align*}
+\subsection*{Solution to \cref{ex:categorical-connectivity}}
+
+Let us denote by $\mathsf{isConn}(A)$ the connectivity of type $A$. It is known that
+\begin{displaymath}
+ \mathsf{isConn}(A) \simeq \trunc {} A \times \prd{x,y:A} \trunc {} {\id[A]xy}
+\end{displaymath}
+(see \cref{ex:connectivity-inductively}).
+\begin{enumerate}
+ \item Suppose a type $A$ is connected. The goal $\prd{B,C:\type} \isequiv(e_{A,B,C})$ is a mere proposition, so we can assume $a:A$ and $\prd{x,y:A} \trunc {} {x = y}$.
+
+       Let $B,C$ be types. We want to construct $h:(A\to B+C) \to (A\to B)+(A\to C)$ such that $h \circ e = \idfunc$ and $e \circ h = \idfunc$.
+       Let $f:A \to B+C$ be an arbitrary function. We have case analysis on $f(a):B + C$.\\
+       (a) if $f(a) \equiv \inl(u)$ for some $u:B$:
+       We want a function $g:A\to B$ such that $f(x) = \inl(g(x))$ for every $x:A$. Let us define $k:B+C\to B$ by
+       \begin{align*}
+	k(\inl(b)) &\defeq b;\\
+	k(\inr(c)) &\defeq f(a) \enspace,
+       \end{align*}
+       and $g \defeq k \circ f$. Then we have $\inl(g(x)) = \inl(k(f(x))) = f(x)$ for every $x:A$ (by case analysis on $f(x)$ and $\trunc {} {\id[A]{a}{x}}$).
+       With this $g$, we define $h(f) \defeq \inl(g)$. Then we have
+       \begin{displaymath}
+	e_{A,B,C}(h(f)) = e_{A,B,C}(\inl(g)) = \lam{x} \inl(g(x)) = f
+       \end{displaymath}
+       and
+       \begin{displaymath}
+	h(e_{A,B,C}(\inl(v))) = h(\lam{x} \inl(v(x))) = \lam{x} k(\inl(v(x))) = v
+       \end{displaymath}
+       for any $v: A\to B$.\\
+       (b) if $f(a) \equiv \inr(u)$ for some $u:C$: Similar to (a).\\
+ \item (Categorial connectivity to $\mathsf{isConn}$ implies $\LEM{}$):
+       Assume for every type $A$,
+       $(\prd{B,C:\type}\isequiv(e_{A,B,C})) \to \mathsf{isConn}(A)$.
+       Assuming $\neg \neg P$ for a mere proposition $P$, we want to prove $P$.
+       Let us define $A \defeq \susp P$.
+       Since $P \simeq (\id[\susp P]{\north}{\south}) \simeq \trunc {} {\id[\susp P]{\north}{\south}}$ (by \cref{prop:trunc_of_prop_is_set}
+       and since $P$ is mere) and $\mathsf{isConn}(\susp P)$ implies $\trunc {} {\id[\susp P]{\north}{\south}}$ (by \cref{ex:connectivity-inductively}),
+       it suffices to prove $\prd{B,C:\type}\isequiv(e_{\susp P,B,C})$. The proof is done by case analysis on $(f(\north), f(\south))$ for $f:\susp P\to B+C$.
+
+       ($\LEM{}$ implies categorial connectivity to $\mathsf{isConn}$):
+       Assume $\LEM{}$, $A:\type$ and $\prd{B,C:\type} \isequiv(e_{A,B,C})$.
+       We need to prove $\mathsf{isConn}(A)$.
+       By $\LEM{}$ We have $\trunc {} A$ because if $\neg \trunc {} A$ we have $A \simeq 0$ and $1 + 1 \simeq 1$, which is not the case.
+       Also by $\LEM{}$, for every $x,y:A$ we have $\trunc {} {x = y} + \neg \trunc {} {x = y}$. So if we fix $x:A$ we have a function $f_x:A \to 1 + 1$ such that
+       \begin{displaymath}
+	f_x(y) \defeq \begin{cases}
+		     \inl(*) & \mbox{if } \trunc {} {x = y} \\ % TODO
+		     \inr(*) & \mbox{if } \neg \trunc {} {x = y}
+		    \end{cases}
+       \end{displaymath}
+       Applying the assumption to $f_x$, we obtain
+       \begin{displaymath}
+	e_{A,1,1}^{-1}(f_x): (A \to 1) + (A \to 1)
+       \end{displaymath}
+       but by definition of $e$ and because $f_x(x) = \inl(*)$, it must be equal to $\inl(\lam{y} *): (A \to 1) + (A \to 1)$, which means we have $\prd{y:A} \trunc {} {x = y}$.
+\end{enumerate}
+
 
 \section*{Exercises from \cref{cha:homotopy}}
 

--- a/exercise_solutions.tex
+++ b/exercise_solutions.tex
@@ -1488,7 +1488,14 @@ Let us denote by $\mathsf{isConn}(A)$ the proposition that a type $A$ is connect
 	k(\inl(b)) &\defeq b;\\
 	k(\inr(c)) &\defeq f(a),
        \end{align*}
-       and $g \defeq k \circ f$. Then we have $\inl(g(x)) = \inl(k(f(x))) = f(x)$ for every $x:A$ (by case analysis on $f(x)$ and $\brck {\id[A]{a}{x}}$).
+       and $g \defeq k \circ f$. Then we have $\inl(g(x)) = \inl(k(f(x))) = f(x)$ for every $x:A$ by case analysis on $f(x)$:
+       \begin{itemize}
+	\item if $f(x) \jdeq \inl(v)$:
+	      $\inl(k(f(x))) = \inl(k(\inl(v))) = \inl(v) = f(x)$,
+	\item if $f(x) \jdeq \inr(v)$:
+	      we have $f(a) \neq f(x)$,
+	      which is impossible by $\brck {\id[A]{a}{x}}$.
+       \end{itemize}
        With this $g$, we define $h(f) \defeq \inl(g)$. Then we have
        \begin{displaymath}
 	e_{A,B,C}(h(f)) = e_{A,B,C}(\inl(g)) = \lam{x} \inl(g(x)) = f

--- a/exercise_solutions.tex
+++ b/exercise_solutions.tex
@@ -1541,7 +1541,96 @@ Let us denote by $\mathsf{isConn}(A)$ the proposition that a type $A$ is connect
        Let us define $A \defeq \susp P$.
        Since $P \eqvsym (\id[\susp P]{\north}{\south}) \eqvsym \brck {\id[\susp P]{\north}{\south}}$ (by \cref{prop:trunc_of_prop_is_set}
        and since $P$ is a mere proposition) and $\mathsf{isConn}(\susp P)$ implies $\brck {\id[\susp P]{\north}{\south}}$ (by \cref{ex:connectivity-inductively}),
-       it suffices to prove $\prd{B,C:\type}\isequiv(e_{\susp P,B,C})$. The proof is done by case analysis on $(f(\north), f(\south))$ for $f:\susp P\to B+C$.
+       it suffices to prove $\prd{B,C:\type}\isequiv(e_{\susp P,B,C})$.
+
+       Before proving this, we prove that
+       \begin{equation}
+	\label{lem:cat-conn-neg-neg-eq-xy}
+	\prd{x, y:\susp P} \neg \neg (x =_{\susp P} y)
+       \end{equation}
+       by case analysis on $x$ and $y$:\\
+       (a) if $x \jdeq \north$:\\
+       (a-a) if $y \jdeq \north$: $\lam{k} k(\refl{\north})$ has type
+       $\neg \neg (\north = \north)$.\\
+       (a-b) if $y \jdeq \south$:
+       $\neg \neg (\north = \south)$ is equivalent to $\neg \neg P$,
+       so it is inhabited.\\
+       (a-c) if $y$ varies on $\merid(p)$ for some $p: P$: Since
+       $\neg \neg (\north =_{\susp P} y)$ is a mere proposition
+       for every $y$, we do not need to consider this case.\\
+       (b) if $x \jdeq \south$: Similar to (a).\\
+       (c) if $x$ varies on $\merid(p)$ for some $p: P$: Since
+       $\prd{y:\susp P} \neg \neg (x =_{\susp P} y)$ is a mere proposition
+       for every $x$, we do not need to consider this case.
+
+       Let us prove $\prd{B,C:\type}\isequiv(e_{\susp P,B,C})$.
+       Let $B, C$ be types.
+       We want to construct
+       $h:(\susp P\to B+C) \to (\susp P \to B)+(\susp P\to C)$ such that
+       $h \circ e_{\susp P,B,C} = \idfunc[(\susp P\to B) + (\susp P\to C)]$ and
+       $e_{\susp P,B,C} \circ h = \idfunc[\susp P\to B + C]$.
+       Let $f:\susp P\to B+C$ be an arbitrary function.
+       Let us define $h(f):(\susp P\to B) + (\susp P\to C)$
+       by case analysis on $(f(\north), f(\south)):(B + C) \times (B + C)$:
+       \begin{itemize}
+	\item if $(f(\north), f(\south)) \jdeq (\inl(u_1), \inl(u_2))$
+	      for some $u_1, u_2:B$:
+	      Let us define $k_1:B+C\to B$ by
+	      \begin{align*}
+	       k_1(\inl(b)) &\defeq b;\\
+	       k_1(\inr(c)) &\defeq u_1,
+	      \end{align*}
+	      and let $h(f)$ be $\inl(k_1 \circ f)$.
+	\item if $(f(\north), f(\south)) \jdeq (\inr(u_1), \inr(u_2))$
+	      for some $u_1, u_2:C$:
+	      Let us define $k_2:B+C\to C$ by
+	      \begin{align*}
+	       k_2(\inl(b)) &\defeq u_1;\\
+	       k_2(\inr(c)) &\defeq c,
+	      \end{align*}
+	      and let $h(f)$ be $\inl(k_2 \circ f)$.
+	\item if $(f(\north), f(\south)) \jdeq (\inl(u), \inr(v))$
+	      for some $u: B, v:C$: This case is impossible.
+	      $f(\north) \neq f(\south)$ implies $\north \neq \south$,
+	      which contradicts \eqref{lem:cat-conn-neg-neg-eq-xy}.
+	\item if $(f(\north), f(\south)) \jdeq (\inr(u), \inl(v))$
+	      for some $u: C, v:B$: This case is also impossible.
+       \end{itemize}
+       Let us prove that this $h$ is indeed an inverse of $e_{\susp P,B,C}$.\\
+       First we prove $e_{\susp P,B,C}(h(f)) = f$ for every $f:\susp P\to B+C$.
+       It is done by case analysis on
+       $(f(\north), f(\south)):(B + C) \times (B + C)$:\\
+       (a) if $(f(\north), f(\south)) \jdeq (\inl(u_1), \inl(u_2))$
+	      for some $u_1, u_2:B$:
+       We have $\inl(k_1(f(x))) = f(x)$ for every $x:\susp P$
+       by case analysis on $f(x)$:
+       \begin{itemize}
+	\item if $f(x) \jdeq \inl(v)$ for some $v:B$:
+	      $\inl(k_1(f(x))) = \inl(k_1(\inl(v))) = \inl(v) = f(x)$,
+	\item if $f(x) \jdeq \inr(v)$ for some $v:C$:
+	      we have $f(\north) \neq f(x)$ and hence $\north \neq x$,
+	      which contradicts \eqref{lem:cat-conn-neg-neg-eq-xy}.
+       \end{itemize}
+       Then we have
+       \begin{displaymath}
+	e_{\susp P,B,C}(h(f)) = e_{\susp P,B,C}(\inl(k_1 \circ f))
+	= \lam{x} \inl(k_1(f(x))) = f.
+       \end{displaymath}
+       (b) if $(f(\north), f(\south)) \jdeq (\inr(u_1), \inr(u_2))$
+	      for some $u_1, u_2:C$: Similar to (a).\\
+       Next we prove $h(e_{\susp P,B,C}(f)) = f$ for every $f:(\susp P\to B) + (\susp P\to C)$
+       by case analysis on $f$:\\
+       (a) if $f \jdeq \inl(g)$ for some $g: \susp P\to B$:
+       \begin{displaymath}
+	h(e_{\susp P,B,C}(f)) = h(e_{\susp P,B,C}(\inl(g))) = h(\lam{x} \inl(g(x)))
+	= \inl(\lam{x} g(x)) = f,
+       \end{displaymath}
+       (b) if $f \jdeq \inr(g)$ for some $g: \susp P\to C$:
+       \begin{displaymath}
+	h(e_{\susp P,B,C}(f)) = h(e_{\susp P,B,C}(\inr(g))) = h(\lam{x} \inr(g(x)))
+	= \inr(\lam{x} g(x)) = f.
+       \end{displaymath}
+       Therefore we have $\isequiv(e_{\susp P,B,C})$.
 
        ($\LEM{}$ implies categorial connectivity to $\mathsf{isConn}$):
        Assume $\LEM{}$, $A:\type$ and

--- a/exercise_solutions.tex
+++ b/exercise_solutions.tex
@@ -1503,34 +1503,40 @@ Let us denote by $\mathsf{isConn}(A)$ the proposition that a type $A$ is connect
        Let us prove that this $h$ is indeed an inverse of $e_{A,B,C}$.\\
        First we prove $e_{A,B,C}(h(f)) = f$ for every $f:A \to B + C$
        by case analysis on $f(a)$:\\
-       (a) if $f(a) \jdeq \inl(u)$ for some $u:B$:
-       We have $\inl(k_1(f(x))) = f(x)$ for every $x:A$
-       by case analysis on $f(x)$:
-       \begin{itemize}
-	\item if $f(x) \jdeq \inl(v)$ for some $v:B$:
-	      $\inl(k_1(f(x))) = \inl(k_1(\inl(v))) = \inl(v) = f(x)$,
-	\item if $f(x) \jdeq \inr(v)$ for some $v:C$:
-	      we have $f(a) \neq f(x)$,
-	      which contradicts $\brck {\id[A]{a}{x}}$.
-       \end{itemize}
-       Then we have
-       \begin{displaymath}
-	e_{A,B,C}(h(f)) = e_{A,B,C}(\inl(k_1 \circ f))
-	= \lam{x} \inl(k_1(f(x))) = f.
-       \end{displaymath}
-       (b) if $f(a) \jdeq \inr(u)$ for some $u:C$: Similar to (a).\\
+       \begin{enumerate}[label=(\alph*)]
+        \item if $f(a) \jdeq \inl(u)$ for some $u:B$:
+	      We have $\inl(k_1(f(x))) = f(x)$ for every $x:A$
+	      by case analysis on $f(x)$:
+	      \begin{itemize}
+	       \item if $f(x) \jdeq \inl(v)$ for some $v:B$:
+		     $\inl(k_1(f(x))) = \inl(k_1(\inl(v))) = \inl(v) = f(x)$,
+	       \item if $f(x) \jdeq \inr(v)$ for some $v:C$:
+		     we have $f(a) \neq f(x)$,
+		     which contradicts $\brck {\id[A]{a}{x}}$.
+	      \end{itemize}
+	      Then we have
+	      \begin{displaymath}
+	       e_{A,B,C}(h(f)) = e_{A,B,C}(\inl(k_1 \circ f))
+	       = \lam{x} \inl(k_1(f(x))) = f.
+	      \end{displaymath}
+	      \label{enum:categorical-connectivity-inl}
+	\item if $f(a) \jdeq \inr(u)$ for some $u:C$:
+	      Similar to \ref{enum:categorical-connectivity-inl}.
+       \end{enumerate}
        Next we prove $h(e_{A,B,C}(f)) = f$ for every $f:(A \to B) + (A \to C)$
-       by case analysis on $f$:\\
-       (a) if $f \jdeq \inl(g)$ for some $g: A \to B$:
-       \begin{displaymath}
-	h(e_{A,B,C}(f)) = h(e_{A,B,C}(\inl(g))) = h(\lam{x} \inl(g(x)))
-	= \inl(\lam{x} g(x)) = f,
-       \end{displaymath}
-       (b) if $f \jdeq \inr(g)$ for some $g: A \to C$:
-       \begin{displaymath}
-	h(e_{A,B,C}(f)) = h(e_{A,B,C}(\inr(g))) = h(\lam{x} \inr(g(x)))
-	= \inr(\lam{x} g(x)) = f.
-       \end{displaymath}
+       by case analysis on $f$:
+       \begin{enumerate}[label=(\alph*)]
+        \item if $f \jdeq \inl(g)$ for some $g: A \to B$:
+	      \begin{displaymath}
+	       h(e_{A,B,C}(f)) = h(e_{A,B,C}(\inl(g))) = h(\lam{x} \inl(g(x)))
+	       = \inl(\lam{x} g(x)) = f,
+	      \end{displaymath}
+	\item if $f \jdeq \inr(g)$ for some $g: A \to C$:
+	      \begin{displaymath}
+	       h(e_{A,B,C}(f)) = h(e_{A,B,C}(\inr(g))) = h(\lam{x} \inr(g(x)))
+	       = \inr(\lam{x} g(x)) = f.
+	      \end{displaymath}
+       \end{enumerate}
        Therefore we have $\isequiv(e_{A,B,C})$.
  \item (Categorial connectivity to $\mathsf{isConn}$ implies $\LEM{}$):
        Assume for every type $A$,
@@ -1549,19 +1555,27 @@ Let us denote by $\mathsf{isConn}(A)$ the proposition that a type $A$ is connect
 	\prd{x, y:\susp P} \neg \neg (x =_{\susp P} y)
        \end{equation}
        by case analysis on $x$ and $y$:\\
-       (a) if $x \jdeq \north$:\\
-       (a-a) if $y \jdeq \north$: $\lam{k} k(\refl{\north})$ has type
-       $\neg \neg (\north = \north)$.\\
-       (a-b) if $y \jdeq \south$:
-       $\neg \neg (\north = \south)$ is equivalent to $\neg \neg P$,
-       so it is inhabited.\\
-       (a-c) if $y$ varies on $\merid(p)$ for some $p: P$: Since
-       $\neg \neg (\north =_{\susp P} y)$ is a mere proposition
-       for every $y$, we do not need to consider this case.\\
-       (b) if $x \jdeq \south$: Similar to (a).\\
-       (c) if $x$ varies on $\merid(p)$ for some $p: P$: Since
-       $\prd{y:\susp P} \neg \neg (x =_{\susp P} y)$ is a mere proposition
-       for every $x$, we do not need to consider this case.
+       \begin{enumerate}[label=(\alph*)]
+	\item if $x \jdeq \north$:
+	      \begin{itemize}
+	       \item if $y \jdeq \north$: $\lam{k} k(\refl{\north})$ has type
+		     $\neg \neg (\north = \north)$.
+	       \item if $y \jdeq \south$:
+		     $\neg \neg (\north = \south)$ is equivalent to
+		     $\neg \neg P$, so it is inhabited.
+	       \item if $y$ varies on $\merid(p)$ for some $p: P$: Since
+		     $\neg \neg (\north =_{\susp P} y)$ is a mere proposition
+		     for every $y$ (see \cref{thm:isprop-forall}),
+		     we do not need to consider this case.
+	      \end{itemize}
+	      \label{enum:categorical-connectivity-north}
+	\item if $x \jdeq \south$:
+	      Similar to \ref{enum:categorical-connectivity-north}.
+	\item if $x$ varies on $\merid(p)$ for some $p: P$:
+	      Since $\prd{y:\susp P} \neg \neg (x =_{\susp P} y)$
+	      is a mere proposition for every $x$,
+	      we do not need to consider this case.
+       \end{enumerate}
 
        Let us prove $\prd{B,C:\type}\isequiv(e_{\susp P,B,C})$.
        Let $B, C$ be types.
@@ -1569,6 +1583,7 @@ Let us denote by $\mathsf{isConn}(A)$ the proposition that a type $A$ is connect
        $h:(\susp P\to B+C) \to (\susp P \to B)+(\susp P\to C)$ such that
        $h \circ e_{\susp P,B,C} = \idfunc[(\susp P\to B) + (\susp P\to C)]$ and
        $e_{\susp P,B,C} \circ h = \idfunc[\susp P\to B + C]$.
+
        Let $f:\susp P\to B+C$ be an arbitrary function.
        Let us define $h(f):(\susp P\to B) + (\susp P\to C)$
        by case analysis on $(f(\north), f(\south)):(B + C) \times (B + C)$:
@@ -1600,36 +1615,44 @@ Let us denote by $\mathsf{isConn}(A)$ the proposition that a type $A$ is connect
        First we prove $e_{\susp P,B,C}(h(f)) = f$ for every $f:\susp P\to B+C$.
        It is done by case analysis on
        $(f(\north), f(\south)):(B + C) \times (B + C)$:\\
-       (a) if $(f(\north), f(\south)) \jdeq (\inl(u_1), \inl(u_2))$
+       \begin{enumerate}[label=(\alph*)]
+        \item if $(f(\north), f(\south)) \jdeq (\inl(u_1), \inl(u_2))$
 	      for some $u_1, u_2:B$:
-       We have $\inl(k_1(f(x))) = f(x)$ for every $x:\susp P$
-       by case analysis on $f(x)$:
-       \begin{itemize}
-	\item if $f(x) \jdeq \inl(v)$ for some $v:B$:
-	      $\inl(k_1(f(x))) = \inl(k_1(\inl(v))) = \inl(v) = f(x)$,
-	\item if $f(x) \jdeq \inr(v)$ for some $v:C$:
-	      we have $f(\north) \neq f(x)$ and hence $\north \neq x$,
-	      which contradicts \eqref{lem:cat-conn-neg-neg-eq-xy}.
-       \end{itemize}
-       Then we have
-       \begin{displaymath}
-	e_{\susp P,B,C}(h(f)) = e_{\susp P,B,C}(\inl(k_1 \circ f))
-	= \lam{x} \inl(k_1(f(x))) = f.
-       \end{displaymath}
-       (b) if $(f(\north), f(\south)) \jdeq (\inr(u_1), \inr(u_2))$
-	      for some $u_1, u_2:C$: Similar to (a).\\
-       Next we prove $h(e_{\susp P,B,C}(f)) = f$ for every $f:(\susp P\to B) + (\susp P\to C)$
-       by case analysis on $f$:\\
-       (a) if $f \jdeq \inl(g)$ for some $g: \susp P\to B$:
-       \begin{displaymath}
-	h(e_{\susp P,B,C}(f)) = h(e_{\susp P,B,C}(\inl(g))) = h(\lam{x} \inl(g(x)))
-	= \inl(\lam{x} g(x)) = f,
-       \end{displaymath}
-       (b) if $f \jdeq \inr(g)$ for some $g: \susp P\to C$:
-       \begin{displaymath}
-	h(e_{\susp P,B,C}(f)) = h(e_{\susp P,B,C}(\inr(g))) = h(\lam{x} \inr(g(x)))
-	= \inr(\lam{x} g(x)) = f.
-       \end{displaymath}
+	      We have $\inl(k_1(f(x))) = f(x)$ for every $x:\susp P$
+	      by case analysis on $f(x)$:
+	      \begin{itemize}
+	       \item if $f(x) \jdeq \inl(v)$ for some $v:B$:
+		     $\inl(k_1(f(x))) = \inl(k_1(\inl(v))) = \inl(v) = f(x)$,
+	       \item if $f(x) \jdeq \inr(v)$ for some $v:C$:
+		     we have $f(\north) \neq f(x)$ and hence $\north \neq x$,
+		     which contradicts \eqref{lem:cat-conn-neg-neg-eq-xy}.
+	      \end{itemize}
+	      Then we have
+	      \begin{displaymath}
+	       e_{\susp P,B,C}(h(f)) = e_{\susp P,B,C}(\inl(k_1 \circ f))
+	       = \lam{x} \inl(k_1(f(x))) = f.
+	      \end{displaymath}
+	      \label{enum:inl-inl}
+	\item if $(f(\north), f(\south)) \jdeq (\inr(u_1), \inr(u_2))$
+	      for some $u_1, u_2:C$: Similar to \ref{enum:inl-inl}.
+       \end{enumerate}
+       Next we prove $h(e_{\susp P,B,C}(f)) = f$
+       for every $f:(\susp P\to B) + (\susp P\to C)$
+       by case analysis on $f$:
+       \begin{enumerate}
+        \item if $f \jdeq \inl(g)$ for some $g: \susp P\to B$:
+	      \begin{displaymath}
+	       h(e_{\susp P,B,C}(f)) = h(e_{\susp P,B,C}(\inl(g)))
+	       = h(\lam{x} \inl(g(x)))
+	       = \inl(\lam{x} g(x)) = f,
+	      \end{displaymath}
+	\item if $f \jdeq \inr(g)$ for some $g: \susp P\to C$:
+	      \begin{displaymath}
+	       h(e_{\susp P,B,C}(f)) = h(e_{\susp P,B,C}(\inr(g)))
+	       = h(\lam{x} \inr(g(x)))
+	       = \inr(\lam{x} g(x)) = f.
+	      \end{displaymath}
+       \end{enumerate}
        Therefore we have $\isequiv(e_{\susp P,B,C})$.
 
        ($\LEM{}$ implies categorial connectivity to $\mathsf{isConn}$):

--- a/hlevels.tex
+++ b/hlevels.tex
@@ -2110,10 +2110,10 @@ The modalities we have considered in this chapter are all idempotent, whereas th
 \end{ex}
 
 \begin{ex}\label{ex:categorical-connectivity}
-  We say a type $A$ is \define{categorically connected}\indexdef{connected!categorically} if for every type $B, C$ the canonical map $e_{A, B, C}:(A\to B) + (A\to C) \to A \to B + C$ defined by
+  We say a type $A$ is \define{categorically connected}\indexdef{connected!categorically} if for every types $B, C$ the canonical map $e_{A, B, C}:(A\to B) + (A\to C) \to A \to B + C$ defined by
   \begin{align*}
-    e_{A,B,C}(\inl(g)) \defeq \lam{x} \inl(g(x)),\\
-    e_{A,B,C}(\inr(g)) \defeq \lam{x} \inr(g(x))
+    e_{A,B,C}(\inl(g)) &\defeq \lam{x} \inl(g(x)),\\
+    e_{A,B,C}(\inr(g)) &\defeq \lam{x} \inr(g(x))
   \end{align*}
   is an equivalence.
   \begin{enumerate}

--- a/hlevels.tex
+++ b/hlevels.tex
@@ -2109,7 +2109,7 @@ The modalities we have considered in this chapter are all idempotent, whereas th
   Show that if $f : A \to B$ is $n$-connected, then $\trunc kf : \trunc kA \to \trunc kB$ is also $n$-connected.
 \end{ex}
 
-\begin{ex}\label{ex:categorical-connectivity}
+\begin{ex}\label{ex:categorical-connectedness}
   We say a type $A$ is \define{categorically connected}
   \indexdef{connected!categorically} if for every types $B, C$ the canonical map
   $e_{A, B, C}:((A\to B) + (A\to C)) \to (A \to B + C)$ defined by

--- a/hlevels.tex
+++ b/hlevels.tex
@@ -2110,7 +2110,9 @@ The modalities we have considered in this chapter are all idempotent, whereas th
 \end{ex}
 
 \begin{ex}\label{ex:categorical-connectivity}
-  We say a type $A$ is \define{categorically connected}\indexdef{connected!categorically} if for every types $B, C$ the canonical map $e_{A, B, C}:(A\to B) + (A\to C) \to A \to B + C$ defined by
+  We say a type $A$ is \define{categorically connected}
+  \indexdef{connected!categorically} if for every types $B, C$ the canonical map
+  $e_{A, B, C}:((A\to B) + (A\to C)) \to (A \to B + C)$ defined by
   \begin{align*}
     e_{A,B,C}(\inl(g)) &\defeq \lam{x} \inl(g(x)),\\
     e_{A,B,C}(\inr(g)) &\defeq \lam{x} \inr(g(x))

--- a/hlevels.tex
+++ b/hlevels.tex
@@ -2109,6 +2109,19 @@ The modalities we have considered in this chapter are all idempotent, whereas th
   Show that if $f : A \to B$ is $n$-connected, then $\trunc kf : \trunc kA \to \trunc kB$ is also $n$-connected.
 \end{ex}
 
+\begin{ex}\label{ex:categorical-connectivity}
+  We say a type $A$ is \define{categorically connected}\indexdef{connected!categorically} if for every type $B, C$ the canonical map $e_{A, B, C}:(A\to B) + (A\to C) \to A \to B + C$ defined by
+  \begin{align*}
+    e_{A,B,C}(\inl(g)) \defeq \lam{x} \inl(g(x)),\\
+    e_{A,B,C}(\inr(g)) \defeq \lam{x} \inr(g(x))
+  \end{align*}
+  is an equivalence.
+  \begin{enumerate}
+  \item Show that any connected type is categorically connected.
+  \item Show that all categorically connected types are connected if and only if $\LEM{}$ holds. (Hint: consider $A \defeq \Sigma P$ such that $\neg \neg P$ holds.)
+  \end{enumerate}
+\end{ex}
+
 %%% Local Variables:
 %%% mode: latex
 %%% TeX-master: "hott-online"


### PR DESCRIPTION
Fix #920.
This exercise will be appended to the last of Exercise 7, so it will change no numbering.

Here are some questions:
(1) Is the solution to this exercise needed? If so, I think I can write it.
(2) Is an errata needed?
(3) Is the index `\makeindex{connected!categorically}` sufficient, or do we need extra `\makeindex`s?
