### PR TITLE
Updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,9 +37,7 @@ main.labels
 main.labelnumbers
 exercise_solutions.pdf
 indexterms.txt
-cover-lulu-paperback.pdf
-cover-lulu-hardcover.pdf
-cover-letter.pdf
+cover-*.pdf
 version.tex
 hott-arxiv.tex
 hott-arxiv.tar.gz


### PR DESCRIPTION
One of the generated cover pdfs, `cover-a4.pdf`, was not ignored; updated `.gitignore` to cover it.