### PR TITLE
Fix anomalous newline screwing things up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ log-check:
 	! grep -n "!! Input index error" hott-online.ilg /dev/null
 
 version.tex:
-	/bin/echo -n '\newcommand{\OPTversion}{' > version.tex
+	/bin/echo -n '\\newcommand{\\OPTversion}{' > version.tex
 	git describe --always --long >> version.tex
 	/bin/echo -n '}' >> version.tex
 

--- a/Makefile
+++ b/Makefile
@@ -107,9 +107,7 @@ log-check:
 	! grep -n "!! Input index error" hott-online.ilg /dev/null
 
 version.tex:
-	/bin/echo -n '\\newcommand{\\OPTversion}{' > version.tex
-	git describe --always --long >> version.tex
-	/bin/echo -n '}' >> version.tex
+	printf '\\newcommand{\\OPTversion}{%s}\n' "`git describe --always --long`" > version.tex
 
 # these warnings are mostly spurious, and could have been prevented by a better makeindex algorithm
 log-check-for-warnings:


### PR DESCRIPTION
Prior to this fix, `version.tex` would have the following contents:
```latex

ewcommand{\\OPTversion}{
```
This would cause errors when building.