### PR TITLE
Fix typo in 6.5.3 lemma

### DIFF
--- a/errata.tex
+++ b/errata.tex
@@ -544,6 +544,10 @@ While the page numbering may differ between copies with different version marker
   & 1039-g30da4c6
   & In the sentence after the proof of \cref{thm:apd2}, the type family in which $s$ is a dependent path should be $\lam{p} \dpath P p b b$ instead of $P$.\\
   %
+  \cref{thm:based-map-pointed-type-eqv-unbased-fn}
+  & % merge of 8ebf2c3cdf8fdc8668ccf031e7af7df819bfab71
+  & Unbound variable $u$ was referenced where $\ttt$ was expected.\\
+  %
   \cref{sec:cell-complexes}
   & 289-gdefeb8c
   & In the induction principle for the torus, the types of $p'$ and $q'$ should be $\dpath P p {b'} {b'}$ and $\dpath P q b b$ respectively.\\

--- a/hits.tex
+++ b/hits.tex
@@ -660,7 +660,7 @@ Note that any type $A$ gives rise to a pointed type $A_+ \defeq A+\unit$ with ba
 Note that on the right we have the ordinary type of \emph{unbased} functions from $A$ to $B$.
 \begin{proof}
   From left to right, given $f:A_+ \to B$ with $p:f(\inr(\ttt)) = b_0$, we have $f\circ \inl : A \to B$.
-  And from right to left, given $g:A\to B$ we define $g':A_+ \to B$ by $g'(\inl(a))\defeq g(a)$ and $g'(\inr(u)) \defeq b_0$.
+  And from right to left, given $g:A\to B$ we define $g':A_+ \to B$ by $g'(\inl(a))\defeq g(a)$ and $g'(\inr(\ttt)) \defeq b_0$.
   We leave it to the reader to show that these are quasi-inverse operations.
 \end{proof}
 

--- a/hits.tex
+++ b/hits.tex
@@ -653,7 +653,7 @@ Note that any type $A$ gives rise to a pointed type $A_+ \defeq A+\unit$ with ba
 \index{disjoint!basepoint}%
 \index{adjoining a disjoint basepoint}%
 
-\begin{lem}
+\begin{lem}\label{thm:based-map-pointed-type-eqv-unbased-fn}
   For a type $A$ and a pointed type $(B,b_0)$, we have
   \[ \eqv{\Map_*(A_+,B)}{(A\to B)} \]
 \end{lem}


### PR DESCRIPTION
1. I added `\label` to fixed lemma so I can reference it in errata. It was the only lemma in HIT (6th) chapter without `\label`
2. Visually (in PDF) numberings did not change but `make labelcheck` prints `Some label numbers have changed since the first edition!` both before and after my change. Output of `make labelcheck` is identical before and after my change so I assume it's okay.
