### PR TITLE
Improve typography, using true small capitals and microtypography

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ and nightly builds are available on the
 ## Prerequisites and compilation
 
 To compile the book for yourself you need a fairly new version of LaTeX.
-[Texlive](http://www.tug.org/texlive/) 2012 is confirmed to work. You might need
+[Texlive](http://www.tug.org/texlive/) 2018 is confirmed to work. You might need
 to install some packages; see `main.tex` for packages that are used by the book.
 
 [BasicTeX](http://www.tug.org/mactex/morepackages.html), which is a minimalistic
 version of MacTeX, is confirmed to work once the following packages have been
-installed: `tlmgr`, `install`, `braket`, `comment`, `courier`, `enumitem`,
-`helvetic`, `mathpazo`, `nextpage`, `ntheorem`, `palatino`, `rsfs`, `stmaryrd`,
+installed: `tlmgr`, `install`, `braket`, `comment`, `courier`, `domitian`, `enumitem`,
+`helvetic`, `mathpazo`, `microtype`, `nextpage`, `ntheorem`, `palatino`, `rsfs`, `stmaryrd`,
 `symbol`, `titlesec`, `wallpaper`, `wasy`, `wasysym`, `xstring`, `zapfding`.
 
 You also need the `make` utility. The book is a fairly complex piece of LaTeX

--- a/main.tex
+++ b/main.tex
@@ -56,10 +56,14 @@
 \usepackage{multicol}
 
 %%% Set the fonts
-\usepackage{mathpazo}
+\usepackage{mathpazo,domitian}
 \usepackage[scaled=0.95]{helvet}
 \usepackage{courier}
 \linespread{1.05} % Palatino looks better with this
+
+%%% Use microtypography
+\usepackage[expansion=all,protrusion,step=1]{microtype}
+\DeclareMicrotypeAlias{Domitian}{ppl}
 
 \usepackage{ifpdf}
 


### PR DESCRIPTION
This is a typographic adjustment to the book, and does not impact the content.

There are two changes which are:

(1) Use Domitian as the body text font (the math font remains Pazo). Domitian is an updated and extended version of the URW Palladio font (which was the version of Palatino being used already). Its basis is an updated version of Palladio released by URW in 2015; Domitian goes further by adding true small capitals. Now, you will notice that the main difference introduced by this change is the presence of the small capitals in the headers. This is in contrast with the formerly-used package, which used scaled-down versions of the normal-size capitals instead. This is a bit ugly and is not generally considered typographically correct where it can be avoided. (Disclaimer: I am the maintainer of this package.)

(2) I have enabled microtypography, which is a feature of pdfLaTeX (and has been for a number of years). Two features of microtypography have been enabled: protrusion and expansion. The first of these features, protrusion, means that punctuation may slightly protrude from the edge of the line; this is common in professionally published material. Expansion, meanwhile, allows for characters to be stretched and squeezed very slightly, in a way which is not visually noticeable. The benefit of these small adjustments is that the lines are spaced in a way which looks more natural, with far fewer line breaks in the middle of words and the avoidance of bad compositional features such as rivers. Also, I have set `microtype` to use protrusion settings specifically tailed for Palatino.

These packages are part of the standard TeX distributions.