### PR TITLE
fix: Comment out merge sign in errata.tex

### DIFF
--- a/errata.tex
+++ b/errata.tex
@@ -480,11 +480,11 @@ While the page numbering may differ between copies with different version marker
   & The text should be ``Show that for any $A,B:\UU$, the following type is equivalent to $\eqv A B$.  Can you extract from this a definition of a type satisfying the three desiderata of $\isequiv(f)$?''\\
   %
   \cref{thm:object-classifier}
-  & merge of 367864df
+  & % merge of 367864df
   & To maintain consistency, one line was added at the end of the computation of the composite equivalence in the proof.
   %
   \cref{thm:fiber-of-a-fibration}
-  & merge of edb908a2
+  & % merge of edb908a2
   & The type of $\proj{1}$ should be $(\sm{x:A}P(x))\to A$.
   %
   % Chapter 5

--- a/errata.tex
+++ b/errata.tex
@@ -411,7 +411,7 @@ While the page numbering may differ between copies with different version marker
   %
   \cref{subsec:logic-hprop}
   & 37-g0bd66c8
-  & In the discussion for $\Sigma$-types in the last paragraph, $A$ is an arbitrary type.
+  & In the discussion for $\Sigma$-types in the last paragraph, $A$ is an arbitrary type.\\
   %
   \cref{thm:retract-contr}
   & 95-gce0131f
@@ -481,11 +481,11 @@ While the page numbering may differ between copies with different version marker
   %
   \cref{thm:object-classifier}
   & % merge of 367864df
-  & To maintain consistency, one line was added at the end of the computation of the composite equivalence in the proof.
+  & To maintain consistency, one line was added at the end of the computation of the composite equivalence in the proof.\\
   %
   \cref{thm:fiber-of-a-fibration}
   & % merge of edb908a2
-  & The type of $\proj{1}$ should be $(\sm{x:A}P(x))\to A$.
+  & The type of $\proj{1}$ should be $(\sm{x:A}P(x))\to A$.\\
   %
   % Chapter 5
   %


### PR DESCRIPTION
I noticed that I forgot to comment out the merge marker in errata.tex in the previous pull request (#1174). Apologies for the oversight.