### PR TITLE
fix Church reference typo

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -996,7 +996,7 @@ URL = {http://journals.cambridge.org/article_S0960129514000516},
 @book{Church:1941tc,
 	Author = {Alonzo Church},
 	Publisher = {Princeton University Press},
-	Title = {The Calculi of Lambda Conversation},
+	Title = {The Calculi of Lambda Conversion},
 	Year = {1941}}
 
 @article{kolmogorov,


### PR DESCRIPTION
There was a typo on a reference: Alonzo Church. The Calculi of Lambda Conversation. -> Alonzo Church. The Calculi of Lambda Conversion.