### PR TITLE
Fix typo, missing parenthesis in transport

### DIFF
--- a/basics.tex
+++ b/basics.tex
@@ -1511,7 +1511,7 @@ This appears in the statement of action of transport on $\Sigma$-types, which is
   \end{equation*}
   For any path $p:x=y$ and any $(u,z):\sm{u:P(x)} Q(x,u)$ we have
   \begin{equation*}
-    \trans{p}{u,z}=\big(\trans{p}{u},\,\trans{\pairpath(p,\refl{\trans pu})}{z}\big).
+    \trans{p}{(u,z)}=\big(\trans{p}{u},\,\trans{\pairpath(p,\refl{\trans pu})}{z}\big).
   \end{equation*}
 \end{thm}
 


### PR DESCRIPTION
`\trans{p}{_}` is a unary-function. 