### PR TITLE
Removed references to natbib, since not actually used since 2013.

### DIFF
--- a/CONVENTIONS.txt
+++ b/CONVENTIONS.txt
@@ -41,9 +41,8 @@
    chapter should have an unnumbered "Notes" section at the end
    containing references to the literature and relevant comments.
    References should go in the references.bib file in BibTeX format.
-   Try to use \cite for your citations so that they will all have a
-   uniform appearance; \cite is currently aliased to natbib's \citep,
-   but we may change it in the future.
+   Use \cite for your citations so that they will all have a uniform
+   appearance.
 
 4. The following theorem-type environments are predefined:
 

--- a/errata.tex
+++ b/errata.tex
@@ -104,7 +104,6 @@
 \usepackage[capitalize]{cleveref}
 \usepackage[all,2cell]{xy}
 \UseAllTwocells
-\usepackage{natbib}
 \usepackage{braket} % used for \setof{ ... } macro
 \usepackage{tikz}
 \usetikzlibrary{decorations.pathmorphing}

--- a/exercise_solutions.tex
+++ b/exercise_solutions.tex
@@ -104,7 +104,6 @@
 \usepackage[capitalize]{cleveref}
 \usepackage[all,2cell]{xy}
 \UseAllTwocells
-\usepackage{natbib}
 \usepackage{braket} % used for \setof{ ... } macro
 \usepackage{tikz}
 \usetikzlibrary{decorations.pathmorphing}

--- a/main.tex
+++ b/main.tex
@@ -87,7 +87,6 @@
 \usepackage[capitalize]{cleveref}
 \usepackage[all,2cell,cmtip]{xy}
 \UseAllTwocells
-%\usepackage{natbib}
 \usepackage{braket} % used for \setof{ ... } macro
 
 \usepackage{tikz}


### PR DESCRIPTION
Removed erroneous mention of `natbib` in `CONVENTIONS.txt` — `natbib` hasn't been used in the book since 6de1b62 (May 2013).  Also removed `\usepackage{natbib}` from `errata.tex` and `exercise-solutions.tex` — they don’t currently include any citations, so it has no effect now, but if they ever *do* need citations (see #928 shortly) they should be consistent with the book itself. 