### PR TITLE
Remove big space

### DIFF
--- a/basics.tex
+++ b/basics.tex
@@ -94,9 +94,9 @@ $\infty$-groupoid preserves enough aspects of the space to do homotopy theory:
 the fundamental $\infty$-groupoid construction is adjoint\index{adjoint!functor} to the
 geometric\index{geometric realization} realization of an $\infty$-groupoid as a space, and this
 adjunction preserves homotopy theory (this is called the \emph{homotopy
-  hypothesis/theorem},
-\index{hypothesis!homotopy}
-\index{homotopy!hypothesis}
+  hypothesis/theorem},%
+\index{hypothesis!homotopy}%
+\index{homotopy!hypothesis}%
 because whether it is a hypothesis or theorem
 depends on how you define $\infty$-groupoid).  For example, you can
 easily define the fundamental group of an $\infty$-groupoid, and if you

--- a/basics.tex
+++ b/basics.tex
@@ -94,7 +94,7 @@ $\infty$-groupoid preserves enough aspects of the space to do homotopy theory:
 the fundamental $\infty$-groupoid construction is adjoint\index{adjoint!functor} to the
 geometric\index{geometric realization} realization of an $\infty$-groupoid as a space, and this
 adjunction preserves homotopy theory (this is called the \emph{homotopy
-  hypothesis/theorem},%
+  hypothesis/theorem},
 \index{hypothesis!homotopy}%
 \index{homotopy!hypothesis}%
 because whether it is a hypothesis or theorem


### PR DESCRIPTION
I don’t know if this even works, but look for a bigger-than-usual space between “called the homotopy hypothesis/theorem,” and “because”.

**Edit:** There are many such cases. I don’t know if I have time to find and fix them all.