### PR TITLE
Fix typo in flattening-rectnd-beta-ppt's proof

### DIFF
--- a/errata.tex
+++ b/errata.tex
@@ -635,6 +635,11 @@ While the page numbering may differ between copies with different version marker
   In the fourth and fifth displays, the path-concatenations should be in the other order.
   And in the fifth display, $\refl{g(b)}$ should be $\refl{\cc(g(b))}$.\\
   %
+  \cref{thm:flattening-rectnd-beta-ppt}
+  & 961-gde36592
+  & Both occurrence of the function $f$ should be replaced with $g$ in the
+  final two steps of the calculation within the proof.\\
+  %
   \cref{thm:ap-sigma-rect-path-pair}
   & 501-ge895f81
   & Both occurrences of $P$ in the statement should be $Y$, and both occurrences of $Q$ in the proof should be $Z$.\\

--- a/hits.tex
+++ b/hits.tex
@@ -2012,9 +2012,9 @@ Once we have managed this, the proof is easy by path induction.
     \notag \\
     &= c(f(b),y)
     \tag{by \cref{thm:trans-trivial}}\\
-    &= c(f(b),D(b)(y))
+    &= c(g(b),D(b)(y))
    \tag{by $p(b,y)$}\\
-    &= c(f(b),\trans{\pp(b)}{y}).
+    &= c(g(b),\trans{\pp(b)}{y}).
     \tag{by $\opp{\apfunc{c(g(b),-)}(q)}$}
   \end{align}
   Finally, substituting these values of $\apfunc{d(x_2)}(r)$ and $\happly(\apdfunc{d}(s),\trans s {y_1})$ into \cref{thm:ap-sigma-rect-path-pair}, we see that all the paths cancel out in pairs, leaving only $p(b,y)$.


### PR DESCRIPTION
This PR brings back to life an abandoned PR fixing some typos:
- https://github.com/HoTT/book/pull/1001

I had to open this one, because, for some reason, I deleted the branch for
the old PR and couldn't continue there.

The CI is failing, same error as:

- https://github.com/HoTT/book/issues/1139