### PR TITLE
Exercise 3.14

### DIFF
--- a/errata.tex
+++ b/errata.tex
@@ -400,6 +400,10 @@ While the page numbering may differ between copies with different version marker
   \cref{thm:retract-contr}
   & 95-gce0131f
   & In the proof, $p$ should be $r$ to match the preceding definition of retraction.\\
+  % 
+  \cref{ex:lem-brck}
+  & % merge of 40c92d1
+  & Should be to show that $\neg\neg A$ satisfies the recursion principle of $\brck{A}$ but with only a propositional computation rule.\\
   %
   % Chapter 4
   %

--- a/logic.tex
+++ b/logic.tex
@@ -1210,7 +1210,9 @@ Of course, constructive and intuitionistic mathematics has a long and complicate
 \end{ex}
 
 \begin{ex}\label{ex:lem-brck}
-  Show that assuming \LEM{}, the double negation $\neg \neg A$ has the same universal property as the propositional truncation $\brck A$, and is therefore equivalent to it.
+  Show that assuming \LEM{}, the double negation $\neg \neg A$ has the same recursion principle as the propositional truncation $\brck A$ but with a propositional computation rule rather than a judgmental one.
+  In other words, prove that assuming \LEM{}, if $B$ is a mere proposition and we have $f:A\to B$, then there is an induced $g:\neg\neg A \to B$ such that $g(\bproj a) = f(a)$ for all $a:A$.
+  Deduce that (assuming \LEM{}) we have $\eqv{\neg\neg A}{\brck{A}}$.
   Thus, under \LEM{}, the propositional truncation can be defined rather than taken as a separate type former.
 \end{ex}
 
@@ -1218,7 +1220,7 @@ Of course, constructive and intuitionistic mathematics has a long and complicate
   \index{propositional!resizing}%
   Show that if we assume propositional resizing as in \cref{subsec:prop-subsets}, then the type
   \[\prd{P:\prop} \Parens{(A\to P)\to P}\]
-  has the same universal property as $\brck A$.
+  has the same recursion principle as $\brck A$, \emph{with} the same judgmental computation rule.
   Thus, we can also define the propositional truncation in this case.
 \end{ex}
 


### PR DESCRIPTION
As pointed out at https://math.stackexchange.com/questions/2679408/define-neg-neg-a-to-be-truncation-using-lem/2680026, exercise 3.14 is confusing because we haven't defined the "universal property" yet, and \neg\neg A doesn't have the judgmental computation rule of ||A||.