### PR TITLE
Fix typo in natural numbers addition example

### DIFF
--- a/errata.tex
+++ b/errata.tex
@@ -229,6 +229,10 @@ While the page numbering may differ between copies with different version marker
   & 111-g1e868fa
   & When translating English to type theory, ``unnamed variables'' are unnamed in English but must be named in type theory.\\
   %
+  \cref{sec:inductive-types}
+  & % merge of bf74e1eb426ed3eed1f41368c992d2ac52e11e8b
+  & In the definition of $\add$ by primitive recursion, curry over the first argument $m$ to match the type $\nat \to \nat$ of the second argument of $c_s$\\
+  %
   \cref{sec:identity-types}
   & 154-g4ef49f7
   & Emphasize that path induction, like all other induction principles, defines a \emph{specified} function.\\

--- a/preliminaries.tex
+++ b/preliminaries.tex
@@ -1113,7 +1113,7 @@ For example, we define addition $\add : \nat \to \nat \to \nat$ with $C \defeq \
   c_0 & : \nat \to \nat \\
   c_0 (n) & \defeq n \\
   c_s & : \nat \to (\nat \to \nat) \to (\nat \to \nat) \\
-  c_s(m,g)(n) & \defeq \suc(g(n)).
+  c_s(m,g(m))(n) & \defeq \suc(g(m)(n)).
 \end{align*}
 We thus obtain $\add : \nat \to \nat \to \nat$ satisfying the definitional equalities
 \begin{align*}


### PR DESCRIPTION
Section 1.9 on natural numbers gives the example of integer addition for primitive recursion with a function of several variables. The defining equation: \add(\suc(m),n) &\jdeq \suc(\add(m,n)) uses the "next step" function:

  c_s & : \nat \to (\nat \to \nat) \to (\nat \to \nat) \\
  c_s(m,g)(n) & \defeq \suc(g(n)).

The currying of g should be made explicit to match the type \nat \to \nat for the second parameter of c_s, e.g. c_s(m, g(m))(n) & \defeq \suc(g(m)(n)).