### PR TITLE
Fix minor typographical typo in reals.tex

### DIFF
--- a/reals.tex
+++ b/reals.tex
@@ -177,7 +177,7 @@ logical notation from \cref{defn:logical-notation}.
   : \Q \to \Omega$ which is:
   %
   \begin{enumerate}
-  \item \emph{inhabited:} $\exis{q : \Q} L(q)$ and $\exis{r : Q} U(r)$,
+  \item \emph{inhabited:} $\exis{q : \Q} L(q)$ and $\exis{r : \Q} U(r)$,
   \item \emph{rounded:} for all $q, r : \Q$,
     \index{rounded!Dedekind cut}
     %


### PR DESCRIPTION
Change $Q$ to $\Q$ for the set of rationals.