### PR TITLE
Option to typeset exercises one-per-page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 DEFAULTTOPTEX = hott-online.tex
 
 # Top-level LaTeX files from which HoTT book can be generated
-TOPTEXFILES = $(DEFAULTTOPTEX) hott-ustrade.tex hott-letter.tex hott-a4.tex hott-ebook.tex hott-arxiv.tex
+TOPTEXFILES = $(DEFAULTTOPTEX) hott-ustrade.tex hott-letter.tex hott-letter-exercises.tex hott-a4.tex hott-a4-exercises.tex hott-ebook.tex hott-arxiv.tex
 
 # LaTeX files that actually comprise the book
 # (that is, all of them except configuration)

--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ code. Also, the file `version.tex` is generated on the fly, so you will need the
 * `make hott-ebook.pdf` -- the book with small margins, suitable for ebook readers
 * `make hott-letter.pdf hott-cover.pdf` -- the book in black & white, letter paper format,
    for printing at home, as well as a color cover (just two pages)
+*  make hott-letter-exercises.pdf -- the book in black & white, letter paper format, but with exercises one-per-page
 * `make hott-a4.pdf hott-a4.pdf` -- the book in black & white, A4 paper format,
    for printing at home, as well as a color cover (just two pages)
+*  make hott-letter-exercises.pdf -- the book in black & white, A4 paper format, but with exercises one-per-page
 * `make hott-ustrade.pdf cover-lulu-hardcover.pdf cover-lulu-paperback.pdf` --
    the book in US Trade format, without cover, used for the bound copy available
    at http://lulu.com/

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ code. Also, the file `version.tex` is generated on the fly, so you will need the
 *  make hott-letter-exercises.pdf -- the book in black & white, letter paper format, but with exercises one-per-page
 * `make hott-a4.pdf hott-a4.pdf` -- the book in black & white, A4 paper format,
    for printing at home, as well as a color cover (just two pages)
-*  make hott-letter-exercises.pdf -- the book in black & white, A4 paper format, but with exercises one-per-page
+*  make hott-a4-exercises.pdf -- the book in black & white, A4 paper format, but with exercises one-per-page
 * `make hott-ustrade.pdf cover-lulu-hardcover.pdf cover-lulu-paperback.pdf` --
    the book in US Trade format, without cover, used for the bound copy available
    at http://lulu.com/

--- a/hott-a4-exercises.tex
+++ b/hott-a4-exercises.tex
@@ -1,7 +1,7 @@
 % -*- mode: LaTeX -*-
 % This is a main LaTeX file for generating the HoTT book
-% for printing on A4 paper. The links are black in this
-% version.
+% for printing on A4 paper, with exercises on per page.
+% The links are black in this version.
 
 % **** OPTIONS ****
 

--- a/hott-a4-exercises.tex
+++ b/hott-a4-exercises.tex
@@ -1,0 +1,31 @@
+% -*- mode: LaTeX -*-
+% This is a main LaTeX file for generating the HoTT book
+% for printing on A4 paper. The links are black in this
+% version.
+
+% **** OPTIONS ****
+
+% INCLUDE A COVER
+\input{opt-cover}
+
+% INCLUDE A BASTARD TITLE
+\input{opt-bastard}
+
+% BLACK & WHITE
+\input{opt-black-white}
+
+% FORMATTING DEPENDENT ON PAPER SIZE
+\input{opt-a4}
+
+% ONE EXERCISE PER PAGE
+\input{opt-exerciseperpage}
+
+% IMAGE FOR HALF-TITLE
+\def\OPThalftorus{torus-hires-bw}
+
+% IMAGE FOR FRONT AND BACK
+\let\OPTfrontimage=\OPThifrontimage
+\let\OPTbackimage=\OPThibackimage
+
+% INCLUDE THE ACTUAL MAIN FILE
+\input{main}

