### PR TITLE
Fix missing `apfunc` in lemma `transport-s1-code`

### DIFF
--- a/errata.tex
+++ b/errata.tex
@@ -667,6 +667,10 @@ While the page numbering may differ between copies with different version marker
   %
   % Chapter 8
   %
+  \cref{lem:transport-s1-code}
+  & % merge of 28a54e3024104d5b695ebaa468125947dce89010
+  & Ordinary function application ($\ap{\code}{\lloop}$) was given where application to path was required ($\apfunc{\code}({\lloop})$).\\
+  %
   \cref{lem:s1-encode-decode}
   & 535-g0a9abfe
   & The proof by induction on $n:\Z$ is justified by \cref{thm:sign-induction}, not \cref{thm:looptothe}.\\

--- a/homotopy.tex
+++ b/homotopy.tex
@@ -452,7 +452,7 @@ $\opp{\lloop}$ to the predecessor function:
 For the first equation, we calculate as follows:
 \begin{align}
 {\transfib \code \lloop x}
-&= \transfib {A \mapsto A} {(\ap{\code}{\lloop})} x \tag{by \cref{thm:transport-compose}}\\
+&= \transfib {A \mapsto A} {\apfunc{\code}({\lloop})} x \tag{by \cref{thm:transport-compose}}\\
 &= \transfib {A \mapsto A} {\ua (\Zsuc)} x \tag{by computation for $\rec{\Sn^1}$}\\
 &= x + 1 \tag{by computation for \ua}.
 \end{align}


### PR DESCRIPTION
Hello!
In proof of `transport-s1-code` the `transport-compose` lemma was applied incorrectly and there was ordinary application of function instead of application to path which made proof incorrectly-typed
This time it's real typo fix :)