### PR TITLE
Add Sambin credit in bibentry for Martin-Löf Biliopolis book (fixes #881)

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -677,7 +677,7 @@
 	Pages = {iv+91},
 	Publisher = {Bibliopolis},
 	Series = {Studies in Proof Theory},
-	Subtitle = {Notes by Giovanni Sambin},
+	Note = {Notes by Giovanni Sambin of a series of lectures given in Padua, June 1980},
 	Title = {Intuitionistic type theory},
 	Volume = {1},
 	Year = {1984}}


### PR DESCRIPTION
Does this need an erratum?  If so, see #928 re difficulty referring to bib entries from `errata.tex`. 