### PR TITLE
Fixed typo in introduction to W-types section

### DIFF
--- a/induction.tex
+++ b/induction.tex
@@ -255,7 +255,7 @@ In \cref{sec:initial-alg} we will see that inductive types actually do have a un
 
 Inductive types are very general, which is excellent for their usefulness and applicability, but makes them difficult to study as a whole.
 Fortunately, they can all be formally reduced to a few special cases.
-It is beyond the scope of this book to discuss this reduction --- which is anyway irrelevant to the mathematician using type theory in practice --- but we will take a little time to discuss the one of the basic special cases that we have not yet met.
+It is beyond the scope of this book to discuss this reduction --- which is anyway irrelevant to the mathematician using type theory in practice --- but we will take a little time to discuss one of the basic special cases that we have not yet met.
 These are Martin-L{\"o}f's \emph{$\w$-types}, also known as the types of \emph{well-founded trees}.
 \index{tree, well-founded}%
 $\w$-types are a generalization of such types as natural numbers, lists, and binary trees, which are sufficiently general to encapsulate the ``recursion'' aspect of \emph{any} inductive type.


### PR DESCRIPTION
In the intro of the section on W-types in the Induction chapter, I changed the line
" but we will take a little time to discuss the one of the basic special cases that we have not yet met."
to
"but we will take a little time to discuss one of the basic special cases that we have not yet met."