### PR TITLE
Fix incorrect ordering of `r` and `s` in Definition 11.5.13(v)

### DIFF
--- a/errata.tex
+++ b/errata.tex
@@ -931,6 +931,10 @@ While the page numbering may differ between copies with different version marker
   & 1270-g3f17b85
   & In the proof, $n : \N$ should be $k : \N$. And the range of $i$ should be $0 \leq i \leq k$. Also in the last equation, $r(\lim x) = \ell$ should be $\lim x = \ell$.\\
   %
+  \cref{defn:inductive-cover}
+  & % merge of 251b4c4fb5faf6eb21b5926309835d9d569ef2d5
+  & In (\cref{defn:inductive-cover-interval-1}), the order of $r$ and $s$ should be flipped on the right-hand side: $(r, s)$ should be $(s, r)$.\\
+  %
   \cref{sec:surreals}
   & 1189-ga9c35f0
   & The inductive case of $\iota_{\Q_D}$ should be defined as $\iota_{\Q_D}(a/2^n) \defeq \surr{\iota_{\Q_D}(a/2^n - 1/2^n)}{\iota_{\Q_D}(a/2^n + 1/2^n)}$.\\

--- a/reals.tex
+++ b/reals.tex
@@ -2315,7 +2315,7 @@ good rules and turn them into an inductive definition.
     \intfam{i}{I}{(\mathcal{F}(i) \cap (s, t))}$.
 
   \item \label{defn:inductive-cover-interval-1}
-    if $q < s < t < r$ then $(q, r) \cover [(q, t), (r, s)]$,
+    if $q < s < t < r$ then $(q, r) \cover [(q, t), (s, r)]$,
 
   \item \label{defn:inductive-cover-interval-2}
     $(q, r) \cover \intfam{u}{\setof{ (s,t) : \Q \times \Q | q < s < t < r}}{u}$.


### PR DESCRIPTION
For context, Definition 11.5.13 reads:
> The inductive cover $◁$ is a mere relation […] defined inductively by the following rules, where $q, r, s, t$ are rational numbers […]:
> […]
> (v) if $q < s < t < r$ then $(q, r) ◁ [(q, t), (r, s)]$,
> […]

Quite obviously, if $s < r$, then $(r, s)$ is an empty interval, but clearly, $(s, r)$ was intended.