### PR TITLE
adjust references to origin of Martin-Löf identity types

### DIFF
--- a/basics.tex
+++ b/basics.tex
@@ -2494,7 +2494,7 @@ Some more general homotopy limits can be constructed in a similar way, but for c
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \sectionNotes
 
-The definition of identity types, with their induction principle, is due to Martin-L\"of \cite{Martin-Lof-1972}.
+The definition of identity types, with their induction principle, is due to Martin-L\"of \cite{Martin-Lof-1973}.
 \index{intensional type theory}%
 \index{extensional!type theory}%
 \index{type theory!intensional}%

--- a/preliminaries.tex
+++ b/preliminaries.tex
@@ -1930,7 +1930,7 @@ For some purposes, it is more appropriate to assume only that every universe is 
 There are many other possible variations, such as including a universe ``$\UU_{\omega}$'' that contains all $\UU_i$ (or even higher ``large cardinal'' type universes), or by internalizing the hierarchy into a type family $\lam{i} \UU_i$.
 The latter is in fact done in \Agda.
 
-The path induction principle for identity types was formulated by Martin-L\"{o}f~\cite{Martin-Lof-1972}.
+The path induction principle for identity types was formulated by Martin-L\"{o}f~\cite{Martin-Lof-1973}.
 The based path induction rule in the setting of Martin-L\"of type theory is due to Paulin-Mohring \cite{Moh93}; it can be seen as an intensional generalization of the concept of ``pointwise functionality''\index{pointwise!functionality} for hypothetical judgments from \NuPRL~\cite[Section~8.1]{constable+86nuprl-book}.
 The fact that Martin-L\"of's rule implies Paulin-Mohring's was proved by Streicher using Axiom K (see~\cref{sec:hedberg}), by Altenkirch and Goguen as in \cref{sec:identity-types}, and finally by Hofmann without universes (as in \cref{ex:pm-to-ml}); see~\cite[\S1.3 and Addendum]{Streicher93}.
 


### PR DESCRIPTION
General identity types do not appear in [Martin-Lof-1972](https://archive-pml.github.io/martin-lof/pdfs/An-Intuitionistic-Theory-of-Types-1972.pdf) (though there is an equality type for natural numbers defined by recursion), but rather in [Martin-Lof-1973](https://archive-pml.github.io/martin-lof/pdfs/An-Intuitionistic-Theory-of-Types-Predicative-Part-1975.pdf).