### PR TITLE
Misspell: indiscernability -> indiscernibility

### DIFF
--- a/basics.tex
+++ b/basics.tex
@@ -749,8 +749,8 @@ Since \emph{dependently typed} functions are essential in type theory, we will a
 However, this is not quite so simple to state, because if $f:\prd{x:A} B(x)$ and $p:x=y$, then $f(x):B(x)$ and $f(y):B(y)$ are elements of distinct types, so that \emph{a priori} we cannot even ask whether they are equal.
 The missing ingredient is that $p$ itself gives us a way to relate the types $B(x)$ and $B(y)$.
 
-We have already seen this in \autoref{sec:identity-types}, where we called it ``indiscernability of identicals''.
-\index{indiscernability of identicals}%
+We have already seen this in \autoref{sec:identity-types}, where we called it ``indiscernibility of identicals''.
+\index{indiscernibility of identicals}%
 We now introduce a different name and notation for it that we will use from now on.
 
 \begin{lem}[Transport]\label{lem:transport}

--- a/preliminaries.tex
+++ b/preliminaries.tex
@@ -1584,10 +1584,10 @@ This is well-typed because $a\jdeq b$ means that also the type $\id[A]{a}{b}$ is
 
 The induction principle (i.e.\ the elimination rule) for the identity types is one of the most subtle parts of type theory, and crucial to the homotopy interpretation.
 We begin by considering an important consequence of it, the principle that ``equals may be substituted for equals'', as expressed by the following:
-\index{indiscernability of identicals}%
+\index{indiscernibility of identicals}%
 \index{equals may be substituted for equals}%
 \begin{description}
-\item[Indiscernability of identicals:]
+\item[Indiscernibility of identicals:]
 For every family 
 \[
 C : A \to \UU
@@ -1603,8 +1603,8 @@ f(x,x,\refl{x}) \defeq \idfunc[C(x)].
 \end{description}
 This says that every family of types $C$ respects equality, in the sense that applying $C$ to \emph{equal} elements of $A$ also results in a function between the resulting types. The displayed equality states that the function associated to reflexivity is the identity function (and we shall see that, in general, the function $f(x,y,p): C(x) \to C(y)$ is always an equivalence of types).
 
-Indiscernability of identicals can be regarded as a recursion principle for the identity type, analogous to those given for booleans and natural numbers above.
-Just as $\rec{\nat}$ gives a specified map $\nat\to C$ for any other type $C$ of a certain sort, indiscernability of identicals gives a specified map from $\id[A] x y$ to certain other reflexive, binary relations on $A$, namely those of the form $C(x) \to C(y)$ for some unary predicate $C(x)$.
+Indiscernibility of identicals can be regarded as a recursion principle for the identity type, analogous to those given for booleans and natural numbers above.
+Just as $\rec{\nat}$ gives a specified map $\nat\to C$ for any other type $C$ of a certain sort, indiscernibility of identicals gives a specified map from $\id[A] x y$ to certain other reflexive, binary relations on $A$, namely those of the form $C(x) \to C(y)$ for some unary predicate $C(x)$.
 We could also formulate a more general recursion principle with respect to reflexive relations of the more general form $C(x,y)$.
 However, in order to fully characterize the identity type, we must generalize this recursion principle to an induction principle, which not only considers maps out of $\id[A] x y$ but also families over it.
 Put differently, we consider not only allowing equals to be substituted for equals, but also taking into account the evidence $p$ for the equality.
@@ -1658,7 +1658,7 @@ with the equality\index{computation rule!for identity types}
 \[ \indid{A}(C,c,x,x,\refl{x}) \defeq c(x). \]
 The function $ \indid{A}$ is traditionally called $J$.
 \indexsee{J@$J$}{induction principle for identity type}%
-We will show in \cref{lem:transport} that indiscernability of identicals is an instance of path induction, and also give it a new name and notation.
+We will show in \cref{lem:transport} that indiscernibility of identicals is an instance of path induction, and also give it a new name and notation.
 
 \mentalpause
 
@@ -2032,7 +2032,7 @@ Give an alternative derivation of $\indidb{A}$ from $\indid{A}$ which avoids the
 \end{ex}
 
 \begin{ex}\label{ex:subtFromPathInd}
-  Show that indiscernability of identicals follows from path induction.  
+  Show that indiscernibility of identicals follows from path induction.  
 \end{ex}
 
 \begin{ex}\label{ex:add-nat-commutative}


### PR DESCRIPTION
Hi

* Reference:
https://plato.stanford.edu/entries/identity-indiscernible/
3rd paragraph of "1. Formulating the Principle":
"The converse of the Principle, x=y → ∀F(Fx ↔ Fy), is called the Indiscernibility of Identicals."

* I "grep"ed all the files and fixed all of them.

* I guess this is a trivial change so I didn't edit the errata.