### PR TITLE
fix incorrectly prepared erratum

### DIFF
--- a/errata.tex
+++ b/errata.tex
@@ -887,7 +887,7 @@ While the page numbering may differ between copies with different version marker
   & \eqref{eq:untruncated-linearity} should be $c:\prd{q, r : \Q} (q < r) \to (q < x) + (x < r)$, and therefore the use of $c$ in the proof should be $c(s,t)$ rather than $c(x,s,t)$.\\
   %
   \cref{analysis-interval-ctb}
-  & merge of ad72d4e
+  & % merge of ad72d4e
   & In the proof, $n : \N$ should be $k : \N$. And the range of $i$ should be $0 \leq i \leq k$. Also in the last equation, $r(\lim x) = \ell$ should be $\lim x = \ell$.\\
   %
   \cref{sec:surreals}


### PR DESCRIPTION
A missing `%` prevented the errata-marking script from catching this one.