### PR TITLE
Erratum for 48c7c7d

### DIFF
--- a/errata.tex
+++ b/errata.tex
@@ -730,6 +730,10 @@ While the page numbering may differ between copies with different version marker
   & 1092-ge3b8b71
   & After applying the induction hypothesis, it additionally needs to be checked that for every path $p : a = a$ the map $\pi_k(\apfunc f):\pi_k(x = x,p) \to \pi_k(f(x) = f(x),\apfunc f(p))$ is a bijection. \\
   %
+  \cref{sec:general-encode-decode}
+  & % merge of 48c7c7db90a3b1fa9ceff34a48d6872307f24fce
+  & In the strengthening of condition (iii) from \cref{lem:encode-decode-loop}, the right side should read just ``$c$'' instead of ``$c.a$''.\\
+  %
   % Chapter 9
   %
   \cref{ct:functor}

--- a/homotopy.tex
+++ b/homotopy.tex
@@ -2568,7 +2568,7 @@ clarify the method by stating them in generality.  The simplest
 case is using an encode-decode method to characterize the loop space of a
 type, as in \cref{thm:path-coprod} and \cref{{cor:omega-s1}}.
 
-\begin{lem}[Encode-decode for Loop Spaces]
+\begin{lem}[Encode-decode for Loop Spaces]\label{lem:encode-decode-loop}
   \index{loop space}%
 Given a pointed type $(A,a_0)$ and a fibration
 $\code : A \to \type$, if


### PR DESCRIPTION
I'm not too familiar with cleveref but I think this is right.