### PR TITLE
Fixed math mistake in induction section

### DIFF
--- a/errata.tex
+++ b/errata.tex
@@ -951,6 +951,10 @@ While the page numbering may differ between copies with different version marker
   \cref{sec:more-formal-identity}
   & 578-ga4b94a5
   & The unbased eliminator for the identity type should be named $\indid{A}$, not $\indidb{A}$.\\
+  % 
+  \cref{sec:w-types}
+  & % merge of 99b69043e01bb91cc987b5368dccc6583651ba73
+  & The argument of constant type $C$ should be type family $C(a)$ when specifying $e$ within the w-type recursor definition of double.\\
 %% END ERRATA
 \end{longtable}
 

--- a/induction.tex
+++ b/induction.tex
@@ -313,9 +313,9 @@ How would we define the function $\dbl$ on natural numbers encoded as a $\w$-typ
 which will represent the recurrence for the $\dbl$ function; for simplicity we denote the type family $\rec\bool(\bbU,\emptyt,\unit)$ by $B$.
 
 Clearly, $e$ will be a function taking $a : \bool$ as its first argument. The next step is to perform case analysis on $a$ and proceed based on whether it is $\bfalse$ or $\btrue$. This suggests the following form
-\[ e \defeq \lamu{a:\bool} \ind\bool(C,e_0,e_1,a) \]
+\[ e \defeq \lamu{a:\bool} \ind\bool(C(a),e_0,e_1,a) \]
 where
-\[C \defeq \lamu{a:\bool} \prd{f : B(a) \to \natw}{g : B(a) \to \natw} \natw.\]
+\[C(a) \defeq \prd{f : B(a) \to \natw}{g : B(a) \to \natw} \natw.\]
 If $a$ is $\bfalse$, the type $B(a)$ becomes $\emptyt$. Thus, given $f : \emptyt \to \natw$ and $g : \emptyt \to \natw$, we want to construct an element of $\natw$. Since the label $\bfalse$ represents $\emptyt$, it needs zero inductive arguments and the variables $f$ and $g$ are irrelevant. We return $\zerow$\index{zero} as a result:
 \[ e_0 \defeq \lamu{f:\emptyt \to \natw}{g:\emptyt \to \natw} \zerow. \]
 Analogously, if $a$ is $\btrue$, the type $B(a)$ becomes $\unit$.


### PR DESCRIPTION
In the w-types section of the induction chapter, there is an erroneously notated type 'C' that should be a type family eliminated with argument 'a' i.e. C(a). This happened when deriving 'e' during the derivation of 'double' using the recursor for w-types.