### PR TITLE
Small fix for the proof of Theorem 11.5.6

### DIFF
--- a/errata.tex
+++ b/errata.tex
@@ -878,6 +878,10 @@ While the page numbering may differ between copies with different version marker
   & 87-g82b27c3
   & \eqref{eq:untruncated-linearity} should be $c:\prd{q, r : \Q} (q < r) \to (q < x) + (x < r)$, and therefore the use of $c$ in the proof should be $c(s,t)$ rather than $c(x,s,t)$.\\
   %
+  \cref{analysis-interval-ctb}
+  & merge of ad72d4e
+  & In the proof, $n : \N$ should be $k : \N$. And the range of $i$ should be $0 \leq i \leq k$. Also in the last equation, $r(\lim x) = \ell$ should be $\lim x = \ell$.\\
+  %
   \cref{sec:surreals}
   & 1189-ga9c35f0
   & The inductive case of $\iota_{\Q_D}$ should be defined as $\iota_{\Q_D}(a/2^n) \defeq \surr{\iota_{\Q_D}(a/2^n - 1/2^n)}{\iota_{\Q_D}(a/2^n + 1/2^n)}$.\\

--- a/reals.tex
+++ b/reals.tex
@@ -2027,9 +2027,9 @@ Let us show that $[0,1]$ is compact in the first sense.
 \end{thm}
 
 \begin{proof}
-  Given $\epsilon : \Qp$, there is $n : \N$ such that $2/k < \epsilon$, so we may take the
-  $\epsilon$-net $x_i = i/k$ for $i = 0, \ldots, k-1$. This is an $\epsilon$-net because,
-  for every $y : [0,1]$ there merely exists $i$ such that $0 \leq i < k$ and $(i -
+  Given $\epsilon : \Qp$, there is $k : \N$ such that $2/k < \epsilon$, so we may take the
+  $\epsilon$-net $x_i = i/k$ for $i = 0, \ldots, k$. This is an $\epsilon$-net because,
+  for every $y : [0,1]$ there merely exists $i$ such that $0 \leq i \leq k$ and $(i -
   1)/k < y < (i+1)/k$, and so $|y - x_i| < 2/k < \epsilon$.
 
   For completeness of $[0,1]$, consider a Cauchy approximation $x : \Qp \to
@@ -2041,7 +2041,7 @@ Let us show that $[0,1]$ is compact in the first sense.
     r(\ell) =
     r (\lim x) =
     \lim (r \circ x) =
-    r (\lim x) =
+    \lim x =
     \ell,
   \end{equation*}
   %


### PR DESCRIPTION
- typo: $n$ → $k$
- include $i=k$ for the case $y=1$ which doesn't have $i$ for $0 \leq i < k$ satisfying $(i-1)/k < y < (i+1)/k$
- remove application of $r$ (the equality looks using the fact $r$ behaves just as identity now, it looks somehow typo?)

And sorry for not writing eratta, but I don't know how to write because it includes several points (could I write it for each point?).