### PR TITLE
Fix Minor Typos in Proofs of Corollary 4.9.3 and Theorem 4.8.4

### DIFF
--- a/equivalences.tex
+++ b/equivalences.tex
@@ -886,7 +886,7 @@ We may display the action of this composite equivalence step by step by
 \begin{align*}
 a & \mapsto \pairr{f(a),\; \pairr{a,\refl{f(a)}}}\\
 & \mapsto \pairr{f(a), \; \hfiber{f}{f(a)}, \; \refl{\hfiber{f}{f(a)}}, \; \pairr{a,\refl{f(a)}}}\\
-& \mapsto \pairr{f(a), \; \hfiber{f}{f(a)}, \; \pairr{a,\refl{f(a)}}, \; \refl{\hfiber{f}{f(a)}}}.
+& \mapsto \pairr{f(a), \; \pairr{\hfiber{f}{f(a)}, \; \pairr{a,\refl{f(a)}}}, \; \refl{\hfiber{f}{f(a)}}}.
 \end{align*}
 Therefore, we get homotopies $f\htpy\proj1\circ e$ and $\vartheta_f\htpy \proj2\circ e$.
 \end{proof}

--- a/equivalences.tex
+++ b/equivalences.tex
@@ -944,7 +944,7 @@ Then the projection $\proj{1}:(\sm{x:A}P(x))\to A$ is an equivalence. Assuming $
 \end{cor}
 
 \begin{proof}
-  By \cref{thm:fiber-of-a-fibration}, for $\proj{1}:\sm{x:A}P(X)\to A$ and $x:A$ we have an equivalence
+  By \cref{thm:fiber-of-a-fibration}, for $\proj{1}:(\sm{x:A}P(x))\to A$ and $x:A$ we have an equivalence
   \begin{equation*}
     \eqv{\hfiber{\proj{1}}{x}}{P(x)}.
   \end{equation*}

--- a/equivalences.tex
+++ b/equivalences.tex
@@ -886,6 +886,7 @@ We may display the action of this composite equivalence step by step by
 \begin{align*}
 a & \mapsto \pairr{f(a),\; \pairr{a,\refl{f(a)}}}\\
 & \mapsto \pairr{f(a), \; \hfiber{f}{f(a)}, \; \refl{\hfiber{f}{f(a)}}, \; \pairr{a,\refl{f(a)}}}\\
+& \mapsto \pairr{f(a), \; \hfiber{f}{f(a)}, \; \pairr{a,\refl{f(a)}}, \; \refl{\hfiber{f}{f(a)}}}\\
 & \mapsto \pairr{f(a), \; \pairr{\hfiber{f}{f(a)}, \; \pairr{a,\refl{f(a)}}}, \; \refl{\hfiber{f}{f(a)}}}.
 \end{align*}
 Therefore, we get homotopies $f\htpy\proj1\circ e$ and $\vartheta_f\htpy \proj2\circ e$.

--- a/errata.tex
+++ b/errata.tex
@@ -475,6 +475,14 @@ While the page numbering may differ between copies with different version marker
   & 358-g9543064
   & The text should be ``Show that for any $A,B:\UU$, the following type is equivalent to $\eqv A B$.  Can you extract from this a definition of a type satisfying the three desiderata of $\isequiv(f)$?''\\
   %
+  \cref{thm:object-classifier}
+  & merge of 367864df
+  & To maintain consistency, one line was added at the end of the computation of the composite equivalence in the proof.
+  %
+  %
+  \cref{}
+  & merge of edb908a2
+  & The type of $\proj{1}$ should be $(\sm{x:A}P(x))\to A$.
   % Chapter 5
   %
   \cref{sec:appetizer-univalence}

--- a/errata.tex
+++ b/errata.tex
@@ -479,10 +479,10 @@ While the page numbering may differ between copies with different version marker
   & merge of 367864df
   & To maintain consistency, one line was added at the end of the computation of the composite equivalence in the proof.
   %
-  %
-  \cref{}
+  \cref{thm:fiber-of-a-fibration}
   & merge of edb908a2
   & The type of $\proj{1}$ should be $(\sm{x:A}P(x))\to A$.
+  %
   % Chapter 5
   %
   \cref{sec:appetizer-univalence}


### PR DESCRIPTION
Hi! Thanks for the great book!

This PR includes two minor typo corrections:

1. **In the proof of Corollary 4.9.3**: 
It is written  
$pr_1 : \sum_{(x:A)} P(X) \to A$
(note the uppercase *X*), which I believe should be
$pr_1 : \left(\sum_{(x:A)} P(x)\right) \to A$.
![Screenshot From 2025-05-25 18-54-48](https://github.com/user-attachments/assets/c9023a1e-c5b7-4f2f-90c5-7e9be4d430d1)

2. **In the proof of Theorem 4.8.4**:
In the second-to-last line of the proof, I found  
$(f(a), fib_f(f(a)), (a, refl_{f(a)}), refl_{fib_f(f(a))})$.  
However, this term is of type $B \times_{U} U_\bullet$. I believe it should instead be  
$(f(a), (fib_f(f(a)), (a, refl_{f(a)})), refl_{fib_f(f(a))})$.  
I suspect this is an intentional choice for readability, but I believe this change helps clarify the meaning of $pr_2$ and that $pr_2 \circ e$ is homotopic to $\theta_f$.
![Screenshot From 2025-05-25 18-55-01](https://github.com/user-attachments/assets/28ec3740-98a9-4b28-adf8-95adaa9d2efd)

I would like to add notes for these in `errata.tex`; however, since I'm not sure whether these are actual typos (especially the second one), I’ll wait for confirmation. If they are typos, I’ll update the errata accordingly.

Please let me know if any of these were intentional or if further clarification is needed.

Thanks again!
