### PR TITLE
Don't refer to p which is not defined

### DIFF
--- a/basics.tex
+++ b/basics.tex
@@ -712,7 +712,8 @@ The notation $\apfunc f$ can be read either as the \underline{ap}plication of $f
 \end{proof}
 
 \begin{proof}[Second proof]
-  By induction, it suffices to assume $p$ is $\refl{x}$.
+  To define $\apfunc{f}(p)$ for all $p:x=y$, it suffices, by induction, to assume
+  $p$ is $\refl{x}$.
   In this case, we may define $\apfunc f(p) \defeq \refl{f(x)}:f(x)= f(x)$.
 \end{proof}
 


### PR DESCRIPTION
In the section "2.2 Functions are functors", Lemma 2.2.1 does not contain any reference to `p` but the second proof refers to `p` without any definition. I think this change might be a way to clarify the situation, but please take a look as I'm not confident that I understand the notational conventions or what is or is not supposed to be implicit.

If this change is accepted, I'm not sure something this minor needs to be mentioned in the errata, but again I'm not sure where the dividing line is for that.
