### PR TITLE
Elaborate more on the omitted eq rules

### DIFF
--- a/formal.tex
+++ b/formal.tex
@@ -599,8 +599,9 @@ assume that judgmental equality is an equivalence relation respected by typing.
 \end{mathparpagebreakable}
 %
 Finally, we assume that judgmental equality is a congruence respected by typing,
-i.e., that each constructor preserves judgmental equality in each of its
-arguments. For instance, along with the $\Pi$-\rintro\ rule, we assume the rule
+i.e., that each type and term-former preserves judgmental equality in each of
+its arguments. For instance, along with the $\Pi$-\rintro\ rule, we assume the
+rule
 \[
   \inferrule*[right=$\Pi$-\rintro-eq]
   {\oftp\Gamma{A}{\UU_i} \\
@@ -608,6 +609,8 @@ arguments. For instance, along with the $\Pi$-\rintro\ rule, we assume the rule
    \jdeqtp{\Gamma,\tmtp xA}{b}{b'}{B}}
   {\jdeqtp\Gamma{\lamu{x:A} b}{\lamu{x:A'} b'}{\tprd{x:A} B}}
 \]
+Completing the case of dependent function types, two similar rules,
+$\Pi$-\textsc{form-eq}\ and $\Pi$-\textsc{elim-eq}, are assumed.
 Taken together, these local principles imply the global congruence principles
 $\Subst_2$ and $\Subst_3$ above. We will omit these local rules for brevity.
 

--- a/formal.tex
+++ b/formal.tex
@@ -611,7 +611,7 @@ rule
 \]
 Completing the case of dependent function types, two similar rules,
 $\Pi$-\textsc{form-eq}\ and $\Pi$-\textsc{elim-eq}, are assumed.
-Taken together, these local principles imply the global congruence principles
+Taken together, these local principles (at every type) imply the global congruence principles
 $\Subst_2$ and $\Subst_3$ above. We will omit these local rules for brevity.
 
 \index{rule!structural|)}%


### PR DESCRIPTION
Edited as mentioned in https://github.com/HoTT/book/issues/1113. I do fear that now lines 612 and 613 may confuse the meaning of "these local principles" in line 614 as to only refer to the dependent function type rules. I do not know how to express this better. Maybe those two lines should be removed after all. I leave this to your judgment. 
Thanks for maintaining this book :)