### PR TITLE
Fix a tiny typo

### DIFF
--- a/reals.tex
+++ b/reals.tex
@@ -2459,7 +2459,7 @@ difference between pointwise and inductive covers is not what they cover but in 
 We could write another book by going on like this, but let us stop here and hope that we
 have provided ample justification for the claim that analysis can be developed in homotopy
 type theory. The curious reader should consult \cref{ex:mean-value-theorem} for
-constructive versions of the mean value theorem.
+constructive versions of the intermediate value theorem.
 
 \index{acceptance|)}
 


### PR DESCRIPTION
(The intermediate value theorem is about continuous functions having a zero, while the mean value theorem is about differentiable functions.)

1. Shall I add an entry to the errata list?
2. Shall I change the label of the exercise (from `ex:mean-value-theorem` to `ex:intermediate-value-theorem`)?