### PR TITLE
Add an admissible substitution rule and clarify congruence.

### DIFF
--- a/formal.tex
+++ b/formal.tex
@@ -595,7 +595,7 @@ assume that judgmental equality is an equivalence relation respected by typing.
 \end{mathparpagebreakable}
 %
 Finally, we assume that judgmental equality is a congruence respected by typing,
-i.e., that each constructor locally preserves judgmental equality in each of its
+i.e., that each constructor preserves judgmental equality in each of its
 arguments. For instance, along with the $\Pi$-\rintro\ rule, we assume the rule
 \[
   \inferrule*[right=$\Pi$-\rintro-eq]

--- a/formal.tex
+++ b/formal.tex
@@ -571,6 +571,10 @@ and for judgmental equalities they become
   {\oftp\Gamma{a}{A} \\ \jdeqtp{\Gamma,\tmtp xA,\Delta}{b}{c}{B}}
   {\jdeqtp{\Gamma,\Delta[a/x]}{b[a/x]}{c[a/x]}{B[a/x]}}
 \and
+  \inferrule*[right=$\Subst_3$]
+  {\jdeqtp\Gamma{a}{b}{A} \\ \oftp{\Gamma,\tmtp xA,\Delta}{c}{C}}
+  {\jdeqtp{\Gamma,\Delta[a/x]}{c[a/x]}{c[b/x]}{C[a/x]}}
+\and
   \inferrule*[right=$\Weak_2$]
   {\oftp\Gamma{A}{\UU_i} \\ \jdeqtp{\Gamma,\Delta}{b}{c}{B}}
   {\jdeqtp{\Gamma,\tmtp xA,\Delta}{b}{c}{B}}
@@ -590,7 +594,9 @@ assume that judgmental equality is an equivalence relation respected by typing.
   \inferrule*{\jdeqtp\Gamma{a}{b}{A} \\ \jdeqtp\Gamma{A}{B}{\UU_i}}{\jdeqtp\Gamma{a}{b}{B}}
 \end{mathparpagebreakable}
 %
-Additionally, for all the type formers below, we assume rules stating that each constructor preserves definitional equality in each of its arguments; for instance, along with the $\Pi$-\rintro\ rule, we assume the rule
+Finally, we assume that judgmental equality is a congruence respected by typing,
+i.e., that each constructor locally preserves judgmental equality in each of its
+arguments. For instance, along with the $\Pi$-\rintro\ rule, we assume the rule
 \[
   \inferrule*[right=$\Pi$-\rintro-eq]
   {\oftp\Gamma{A}{\UU_i} \\
@@ -598,7 +604,8 @@ Additionally, for all the type formers below, we assume rules stating that each 
    \jdeqtp{\Gamma,\tmtp xA}{b}{b'}{B}}
   {\jdeqtp\Gamma{\lamu{x:A} b}{\lamu{x:A'} b'}{\tprd{x:A} B}}
 \]
-However, we omit these rules for brevity.
+Taken together, these local principles imply the global congruence principles
+$\Subst_2$ and $\Subst_3$ above. We will omit these local rules for brevity.
 
 \index{rule!structural|)}%
 \index{structural!rules|)}%


### PR DESCRIPTION
Closes #1061. Two changes:

- add the admissible rule "if a = b : A and x : A |- c : C then c[a/x] = c[b/x] : C[a/x]"
- clarify that the "congruence rules" express local congruence, and these congruence rules together imply the above "global congruence".