### PR TITLE
Fix typo: B is a function and needs to be applied to a value

### DIFF
--- a/formal.tex
+++ b/formal.tex
@@ -300,7 +300,7 @@ Using non-dependent function types and leaving implicit the context $\Gamma$, th
 %
 \begin{itemize}
 \item if $A:\UU_n$ and $B:A\to\UU_n$, then $\tprd{x:A}B(x) : \UU_n$
-\item if $x:A \vdash b:B$ then $ \lam{x} b : \tprd{x:A} B(x)$
+\item if $x:A \vdash b:B(x)$ then $ \lam{x} b : \tprd{x:A} B(x)$
 \item if $g:\tprd{x:A} B(x)$ and $t:A$ then $g(t):B(t)$
 \end{itemize}
 %


### PR DESCRIPTION
In this context, rather than depending on $x$ implicitly, $B$ takes an argument (of type $A$).

Closes #1046.