--- a/hott-a4-exercises.tex
+++ b/hott-a4-exercises.tex
@@ -1,7 +1,7 @@
 % -*- mode: LaTeX -*-
 % This is a main LaTeX file for generating the HoTT book
-% for printing on A4 paper, with exercises on per page.
-% The links are black in this version.
+% for printing on A4 paper, with exercises printed
+% one per page. The links are black in this version.
 
 % **** OPTIONS ****
 

--- a/hott-letter-exercises.tex
+++ b/hott-letter-exercises.tex
@@ -1,0 +1,31 @@
+% -*- mode: LaTeX -*-
+% This is a main LaTeX file for generating the HoTT book
+% for printing on letter paper. The links are black in this
+% version.
+
+% **** OPTIONS ****
+
+% INCLUDE A COVER
+\input{opt-cover}
+
+% INCLUDE A BASTARD TITLE
+\input{opt-bastard}
+
+% BLACK & WHITE
+\input{opt-black-white}
+
+% FORMATTING DEPENDENT ON PAPER SIZE
+\input{opt-letter}
+
+% ONE EXERCISE PER PAGE
+\input{opt-exerciseperpage}
+
+% IMAGE FOR HALF-TITLE
+\def\OPThalftorus{torus-hires-bw}
+
+% IMAGE FOR FRONT AND BACK
+\let\OPTfrontimage=\OPThifrontimage
+\let\OPTbackimage=\OPThibackimage
+
+% INCLUDE THE ACTUAL MAIN FILE
+\input{main}

--- a/hott-letter-exercises.tex
+++ b/hott-letter-exercises.tex
@@ -1,7 +1,7 @@
 % -*- mode: LaTeX -*-
 % This is a main LaTeX file for generating the HoTT book
-% for printing on letter paper. The links are black in this
-% version.
+% for printing on letter paper, with exercises printed
+% one per page. The links are black in this version.
 
 % **** OPTIONS ****
 

--- a/macros.tex
+++ b/macros.tex
@@ -4,7 +4,7 @@
 %%% Notes and exercise sections
 \makeatletter
 \newcommand{\sectionNotes}{\phantomsection\section*{Notes}\addcontentsline{toc}{section}{Notes}\markright{\textsc{\@chapapp{} \thechapter{} Notes}}}
-\newcommand{\sectionExercises}[1]{\phantomsection\section*{Exercises}\addcontentsline{toc}{section}{Exercises}\markright{\textsc{\@chapapp{} \thechapter{} Exercises}}}
+\newcommand{\sectionExercises}[1]{\ifdef{\OPTexerciseperpage}{\newpage}{}\phantomsection\section*{Exercises}\addcontentsline{toc}{section}{Exercises}\markright{\textsc{\@chapapp{} \thechapter{} Exercises}}}
 \makeatother
 
 %%% Definitional equality (used infix) %%%

--- a/main.tex
+++ b/main.tex
@@ -150,6 +150,12 @@
 \nopagecolor
 \fi
 
+% Make a new page for each exercise, if the option is set
+\ifdef{\OPTexerciseperpage}
+  {
+    \BeforeBeginEnvironment{ex}{\newpage}
+  }{}
+
 \begin{document}
 
 % NB: This does not actually appear anywhere because we have

--- a/opt-exerciseperpage.tex
+++ b/opt-exerciseperpage.tex
@@ -1,0 +1,1 @@
+\def\OPTexerciseperpage{}           % Put \newpage at the beginning of each exercise


### PR DESCRIPTION
Adds a new options file opt-exerciseperpage.tex, two new top-level tex files `hott-a4-exercises.tex` and `hott-letter-exercises.tex` and corresponding makefile targets. The resulting PDFs swill start each exercise on a new page.

This is useful for printing exercises in a form that affords space to work each exercise. Example exercise page:
[hott-letter-exercises-1.1.pdf](https://github.com/HoTT/book/files/1864904/hott-letter-exercises-1.1.pdf)
