### PR TITLE
Fix errata marking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     name: Update errata
     runs-on: ubuntu-latest
     # It seems the ./mark-errata script would not work correctly for pull_request events.
-    # We want to run the script on the master branch anyways.
-    if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && github.ref == 'refs/heads/master' }}
+    # We want to run the script only on the master branch anyways.
+    if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && github.repository_owner == 'HoTT' && github.ref == 'refs/heads/master' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
   update-errata:
     name: Update errata
     runs-on: ubuntu-latest
-    # It seems the ./mark-errata script would not work correctly for pull_request events.
-    # We want to run the script only on the master branch anyways.
-    if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && github.repository_owner == 'HoTT' && github.ref == 'refs/heads/master' }}
+    # ./mark-errata should only run on the master branch of the main repo.
+    # This job is thus disabled for pull requests and forked repos.
+    if: ${{ github.repository_owner == 'HoTT' && github.ref == 'refs/heads/master' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
   build-default:
     name: Build and update nightlies
     needs: update-errata
-    if: ${{ always() }}
+    if: ${{ ! cancelled() }}
     runs-on: ubuntu-latest
     container: danteev/texlive:latest
     steps:
@@ -50,6 +50,12 @@ jobs:
 
       - name: Generate nightlies
         run: ./generate-nightlies "./_www_dir/" "./_wiki_dir/"
+
+      - name: Check if errata.tex is clean
+        # Interrupt the uploading if errata.tex is not clean.
+        # This should not happen, but it does not hurt to check.
+        if: ${{ github.repository_owner == 'HoTT' && github.ref == 'refs/heads/master' }}
+        run: ./check-errata
 
       - name: Push GitHub pages
         # This step is disabled for all forked repos. The idea is that the nightlies will
@@ -75,7 +81,7 @@ jobs:
   build-dvi:
     name: Build DVIs
     needs: update-errata
-    if: ${{ always() }}
+    if: ${{ ! cancelled() }}
     runs-on: ubuntu-latest
     container: danteev/texlive:latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
   build-default:
     name: Build and update nightlies
     needs: update-errata
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     container: danteev/texlive:latest
     steps:
@@ -74,6 +75,7 @@ jobs:
   build-dvi:
     name: Build DVIs
     needs: update-errata
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     container: danteev/texlive:latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,9 @@ jobs:
   update-errata:
     name: Update errata
     runs-on: ubuntu-latest
-    # it seems impossible to update a branch in a forked repo with the default token
-    if: ${{ ! (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
+    # It seems the ./mark-errata script would not work correctly for pull_request events.
+    # We want to run the script on the master branch anyways.
+    if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && github.ref == 'refs/heads/master' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/check-errata
+++ b/check-errata
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+! grep -o '% merge of.\+' errata.tex

--- a/errata.tex
+++ b/errata.tex
@@ -761,7 +761,7 @@ While the page numbering may differ between copies with different version marker
   % Chapter 9
   %
   \cref{ct:gaunt}
-  & 1315-gb95057d
+  & 1307-gfe63517
   & Stating that every isomorphism is an identity is not very accurate (consider the discrete category on the interval type): a more accurate statement is that every automorphism is an identity arrow. Notice that for precategories, this property must be combined with skeletality for the equivalence to hold.\\
   %
   \cref{ct:functor}
@@ -801,7 +801,7 @@ While the page numbering may differ between copies with different version marker
   % Chapter 10
   %
   \cref{thm:wfmin}
-  & 1315-gb95057d
+  & 1290-g4101ad3
   & In the proof, the second sentence of the second paragraph should have ``$s(a'):\acc(a')$'' rather than ``$s(a'):\acc(a)$''.\\
   %
   \cref{thm:ordord}


### PR DESCRIPTION
Upon closer inspection of errata.tex, I noticed that the errata marking in #1104 has led to incorrect results, possibly due to how `./mark-errata` is designed and how GitHub's actions/checkout performs merge for pull_request events. (I did not really change the script in #1104.) My current hypothesis is that the script can only be run on the master branch, and the CI has been updated accordingly. @JasonGross