### PR TITLE
fix broken link to Generalization of Takeuti-Gandy Interpretation

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -430,7 +430,7 @@
 @Unpublished{coquand2012constructive,
   author =       {Bruno Barras and Thierry Coquand and Simon Huber},
   title =        {A Generalization of {T}akeuti-{G}andy Interpretation},
-  note =         {\url{http://uf-ias-2012.wikispaces.com/file/view/semi.pdf}},
+  note =         {\url{https://ncatlab.org/ufias2012/files/semi.pdf}},
   year =      2013}
 
 @Misc{RijkeSpitters,


### PR DESCRIPTION
uf-iias-2012.wikispaces is no longer active
There are two links pointing there. One is fixed in #1016
This PR fix the other one (to Generalization of Takeuti-Gandy Interpretation - Bruno Barras, Thierry Coquand and Simon Huber).

Link changed from `uf-iias-2012.wikispaces` to `ncatlab.org/ufias2012/files`