### PR TITLE
Fix arXiv link for [Rez01]

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -462,7 +462,7 @@
 
 @article{rezk01css,
 	Author = {Rezk, Charles},
-	Note = {\href{http://arxiv.org/abs/math.AT/}{arXiv:math.AT/9811037}},
+	Note = {\href{https://arxiv.org/abs/math.AT/9811037}{arXiv:math.AT/9811037}},
 	Issn = {0002-9947},
 	Journal = {Transactions of the American Mathematical Society},
 	Number = 3,


### PR DESCRIPTION
http://arxiv.org/abs/math.AT/ changed to https://arxiv.org/abs/math.AT/9811037