### PR TITLE
Concatenate errata-marking and PDF-making and remove DVI-making

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,37 +8,8 @@ on:
   pull_request:
 
 jobs:
-  update-errata:
-    name: Update errata
-    runs-on: ubuntu-latest
-    # ./mark-errata should only run on the master branch of the main repo.
-    # This job is thus disabled for pull requests and forked repos.
-    if: ${{ github.repository_owner == 'HoTT' && github.ref == 'refs/heads/master' }}
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
-
-      - name: Fetch all tags for `git describe`
-        run: git fetch --force --prune --unshallow --tags
-
-      - name: Update ./errata.tex
-        run: ./mark-errata
-
-      - name: Push changes of ./errata.tex
-        run: |
-          if ! git diff --quiet -- ./errata.tex; then
-            git config --global user.name "github-actions"
-            git config --global user.email "github-actions@github.com"
-            git add errata.tex
-            git commit -m "Mark Errata (auto)"
-            git push
-          fi
-  build-default:
+  build:
     name: Build and update nightlies
-    needs: update-errata
-    if: ${{ ! cancelled() }}
     runs-on: ubuntu-latest
     container: danteev/texlive:latest
     steps:
@@ -48,11 +19,25 @@ jobs:
       - name: Fetch all tags for `git describe`
         run: git fetch --force --prune --unshallow --tags
 
+      - name: Update ./errata.tex
+        # ./mark-errata should only run on the master branch of the main repo.
+        # This job is thus disabled for pull requests and forked repos.
+        if: ${{ github.repository_owner == 'HoTT' && github.ref == 'refs/heads/master' }}
+        run: |
+          ./mark-errata
+          if ! git diff --quiet -- ./errata.tex; then
+            git config --global user.name "github-actions"
+            git config --global user.email "github-actions@github.com"
+            git add errata.tex
+            git commit -m "Mark Errata (auto)"
+            git push
+          fi
+
       - name: Generate nightlies
         run: ./generate-nightlies "./_www_dir/" "./_wiki_dir/"
 
       - name: Check if errata.tex is clean
-        # Interrupt the uploading if errata.tex is not clean.
+        # Interrupt the uploading if errata.tex somehow is not clean.
         # This should not happen, but it does not hurt to check.
         if: ${{ github.repository_owner == 'HoTT' && github.ref == 'refs/heads/master' }}
         run: ./check-errata
@@ -78,18 +63,3 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_NAME: "github-actions"
           GH_MAIL: "github-actions@github.com"
-  build-dvi:
-    name: Build DVIs
-    needs: update-errata
-    if: ${{ ! cancelled() }}
-    runs-on: ubuntu-latest
-    container: danteev/texlive:latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-
-      - name: Fetch all tags for `git describe`
-        run: git fetch --force --prune --unshallow --tags
-
-      - name: Build DVI
-        run: make dvi

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ log-check-for-warnings:
 	- ! grep -n "## Warning" hott-online.ilg /dev/null
 
 $(BOOKAUXFILES) : %.aux : %.tex
-	echo "WARNING: assuming $> is up-to-date"
+	echo "WARNING: assuming $@ is up-to-date"
 
 # Generate labels for the solutions
 main.labels: $(BOOKAUXFILES)

--- a/generate-nightlies
+++ b/generate-nightlies
@@ -16,26 +16,30 @@ function generate_www () {
   rm -rf -- "${WWW_DIR}" && mkdir -p -- "${WWW_DIR}" || exit 1
   PDF_TARGETS=(hott-online hott-ebook hott-letter hott-a4 errata)
   for TARGET in "${PDF_TARGETS[@]}"; do
-      echo "Generating ${WWW_DIR}/$TARGET-$VERSION.pdf"
+      echo "::group::Generating ${WWW_DIR}/$TARGET-$VERSION.pdf"
       if [ ! -f "$TARGET.pdf" ]; then
         make "${TARGET}.pdf" || exit 1
       fi
+      echo "Copying $TARGET.pdf to ${WWW_DIR}/$TARGET-$VERSION.pdf"
       cp -f "$TARGET.pdf" "${WWW_DIR}/$TARGET-$VERSION.pdf" || exit 1
-      echo "Generating ${WWW_DIR}/${TARGET}.pdf.html"
-      cat > "${WWW_DIR}/${TARGET}.pdf.html" <<EOF
+      echo "::endgroup::"
+      echo "::group::Generating ${WWW_DIR}/${TARGET}.pdf.html"
+      tee "${WWW_DIR}/${TARGET}.pdf.html" <<EOF
 <!doctype html><title>$TARGET-$VERSION.pdf</title><meta http-equiv=refresh content="0; url=$TARGET-$VERSION.pdf">
 EOF
+      echo "::endgroup::"
   done
 }
 
 function generate_wiki () {
   rm -rf -- "${WIKI_DIR}" && mkdir -p -- "${WIKI_DIR}" || exit 1
-  echo "Generating ${WIKI_DIR}/Home.md"
-  cat > "${WIKI_DIR}/Home.md" <<EOF
+  echo "::group::Generating ${WIKI_DIR}/Home.md"
+  tee "${WIKI_DIR}/Home.md" <<EOF
 This wiki is not in use, except that it hosts the [[Nightly builds]] page.  There is a general wiki for homotopy type theory [here](http://ncatlab.org/homotopytypetheory).
 EOF
-  echo "Generating ${WIKI_DIR}/Nightly-Builds.md"
-  cat > "${WIKI_DIR}/Nightly-Builds.md" <<EOF
+  echo "::endgroup::"
+  echo "::group::Generating ${WIKI_DIR}/Nightly-Builds.md"
+  tee "${WIKI_DIR}/Nightly-Builds.md" <<EOF
 <!--- This page is auto-generated.  To update this page; update the build-nightlies script. --->
 Below are links to "nightly builds" of the book, incorporating fixes and improvements that have not yet been incorporated into the "released version" that can be found on the [official book web site](http://homotopytypetheory.org/book/).  The nightly builds are updated automatically; their most recent update was on $DATE and their version marker is "$VERSION_MARKER".
 
@@ -45,6 +49,7 @@ Below are links to "nightly builds" of the book, incorporating fixes and improve
 * [PDF for printing on A4 paper](//hott.github.io/book/hott-a4-$VERSION.pdf)
 * [errata for previous versions](//hott.github.io/book/errata-$VERSION.pdf)
 EOF
+  echo "::endgroup::"
 }
 
 generate_www


### PR DESCRIPTION
Previously, GitHub chose to check out the same commit hash in later jobs, breaking the assumption that the second job (PDF making) could pick up the commits pushed by the first job (errata marking). The second job thus failed because `errata.tex` does not appear to be clean. By concatenating two jobs into one, we no longer have to worry about carrying over the correct commit to make PDFs.