### PR TITLE
Use OAUTH_TOKEN from github repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       UPDATE_ERRATA: ${{ matrix.update_errata }}
       UPDATE_NIGHTLIES: ${{ matrix.update_nightlies }}
       TARGETS: ${{ matrix.targets }}
+      OAUTH_TOKEN: ${{ secrets.OAUTH_TOKEN }}
 
     steps:
       # Install texlive and other deps

--- a/etc/ci/configure_commit.sh
+++ b/etc/ci/configure_commit.sh
@@ -10,10 +10,10 @@ cd "$ROOT_DIR"
 
 echo "Configuring git for commit"
 if [ -z "$(git config --global user.name)" ]; then
-    git config --global user.name "Travis-CI Bot"
+    git config --global user.name "HoTT Bot"
 fi
 if [ -z "$(git config --global user.email)" ]; then
-    git config --global user.email "Travis-CI-Bot@travis.fake"
+    git config --global user.email "HoTT-Bot@hott.fake"
 fi
 
 popd 1>/dev/null


### PR DESCRIPTION
I have made a secret in this repo called OAUTH_TOKEN that the Github actions workflow will use. It currently contains my personal access token so when "HoTT Bot" tries to push in the scripts, it will be pushing using my authentication.