### PR TITLE
Fix a few typos in categories.tex

### DIFF
--- a/categories.tex
+++ b/categories.tex
@@ -636,7 +636,7 @@ By \cref{ct:adjprop,ct:isoprop}, if $A$ is a category, then the type ``$F$ is an
   Thus, the composites in both directions are equal to identities, hence we have an equivalence \eqv{\text{\ref{item:ct:ffeso1}}}{\text{\ref{item:ct:ffeso2}}}.
 \end{proof}
 
-However, if $B$ is not a category, then neither type in \cref{ct:ffeso} may necessarily be a mere proposition.
+However, if $A$ is not a category, then neither type in \cref{ct:ffeso} may necessarily be a mere proposition.
 This suggests considering as well the following notions.
 
 \begin{defn}\label{ct:essentially-surjective}
@@ -1231,7 +1231,7 @@ of $\bbU$-small sets, where $\bbU$ is a univalent type universe.
     \indexsee{PH-structure@$(P,H)$-structure}{structure}%
     \indexdef{structure!PH@$(P,H)$-}%
     on $x$.
-  \item For $x,y:X_0$ and $\alpha:Px$, $\;\beta:Py$, to each $f:\hom_X(x,y)$ a mere proposition
+  \item For $x,y:X_0$ and $\alpha:Px$, $\;\beta:Py$, we associate to each $f:\hom_X(x,y)$ a mere proposition
   \[ H_{\alpha\beta}(f).\]
     If $H_{\alpha\beta}(f)$ is true, we say that $f$ is a \define{$(P,H)$-homomorphism}
     \indexdef{homomorphism!of structures}%
@@ -1680,7 +1680,7 @@ However, there are a few cases in which the Rezk completion is necessary to obta
   \index{fundamental!pregroupoid}%
   \indexsee{groupoid!fundamental}{fundamental group\-oid}%
   Its Rezk completion is the \emph{fundamental groupoid} of $X$.
-  Recalling that groupoids are equivalent to 1-types, it is not hard to identify this groupoid with $\trunc1X$.
+  Recalling that group\-oids are equivalent to 1-types, it is not hard to identify this groupoid with $\trunc1X$.
 \end{eg}
 
 \begin{eg}\label{ct:hocat}

--- a/categories.tex
+++ b/categories.tex
@@ -1231,7 +1231,7 @@ of $\bbU$-small sets, where $\bbU$ is a univalent type universe.
     \indexsee{PH-structure@$(P,H)$-structure}{structure}%
     \indexdef{structure!PH@$(P,H)$-}%
     on $x$.
-  \item For $x,y:X_0$ and $\alpha:Px$, $\;\beta:Py$, we associate to each $f:\hom_X(x,y)$ a mere proposition
+  \item For $x,y:X_0$, $f:\hom_X(x,y)$ and $\alpha:Px$, $\;\beta:Py$, a mere proposition
   \[ H_{\alpha\beta}(f).\]
     If $H_{\alpha\beta}(f)$ is true, we say that $f$ is a \define{$(P,H)$-homomorphism}
     \indexdef{homomorphism!of structures}%

--- a/errata.tex
+++ b/errata.tex
@@ -748,6 +748,10 @@ While the page numbering may differ between copies with different version marker
   & 807-gebec78b
   & In \cref{ct:functor:comp}, it should read ``$\hom_A(b,c)$'' instead of ``$\hom_B(b,c)$''.\\
   %
+  \cref{sec:equivalences}
+  & % merge of 6abd18e14122a98fb8cfbd9aa90d3844f9cb7d45
+  & Just before \cref{ct:essentially-surjective}, it should say ``However, if $A$ is not a category'' instead of ``However, if $B$ is not a category''.\\
+  %
   \cref{ct:yoneda}
   & 971-g6096085
   & The sequence of equations at the end of the proof should begin with $\alpha_{a'}(f) = \alpha_{a'} (\y a_{a,a'}(f)(1_a))$, and thereafter the subscripts should remain $a,a'$ rather than $a',a$.\\


### PR DESCRIPTION
The optional hyphen added to "groupoids" is to help handle an overfull
line in the ebook version.  I built the ebook version and the online
version and tested that the changes look fine there.  I also updated
the list of errata for the one mathematical change.